### PR TITLE
fix(docker): Tomcat 10 -> 9 (GeoServer 2.x is javax, not jakarta)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
 # GeoServer dev/test image.
-# Base: Tomcat 10 + JDK 17 (Temurin). GeoServer 2.x runs on Servlet 4 (Tomcat 9/10).
+#
+# Base: Tomcat 9 + JDK 17 (Temurin). GeoServer 2.27 LTS / 2.28 stable use the
+# javax.* servlet namespace (Servlet 4.x) and do not run on Tomcat 10/11
+# (which moved to jakarta.*). GeoServer 3.0 will be the Tomcat 11 / Jakarta EE
+# target and is tracked separately for v2 of this client library.
 
-ARG TOMCAT_TAG=10.1-jdk17-temurin
+ARG TOMCAT_TAG=9-jdk17-temurin
 FROM tomcat:${TOMCAT_TAG}
 
 LABEL maintainer="Hesham Karm<hishamwaleedkaram@gmail.com>"


### PR DESCRIPTION
## Summary

GeoServer 2.27/2.28 uses the **javax** servlet namespace; Tomcat 10+ moved to **jakarta** (Jakarta EE 9). My v1.1 modernization in PR #23 picked `tomcat:10.1-jdk17-temurin`, which boots Tomcat fine but then aborts the GeoServer WAR deploy at the listener-init phase:

```
SEVERE [main] StandardContext.startInternal One or more listeners failed to start
SEVERE Context [/geoserver] startup failed due to previous errors
```

Pin `tomcat:9-jdk17-temurin` instead. Tomcat 11 + Jakarta EE 6.1 is the GeoServer 3.0 target — tracked for v2 of this library.

## How this surfaced

PR #30 added `integration.yml` that actually boots `docker compose up -d --wait` (instead of running `go test -tags=integration` against nothing). The first manual run against GeoServer 2.28.0 ([#25274667471](https://github.com/hishamkaram/geoserver/actions/runs/25274667471)) revealed the bad Tomcat pin.

## Test plan

- [x] `go build ./...` clean (no Go changes)
- [ ] After merge: trigger `integration.yml` against 2.28.0 and 2.27.4 manually; both should reach the GeoServer healthcheck and run the integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)