### PR TITLE
test(integration): align TestDoRequest with v1.1 (nil, 0) on bad method

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -29,15 +29,19 @@ func TestSerializeStruct(t *testing.T) {
 }
 func TestDoRequest(t *testing.T) {
 	gsCatalog := GetCatalog("http://localhost:8080/geoserver/", "admin", "geoserver")
+	// v1.1: DoRequest with an unsupported method now logs and returns
+	// (nil, 0) rather than recovering from a panic and returning the
+	// panic message bytes.
 	responseText, statusCode := gsCatalog.DoRequest(HTTPRequest{Method: "dummy_method",
 		Accept: jsonType,
 		URL:    "http://localhost:8080/geoserver/"})
-	assert.Equal(t, statusCode, 0)
-	assert.NotNil(t, responseText)
+	assert.Equal(t, 0, statusCode)
+	assert.Nil(t, responseText)
+	// Real GET hits the WFS endpoint; we expect a non-zero status code.
 	responseText, statusCode = gsCatalog.DoRequest(HTTPRequest{Method: getMethod,
 		Accept: jsonType,
 		URL:    "http://localhost:8080/geoserver/wfs"})
-	assert.NotEqual(t, statusCode, 0)
+	assert.NotEqual(t, 0, statusCode)
 	assert.NotNil(t, responseText)
 }
 


### PR DESCRIPTION
## Summary

Caught while running the new \`integration.yml\` against GeoServer 2.28: \`TestDoRequest\` was still asserting v1.0 panic-recover behavior (NotNil response on unsupported HTTP method), but A2's \"stop the bleeding\" change replaced the panic with \`(nil, 0)\` plus a \`slog.Error\` log.

This PR updates the test assertion to match the v1.1 contract and documents the change in a comment.

## Other integration-suite failures

The same run also surfaced 3 other failures that are NOT v1.1 contract changes:

- \`TestGeoserverStyleSuite\` — depends on style fixtures
- \`TestGetLayerGroup\` — depends on default workspaces (\`cite\`, \`nurc\`, \`topp\`) preloaded into GeoServer
- \`TestPublishPostgisLayer\` — depends on a seeded PostGIS database

These are stale-fixture issues against modern GeoServer 2.28 (the original tests targeted GeoServer 2.13/2.14 with sample data). They will be tracked in a follow-up issue and addressed separately — likely via a postgis init script and/or test rewrites that no longer assume preloaded data.

## Test plan

- [x] \`go test -tags=integration -run='^$' ./...\` compiles
- [x] CI passes
- [ ] Manual integration run: TestDoRequest no longer fails (other 3 still fail but those are tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)