### PR TITLE
ci: pin golangci-lint v2, split integration workflow, fix flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62.0
+          version: v2.1.6
           args: --timeout=5m
 
   unit:
@@ -60,25 +60,6 @@ jobs:
           name: coverage-go${{ matrix.go }}
           path: coverage.out
           retention-days: 14
-
-  integration:
-    name: Integration (GeoServer ${{ matrix.geoserver }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        geoserver: ["2.27.4", "2.28.0"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-          check-latest: true
-          cache: true
-      - name: Run integration tests
-        env:
-          GEOSERVER_VERSION: ${{ matrix.geoserver }}
-        run: go test -race -tags=integration -timeout=15m ./...
 
   vuln:
     name: govulncheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           check-latest: true
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: --timeout=5m

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,72 @@
+name: Integration tests
+
+# Integration tests boot a real GeoServer + PostGIS via docker compose and
+# exercise the package against it. The build is heavy (downloads GeoServer
+# WAR from SourceForge and waits for Tomcat to start), so we don't run it
+# on every push — only on demand and on a weekly schedule.
+
+on:
+  workflow_dispatch:
+    inputs:
+      geoserver:
+        description: GeoServer version to test against
+        required: false
+        default: "2.28.0"
+        type: choice
+        options:
+          - "2.27.4"
+          - "2.28.0"
+  schedule:
+    # Sundays at 03:17 UTC — outside common deploy windows.
+    - cron: "17 3 * * 0"
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  matrix:
+    name: GeoServer ${{ matrix.geoserver }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        geoserver: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.geoserver)) || fromJSON('["2.27.4", "2.28.0"]') }}
+    env:
+      GEOSERVER_VERSION: ${{ matrix.geoserver }}
+      GEOSERVER_URL: http://localhost:8080/geoserver/
+      GEOSERVER_USER: admin
+      GEOSERVER_PASS: geoserver
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          check-latest: true
+          cache: true
+
+      - name: Boot GeoServer + PostGIS
+        run: docker compose up -d --wait --wait-timeout=420
+
+      - name: Show GeoServer version
+        run: |
+          curl -fsS -u ${GEOSERVER_USER}:${GEOSERVER_PASS} "${GEOSERVER_URL}rest/about/version.json" | head -c 1024 || true
+
+      - name: Run integration tests
+        run: go test -race -tags=integration -timeout=15m ./...
+
+      - name: Compose logs (on failure)
+        if: failure()
+        run: docker compose logs --no-color --tail=400
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/coverages_test.go
+++ b/coverages_test.go
@@ -128,12 +128,15 @@ func TestUpdateCoverage(t *testing.T) {
 
 	_, err = gsCatalog.PublishCoverage(coveragesTestWorkspace, coveragesTestStoreName, coveragesTestCoverageName, "")
 	if err != nil {
-		assert.Fail(t, "can't publish the coverage", err.Error())
+		t.Fatalf("can't publish the coverage: %v", err)
 	}
 
 	coverage, err := gsCatalog.GetCoverage(coveragesTestWorkspace, coveragesTestCoverageName)
 	if err != nil {
-		assert.Fail(t, "can't get the coverage", err.Error())
+		t.Fatalf("can't get the coverage: %v", err)
+	}
+	if coverage == nil {
+		t.Fatalf("got nil coverage with no error")
 	}
 
 	coverage.Title = "NEW TITLE"


### PR DESCRIPTION
## Summary

Three CI fixes that surfaced when the v1.1.0-rc.1 master push failed:

1. **Lint job** pinned golangci-lint v1.62.0 but `.golangci.yml` is v2-schema (shipped in PR #23). Bump to `v2.1.6`.
2. **Integration tests** never started the compose stack — every `go test -tags=integration` ran against nothing and panicked. Moved to a dedicated `integration.yml` triggered on `workflow_dispatch` / `schedule` (Sun 03:17 UTC) / `push tags v*` and now actually `docker compose up -d --wait` before testing.
3. **`coverages_test.go` TestUpdateCoverage** was dereferencing the result of `GetCoverage` after a non-nil-error path that used `assert.Fail` (marks failure but doesn't `return`), so any transport failure caused a SIGSEGV. Pre-existing v1.0 latent bug. Replaced with `t.Fatalf` and an explicit nil guard.

## Why split integration off

Building the GeoServer image pulls the WAR from SourceForge (~5 min) and Tomcat needs ~2-3 min to come up. Running this on every push doubles every PR's CI time and isn't valuable since the unit-test layer already covers the wire format. The split keeps daily CI under a minute, while integration runs nightly on Sundays + on every release tag (so v1.1.0-rc.1's tag actually gets verified).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -short ./...` clean (27 unit tests pass)
- [x] `golangci-lint run` clean
- [x] `go test -tags=integration -run='^$' ./...` compiles
- [ ] CI green on this PR
- [ ] Manual `gh workflow run integration.yml` succeeds against GeoServer 2.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)