### PR TITLE
Set of methods to work with raster layers (coverages)

### DIFF
--- a/coverage.types.go
+++ b/coverage.types.go
@@ -1,7 +1,0 @@
-package geoserver
-
-// CoverageInfo is geoserver CoverageInfo
-type Coverage struct {
-	Name               string `json:"name,omitempty"`
-	NativeCoverageName string `json:"nativeCoverageName,omitempty"`
-}

--- a/coverages.go
+++ b/coverages.go
@@ -28,8 +28,8 @@ type Coverage struct {
 	Store                *Resource          `json:"store,omitempty"`
 	CqlFilter            string             `json:"cqlFilter,omitempty"`
 	OverridingServiceSRS bool               `json:"overridingServiceSRS,omitempty"`
-	//Metadata               *Metadata          `json:"metadata,omitempty"`  //need to fix an implementation due to json parse error
-	//SupportedFormats       []string			  `json:"supportedFormats,omitempty"`  //need to fix an implementation due to json parse error
+	//Metadata               *Metadata          `json:"metadata,omitempty"`  //need to fix the implementation due to json parse error
+	//SupportedFormats       []string			  `json:"supportedFormats,omitempty"`  //need to fix the implementation due to json parse error
 }
 
 type publishedCoverageDescr struct {
@@ -79,7 +79,7 @@ func (g *GeoServer) GetCoverages(workspaceName string) (coverages []*Resource, e
 	return coveragesResponse.Coverages.Coverage, nil
 }
 
-// GetStoreCoverages returns all coverages (raster layers) names including unpublished for coverageStore as string list,
+// GetStoreCoverages returns a list for all coverages (raster layers) names including unpublished for coverageStore,
 // err is an error if error occurred else err is nil
 func (g *GeoServer) GetStoreCoverages(workspaceName string, coverageStore string) (coverages []string, err error) {
 	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "coveragestores", coverageStore, "coverages")
@@ -137,7 +137,8 @@ func (g *GeoServer) GetCoverage(workspaceName string, coverageName string) (cove
 	return &coverageResponse.Coverage, nil
 }
 
-//DeleteCoverage removes the coverage,
+// DeleteCoverage removes the coverage,
+// err is an error if error occurred else err is nil
 func (g *GeoServer) DeleteCoverage(workspaceName string, layerName string, recurse bool) (deleted bool, err error) {
 	//it's just a wrapper about DeleteLayer function as it does the same in the most use cases
 	return g.DeleteLayer(workspaceName, layerName, recurse)
@@ -177,7 +178,8 @@ func (g *GeoServer) UpdateCoverage(workspaceName string, coverage *Coverage) (mo
 	return
 }
 
-//PublishCoverage publishes coverage from coverageStore
+// PublishCoverage publishes coverage from coverageStore
+// coverageName - the name of the layer in the coverageStore (use GetStoreCoverages to get them), publishName - the name it was presented at geoserver
 func (g *GeoServer) PublishCoverage(workspaceName string, coverageStoreName string, coverageName string, publishName string) (published bool, err error) {
 
 	if publishName == "" {
@@ -193,6 +195,7 @@ func (g *GeoServer) PublishCoverage(workspaceName string, coverageStoreName stri
 	return g.publishCoverage(workspaceName, coverageStoreName, publishRequest)
 }
 
+// publishCoverage publishes coverage
 func (g *GeoServer) publishCoverage(workspaceName string, coverageStoreName string, publishCoverageRequest publishCoverageRequest) (published bool, err error) {
 
 	if workspaceName != "" {

--- a/coverages.go
+++ b/coverages.go
@@ -178,11 +178,15 @@ func (g *GeoServer) UpdateCoverage(workspaceName string, coverage *Coverage) (mo
 }
 
 //PublishCoverage publishes coverage from coverageStore
-func (g *GeoServer) PublishCoverage(workspaceName string, coverageStoreName string, coverageName string) (published bool, err error) {
+func (g *GeoServer) PublishCoverage(workspaceName string, coverageStoreName string, coverageName string, publishName string) (published bool, err error) {
+
+	if publishName == "" {
+		publishName = coverageName
+	}
 
 	publishRequest := publishCoverageRequest{
 		&publishedCoverageDescr{
-			Name:               coverageName,
+			Name:               publishName,
 			NativeCoverageName: coverageName,
 		},
 	}

--- a/coverages.go
+++ b/coverages.go
@@ -1,0 +1,196 @@
+package geoserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Coverage is geoserver Coverage (raster layer) data struct
+type Coverage struct {
+	Name                 string             `json:"name,omitempty"`
+	NativeCoverageName   string             `json:"nativeCoverageName,omitempty"`
+	NativeName           string             `json:"nativeName,omitempty"`
+	NativeFormat         string             `json:"nativeFormat,omitempty"`
+	Namespace            *Resource          `json:"namespace,omitempty"`
+	Title                string             `json:"title,omitempty"`
+	Abstract             string             `json:"abstract,omitempty"`
+	Keywords             *Keywords          `json:"keywords,omitempty"`
+	NativeCRS            *CRSType           `json:"nativeCRS,omitempty"`
+	Srs                  string             `json:"srs,omitempty"`
+	Enabled              bool               `json:"enabled,omitempty"`
+	NativeBoundingBox    *NativeBoundingBox `json:"nativeBoundingBox,omitempty"`
+	LatLonBoundingBox    *LatLonBoundingBox `json:"latLonBoundingBox,omitempty"`
+	ProjectionPolicy     string             `json:"projectionPolicy,omitempty"`
+	Store                *Resource          `json:"store,omitempty"`
+	CqlFilter            string             `json:"cqlFilter,omitempty"`
+	OverridingServiceSRS bool               `json:"overridingServiceSRS,omitempty"`
+	//Metadata               *Metadata          `json:"metadata,omitempty"`  //need to fix an implementation due to json parse error
+	//SupportedFormats       []string			  `json:"supportedFormats,omitempty"`  //need to fix an implementation due to json parse error
+}
+
+type publishedCoverageDescr struct {
+	Name               string `json:"name,omitempty"`
+	NativeCoverageName string `json:"nativeCoverageName,omitempty"`
+}
+
+type publishCoverageRequest struct {
+	CoverageDescr *publishedCoverageDescr `json:"coverage,omitempty"`
+}
+
+// GetCoverages returns all published raster layers (coverages) for workspace as resources,
+// err is an error if error occurred else err is nil
+func (g *GeoServer) GetCoverages(workspaceName string) (coverages []*Resource, err error) {
+	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "coverages")
+	httpRequest := HTTPRequest{
+		Method: getMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  nil,
+	}
+	response, responseCode := g.DoRequest(httpRequest)
+	if responseCode != statusOk {
+		g.logger.Error(string(response))
+		err = g.GetError(responseCode, response)
+		return
+	}
+
+	var coveragesResponse struct {
+		Coverages struct {
+			Coverage []*Resource `json:"coverage,omitempty"`
+		} `json:"coverages,omitempty"`
+	}
+
+	var coveragesEmptyResponse struct {
+		Coverages string
+	}
+
+	if err = json.Unmarshal(response, &coveragesResponse); err != nil {
+		if err = g.DeSerializeJSON(response, &coveragesEmptyResponse); err != nil {
+			return nil, fmt.Errorf("can't parse the coverage data, %v", err)
+		} else {
+			return []*Resource{}, nil
+		}
+	}
+
+	return coveragesResponse.Coverages.Coverage, nil
+}
+
+// GetStoreCoverages returns all coverages (raster layers) names including unpublished for coverageStore as string list,
+// err is an error if error occurred else err is nil
+func (g *GeoServer) GetStoreCoverages(workspaceName string, coverageStore string) (coverages []string, err error) {
+	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "coveragestores", coverageStore, "coverages")
+	httpRequest := HTTPRequest{
+		Method: getMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  map[string]string{"list": "all"},
+	}
+	response, responseCode := g.DoRequest(httpRequest)
+	if responseCode != statusOk {
+		g.logger.Error(string(response))
+		err = g.GetError(responseCode, response)
+		return
+	}
+
+	var coveragesResponse struct {
+		List struct {
+			CoverageName []string `json:"string,omitempty"`
+		} `json:"list,omitempty"`
+	}
+
+	if err = g.DeSerializeJSON(response, &coveragesResponse); err != nil {
+		return nil, fmt.Errorf("can't parse the coverages data, %v", err)
+	}
+
+	return coveragesResponse.List.CoverageName, nil
+}
+
+// GetCoverage returns the coverage with name coverageName
+// err is an error if error occurred else err is nil
+func (g *GeoServer) GetCoverage(workspaceName string, coverageName string) (coverage *Coverage, err error) {
+	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "coverages", coverageName)
+	httpRequest := HTTPRequest{
+		Method: getMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  nil,
+	}
+	response, responseCode := g.DoRequest(httpRequest)
+	if responseCode != statusOk {
+		g.logger.Error(string(response))
+		err = g.GetError(responseCode, response)
+		return
+	}
+
+	var coverageResponse struct {
+		Coverage Coverage
+	}
+
+	if err = g.DeSerializeJSON(response, &coverageResponse); err != nil {
+		return nil, fmt.Errorf("can't parse the coverage data, %v", err)
+	}
+
+	return &coverageResponse.Coverage, nil
+}
+
+//DeleteCoverage removes the coverage,
+func (g *GeoServer) DeleteCoverage(workspaceName string, layerName string, recurse bool) (deleted bool, err error) {
+	//it's just a wrapper about DeleteLayer function as it does the same in the most use cases
+	return g.DeleteLayer(workspaceName, layerName, recurse)
+}
+
+//PublishCoverage publishes coverage from coverageStore
+func (g *GeoServer) PublishCoverage(workspaceName string, coverageStoreName string, coverageName string) (published bool, err error) {
+
+	publishRequest := publishCoverageRequest{
+		&publishedCoverageDescr{
+			Name:               coverageName,
+			NativeCoverageName: coverageName,
+		},
+	}
+	return g.publishCoverage(workspaceName, coverageStoreName, publishRequest)
+}
+
+func (g *GeoServer) publishCoverage(workspaceName string, coverageStoreName string, publishCoverageRequest publishCoverageRequest) (published bool, err error) {
+
+	if workspaceName != "" {
+		workspaceName = fmt.Sprintf("workspaces/%s/", workspaceName)
+	}
+	targetURL := g.ParseURL("rest", workspaceName, "coveragestores", coverageStoreName, "/coverages")
+
+	serializedLayer, _ := g.SerializeStruct(publishCoverageRequest)
+
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		Data:     bytes.NewBuffer(serializedLayer),
+		DataType: jsonType,
+		URL:      targetURL,
+		Query:    nil,
+	}
+	response, responseCode := g.DoRequest(httpRequest)
+	if responseCode != statusCreated {
+		g.logger.Error(string(response))
+		err = g.GetError(responseCode, response)
+		return
+	}
+
+	return true, nil
+}
+
+//PublishGeoTiffLayer publishes geotiff to geoserver
+func (g *GeoServer) PublishGeoTiffLayer(workspaceName string, coverageStoreName string, publishName string, fileName string) (published bool, err error) {
+	//it was moved from layers.go because this is the better place for raster layers functions (coverages)
+	//I tried to maintain the original behavior for backward compatibilities,
+	//but it didn't seem to be working as expected from scratch
+	//there were no tests for this function and I couldn't reproduce the working case
+	publishRequest := publishCoverageRequest{
+		&publishedCoverageDescr{
+			Name:               publishName,
+			NativeCoverageName: fileName,
+		},
+	}
+
+	return g.publishCoverage(workspaceName, coverageStoreName, publishRequest)
+}

--- a/coverages.go
+++ b/coverages.go
@@ -14,7 +14,7 @@ type Coverage struct {
 	NativeFormat         string             `json:"nativeFormat,omitempty"`
 	Namespace            *Resource          `json:"namespace,omitempty"`
 	Title                string             `json:"title,omitempty"`
-	Abstract             string             `json:"abstract,omitempty"`
+	Description          string             `json:"description,omitempty"`
 	Keywords             *Keywords          `json:"keywords,omitempty"`
 	NativeCRS            *CRSType           `json:"nativeCRS,omitempty"`
 	Srs                  string             `json:"srs,omitempty"`

--- a/coverages_test.go
+++ b/coverages_test.go
@@ -1,0 +1,169 @@
+package geoserver
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+var gsCatalog *GeoServer
+
+var (
+	coveragesTestWorkspace      = "sf"
+	coveragesTestCoverageName   = "sfdem"
+	coveragesTestStoreName      = "sfdem_test"
+	coveragesTestDummyStoreName = "sfdem_dummy"
+
+	coveragesTestStoreFile = map[string]string{
+		coveragesTestStoreName:      "file:data/sf/sfdem.tif",
+		coveragesTestDummyStoreName: "file:data/sf/dummy.tif",
+	}
+)
+
+func before() {
+	if gsCatalog == nil {
+		gsCatalog = GetCatalog("http://localhost:8080/geoserver/", "admin", "geoserver")
+	}
+}
+
+func coveragesPrepareTestStorage(t *testing.T, storeName string) {
+	//creating coverageStore if doesn't exist
+
+	coverageStore := CoverageStore{
+		Name:        storeName,
+		Description: storeName + " Description",
+		Type:        "GeoTIFF",
+		URL:         coveragesTestStoreFile[storeName],
+		Workspace: &Resource{
+			Name: coveragesTestWorkspace,
+		},
+		Enabled: true,
+	}
+	_, err := gsCatalog.CreateCoverageStore("sf", coverageStore)
+	if err != nil && !strings.Contains(err.Error(), "exists") {
+		assert.Fail(t, "can't create coverage store", err.Error())
+	}
+
+}
+
+func coveragesRemoveCoverage(t *testing.T) {
+	_, err := gsCatalog.DeleteCoverage(coveragesTestWorkspace, coveragesTestCoverageName, true)
+	if err != nil {
+		assert.Fail(t, "can't delete coverage", err.Error())
+	}
+}
+
+func TestPublishCoverage(t *testing.T) {
+	before()
+
+	//preparing
+	coveragesPrepareTestStorage(t, coveragesTestStoreName)
+
+	_, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
+	if err == nil {
+		coveragesRemoveCoverage(t)
+	}
+
+	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy")
+	assert.False(t, done)
+	assert.NotNil(t, errFail)
+
+	coveragesRemoveCoverage(t)
+}
+
+/*
+func TestPublishGeoTiffLayer(t *testing.T) {
+	before()
+
+	_, err := gsCatalog.PublishGeoTiffLayer(coveragesTestWorkspace, coveragesTestStoreName + "1", coveragesTestCoverageName, coveragesTestStoreFile[coveragesTestStoreName])
+
+	if err != nil {
+		assert.Fail(t, "can't publish geoTiff", err.Error())
+	}
+
+	return
+}
+*/
+
+func TestGetCoverage(t *testing.T) {
+
+	before()
+
+	//preparing
+	coveragesPrepareTestStorage(t, coveragesTestStoreName)
+
+	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	if err != nil && !strings.Contains(err.Error(), "exists") {
+		assert.Fail(t, "can't publish the coverage", err.Error())
+	}
+
+	//do the test
+	coverage, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
+	assert.NotNil(t, coverage)
+	assert.Nil(t, err)
+	coverageFail, errFail := gsCatalog.GetCoverage(coveragesTestWorkspace, "dummy")
+	assert.Nil(t, coverageFail)
+	assert.NotNil(t, errFail)
+
+	coveragesRemoveCoverage(t)
+}
+
+func TestGetCoverages(t *testing.T) {
+	before()
+
+	//preparing
+	coveragesPrepareTestStorage(t, coveragesTestStoreName)
+
+	_, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
+	if err == nil {
+		coveragesRemoveCoverage(t)
+	}
+
+	coverages, err := gsCatalog.GetCoverages(coveragesTestWorkspace)
+	if err != nil {
+		assert.Fail(t, "can't get coverages list", err.Error())
+	}
+	assert.True(t, len(coverages) == 0)
+
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	if err != nil {
+		assert.Fail(t, "can't get publish the coverage", err.Error())
+	}
+
+	coverages, err = gsCatalog.GetCoverages(coveragesTestWorkspace)
+	if err != nil {
+		assert.Fail(t, "can't get coverages list", err.Error())
+	}
+	assert.True(t, len(coverages) == 1)
+
+	coveragesRemoveCoverage(t)
+}
+
+func TestGetStorageCoverages(t *testing.T) {
+	before()
+
+	//preparing
+	coveragesPrepareTestStorage(t, coveragesTestStoreName)
+
+	coverages, err := gsCatalog.GetStoreCoverages(coveragesTestWorkspace, coveragesTestStoreName)
+	if err != nil {
+		assert.Fail(t, "can't get coverages list", err.Error())
+	}
+	assert.True(t, len(coverages) == 1)
+
+	//create wrong storage
+	coveragesPrepareTestStorage(t, coveragesTestDummyStoreName)
+
+	//we have to get the error while reading wrong storage
+	coverages, err = gsCatalog.GetStoreCoverages(coveragesTestWorkspace, coveragesTestDummyStoreName)
+	assert.NotNil(t, err)
+
+	_, err = gsCatalog.DeleteCoverageStore(coveragesTestWorkspace, coveragesTestDummyStoreName, true)
+	if err != nil {
+		assert.Fail(t, "can't delete temporary coverageStore", err.Error())
+	}
+
+}

--- a/coverages_test.go
+++ b/coverages_test.go
@@ -64,10 +64,10 @@ func TestPublishCoverage(t *testing.T) {
 		coveragesRemoveCoverage(t)
 	}
 
-	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	assert.True(t, done)
 	assert.Nil(t, err)
-	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy")
+	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy", "")
 	assert.False(t, done)
 	assert.NotNil(t, errFail)
 
@@ -95,7 +95,7 @@ func TestGetCoverage(t *testing.T) {
 	//preparing
 	coveragesPrepareTestStorage(t, coveragesTestStoreName)
 
-	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	if err != nil && !strings.Contains(err.Error(), "exists") {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
@@ -122,7 +122,7 @@ func TestUpdateCoverage(t *testing.T) {
 		coveragesRemoveCoverage(t)
 	}
 
-	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	if err != nil {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
@@ -160,7 +160,7 @@ func TestGetCoverages(t *testing.T) {
 	}
 	assert.True(t, len(coverages) == 0)
 
-	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	if err != nil {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}

--- a/coverages_test.go
+++ b/coverages_test.go
@@ -64,10 +64,10 @@ func TestPublishCoverage(t *testing.T) {
 		coveragesRemoveCoverage(t)
 	}
 
-	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
+	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
 	assert.True(t, done)
 	assert.Nil(t, err)
-	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy", "")
+	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy")
 	assert.False(t, done)
 	assert.NotNil(t, errFail)
 
@@ -95,7 +95,7 @@ func TestGetCoverage(t *testing.T) {
 	//preparing
 	coveragesPrepareTestStorage(t, coveragesTestStoreName)
 
-	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "Hop Hei LALALEI")
+	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
 	if err != nil && !strings.Contains(err.Error(), "exists") {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
@@ -122,7 +122,7 @@ func TestUpdateCoverage(t *testing.T) {
 		coveragesRemoveCoverage(t)
 	}
 
-	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
 	if err != nil {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
@@ -160,7 +160,7 @@ func TestGetCoverages(t *testing.T) {
 	}
 	assert.True(t, len(coverages) == 0)
 
-	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
 	if err != nil {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}

--- a/coverages_test.go
+++ b/coverages_test.go
@@ -64,10 +64,10 @@ func TestPublishCoverage(t *testing.T) {
 		coveragesRemoveCoverage(t)
 	}
 
-	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	done, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	assert.True(t, done)
 	assert.Nil(t, err)
-	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy")
+	done, errFail := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, "dummy", "")
 	assert.False(t, done)
 	assert.NotNil(t, errFail)
 
@@ -95,7 +95,7 @@ func TestGetCoverage(t *testing.T) {
 	//preparing
 	coveragesPrepareTestStorage(t, coveragesTestStoreName)
 
-	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	_, err := gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "Hop Hei LALALEI")
 	if err != nil && !strings.Contains(err.Error(), "exists") {
 		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
@@ -109,6 +109,38 @@ func TestGetCoverage(t *testing.T) {
 	assert.NotNil(t, errFail)
 
 	coveragesRemoveCoverage(t)
+}
+
+func TestUpdateCoverage(t *testing.T) {
+	before()
+
+	//preparing
+	coveragesPrepareTestStorage(t, coveragesTestStoreName)
+
+	_, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
+	if err == nil {
+		coveragesRemoveCoverage(t)
+	}
+
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
+	if err != nil {
+		assert.Fail(t, "can't publish the coverage", err.Error())
+	}
+
+	coverage, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
+	if err != nil {
+		assert.Fail(t, "can't get the coverage", err.Error())
+	}
+
+	coverage.Title = "NEW TITLE"
+
+	_, err = gsCatalog.UpdateCoverage(coveragesTestWorkspace, coverage)
+	if err != nil {
+		assert.Fail(t, "can't update the coverage", err.Error())
+	}
+
+	coveragesRemoveCoverage(t)
+
 }
 
 func TestGetCoverages(t *testing.T) {
@@ -128,9 +160,9 @@ func TestGetCoverages(t *testing.T) {
 	}
 	assert.True(t, len(coverages) == 0)
 
-	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName)
+	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	if err != nil {
-		assert.Fail(t, "can't get publish the coverage", err.Error())
+		assert.Fail(t, "can't publish the coverage", err.Error())
 	}
 
 	coverages, err = gsCatalog.GetCoverages(coveragesTestWorkspace)

--- a/layers.go
+++ b/layers.go
@@ -78,11 +78,6 @@ type PublishPostgisLayerRequest struct {
 	FeatureType *FeatureType `json:"featureType,omitempty"`
 }
 
-//PublishGeoTiffLayerRequest is the api body
-type PublishGeoTiffLayerRequest struct {
-	Coverage *Coverage `json:"coverage,omitempty"`
-}
-
 // GetshpFiledsName datastore name from shapefile name
 func (g *GeoServer) GetshpFiledsName(filename string) string {
 	name := strings.TrimSuffix(filename, filepath.Ext(filename))
@@ -222,40 +217,6 @@ func (g *GeoServer) PublishPostgisLayer(workspaceName string, datastoreName stri
 	targetURL := g.ParseURL("rest", workspaceName, "datastores", datastoreName, "/featuretypes")
 	data := PublishPostgisLayerRequest{FeatureType: &FeatureType{Name: publishName,
 		NativeName: tableName}}
-
-	serializedLayer, _ := g.SerializeStruct(data)
-	g.logger.Errorf("%s", serializedLayer)
-	httpRequest := HTTPRequest{
-		Method:   postMethod,
-		Accept:   jsonType,
-		Data:     bytes.NewBuffer(serializedLayer),
-		DataType: jsonType,
-		URL:      targetURL,
-		Query:    nil,
-	}
-	response, responseCode := g.DoRequest(httpRequest)
-	if responseCode != statusCreated {
-		g.logger.Error(response)
-		published = false
-		err = g.GetError(responseCode, response)
-		return
-	}
-	published = true
-	return
-}
-
-//PublishGeoTiffLayer publish geotiff to geoserver
-func (g *GeoServer) PublishGeoTiffLayer(workspaceName string, coveragestoreName string, publishName string, fileName string) (published bool, err error) {
-	if workspaceName != "" {
-		workspaceName = fmt.Sprintf("workspaces/%s/", workspaceName)
-	}
-	targetURL := g.ParseURL("rest", workspaceName, "coveragestores", coveragestoreName, "/coverages")
-	data := PublishGeoTiffLayerRequest{
-		Coverage: &Coverage{
-			Name:               publishName,
-			NativeCoverageName: fileName,
-		},
-	}
 
 	serializedLayer, _ := g.SerializeStruct(data)
 	g.logger.Errorf("%s", serializedLayer)


### PR DESCRIPTION
There are a set of methods to work with raster layers, including: 
- get a list of raster layers (coverages): GetCoverages
- get a list of raster layers in the coverageStore, including unpublished layers: GetStoreCoverages
- get raster layer structure (coverage): GetCoverage
- delete and update raster layer: DeleteCoverage, UpdateCoverage
- publishing the raster layer from the coverageStore: PublishCoverage

PublishGeoTiffLayer is refactored and moved from layers.go to coverages.go because this is a more suitable place for raster layers methods

Tests for all these methods were also implemented