### PR TITLE
fix(integration): make integration suite pass against modern GeoServer 2.28

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,6 +33,8 @@ services:
       POSTGRES_PASSWORD: golang
     ports:
       - "5436:5432"
+    volumes:
+      - ./docker/postgis/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U golang -d gis"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - "5436:5432"
     volumes:
       - postgis-data:/var/lib/postgresql/data
+      - ./docker/postgis/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U golang -d gis"]
       interval: 5s

--- a/docker/postgis/init/01-lbldyt.sql
+++ b/docker/postgis/init/01-lbldyt.sql
@@ -1,0 +1,34 @@
+-- Minimal seed used by the integration test TestPublishPostgisLayer (and any
+-- other suites that publish a postgis-backed layer). The table is named
+-- "lbldyt" to match the historical fixture from the v1.0 era; the GeoServer
+-- PublishPostgisLayer endpoint requires the table to exist with at least one
+-- column besides the geometry column or it 400s with
+--   "Trying to create new feature type inside the store, but no attributes
+--    were specified"
+--
+-- This file lives in /docker-entrypoint-initdb.d/ inside the postgis
+-- container; the postgres image runs *.sql files alphabetically on first
+-- boot of an empty data volume. To re-run after a schema change, recreate
+-- the volume: `docker compose down -v && docker compose up -d --wait`.
+
+\connect gis;
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE IF NOT EXISTS public.lbldyt (
+    gid    SERIAL PRIMARY KEY,
+    name   TEXT,
+    label  TEXT,
+    geom   geometry(Geometry, 4326)
+);
+
+CREATE INDEX IF NOT EXISTS lbldyt_geom_gist ON public.lbldyt USING GIST (geom);
+
+INSERT INTO public.lbldyt (name, label, geom) VALUES
+    ('alpha', 'first label',  ST_SetSRID(ST_MakePoint(  0.0,  0.0), 4326)),
+    ('beta',  'second label', ST_SetSRID(ST_MakePoint( 10.0, 20.0), 4326)),
+    ('gamma', 'third label',  ST_SetSRID(ST_MakePoint(-30.0, 40.0), 4326))
+ON CONFLICT DO NOTHING;
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO golang;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO golang;

--- a/layergroups.go
+++ b/layergroups.go
@@ -65,6 +65,54 @@ type LayerGroupStyles struct {
 	Style []*Resource `json:"style,omitempty" xml:"style"`
 }
 
+// UnmarshalJSON tolerates GeoServer's mixed-shape `style` array. For an
+// unstyled layer in the group, GeoServer emits a bare string literal (often
+// "") instead of an object; for a styled layer it emits an object with
+// name/href fields. Without this the standard JSON decoder errors with
+// json: cannot unmarshal string into Go struct field LayerGroupStyles.style
+// when the layer group has any default-styled members. String entries are
+// preserved as a [Resource] with [Resource.Name] set to the string value.
+func (s *LayerGroupStyles) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	// Decode into the looser intermediate type that accepts either shape.
+	type rawWrapper struct {
+		Style []json.RawMessage `json:"style,omitempty"`
+	}
+	var raw rawWrapper
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("layergroups: decode styles wrapper: %w", err)
+	}
+
+	out := make([]*Resource, 0, len(raw.Style))
+	for i, elem := range raw.Style {
+		if len(elem) == 0 || string(elem) == "null" {
+			out = append(out, nil)
+			continue
+		}
+		switch elem[0] {
+		case '"':
+			var name string
+			if err := json.Unmarshal(elem, &name); err != nil {
+				return fmt.Errorf("layergroups: decode style[%d] string: %w", i, err)
+			}
+			out = append(out, &Resource{Name: name})
+		case '{':
+			var r Resource
+			if err := json.Unmarshal(elem, &r); err != nil {
+				return fmt.Errorf("layergroups: decode style[%d] object: %w", i, err)
+			}
+			out = append(out, &r)
+		default:
+			return fmt.Errorf("layergroups: unexpected style[%d] JSON shape: %s", i, string(elem))
+		}
+	}
+	s.Style = out
+	return nil
+}
+
 // LayerGroup geoserver layergroup details
 type LayerGroup struct {
 	Name          string             `json:"name,omitempty" xml:"name"`

--- a/styles.go
+++ b/styles.go
@@ -3,6 +3,7 @@ package geoserver
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -89,6 +90,20 @@ func (g *GeoServer) GetStylesContext(ctx context.Context, workspaceName string) 
 		err = g.GetError(responseCode, response)
 		return
 	}
+	// GeoServer 2.28 returns `{"styles":""}` (bare string) for an empty
+	// styles collection and `{"styles":{"style":[...]}}` for a populated
+	// one. Decode into json.RawMessage first and then into the typed
+	// shape only if the payload is an object.
+	var stylesEnvelope struct {
+		Styles json.RawMessage `json:"styles,omitempty"`
+	}
+	if err = g.DeSerializeJSON(response, &stylesEnvelope); err != nil {
+		return nil, err
+	}
+	if len(stylesEnvelope.Styles) == 0 || string(stylesEnvelope.Styles) == "null" || stylesEnvelope.Styles[0] == '"' {
+		// Empty list per GeoServer's empty-collection convention.
+		return nil, nil
+	}
 	var stylesResponse struct {
 		Styles struct {
 			Style []*Resource `json:"style,omitempty"`
@@ -159,10 +174,19 @@ func (g *GeoServer) CreateStyleContext(ctx context.Context, workspaceName string
 	}
 	data := bytes.NewBuffer(serializedStyle)
 	httpRequest := HTTPRequest{
-		Method:   postMethod,
-		Accept:   jsonType,
+		Method: postMethod,
+		// GeoServer 2.28's workspace-scoped POST /styles inspects the
+		// Accept header to dispatch to a style-format handler. With
+		// "application/json" it looks for a JSON style handler (which
+		// doesn't exist) and 500s with
+		// "No such style handler: format = application/json". Sending
+		// "*/*" disables that dispatch and routes the request to the
+		// metadata-creation path. The body Content-Type is also
+		// stamped with "; charset=utf-8" — bare "application/json"
+		// triggers the same 500 in older 2.x versions.
+		Accept:   "*/*",
 		Data:     data,
-		DataType: jsonType,
+		DataType: jsonType + "; charset=utf-8",
 		URL:      targetURL,
 		Query:    nil,
 	}


### PR DESCRIPTION
## Summary

Surfaced by running the new \`integration.yml\` against a fresh GeoServer 2.28 stack: 4 integration tests were failing. After this PR all of them pass; full suite is green in ~19s locally.

## Code fixes

### \`CreateStyle\` (workspace-scoped) — \`styles.go\`

GeoServer 2.28's \`POST /workspaces/{ws}/styles\` inspects the **Accept header** to dispatch to a style-format handler. With \`Accept: application/json\` it looks for a JSON style handler (which doesn't exist) and 500s:

> \`No such style handler: format = application/json\`

Send \`Accept: */*\` instead. Also stamp \`Content-Type\` with \`; charset=utf-8\` because older 2.x versions ALSO trip on bare \`application/json\`. Both changes are safe across the workspace-scoped and global endpoints.

### \`GetStyles\` — \`styles.go\`

GeoServer 2.28 returns \`{\"styles\":\"\"}\` (a bare string) for an empty styles collection rather than \`{\"styles\":{\"style\":[]}}\`. The old decoder failed with \`json.UnmarshalTypeError\`. Decode into \`json.RawMessage\` first and short-circuit to \`nil\` if the field is a string or null.

### \`LayerGroupStyles.UnmarshalJSON\` — \`layergroups.go\`

GeoServer emits the \`layergroup.styles.style\` array with mixed shape: an explicit style is an object \`{\"name\":..., \"href\":...}\`, but a layer using its default style is serialized as a bare string (often \`\"\"\`), positionally aligned with \`publishables\`. Custom \`UnmarshalJSON\` accepts either per element. String entries become \`&Resource{Name: \"\"}\` so the field's \`[]*Resource\` type stays unchanged (preserves any v1.0 callsites that constructed literals).

## Fixture

### \`docker/postgis/init/01-lbldyt.sql\` + compose mount

\`TestPublishPostgisLayer\` needs an actual postgis-backed table; otherwise GeoServer 400s with \"no attributes were specified\". Auto-load a small \`lbldyt\` table with \`name\`/\`label\`/\`geom\` columns and three sample rows on first boot of the postgis volume. Both \`docker-compose.yml\` and \`docker-compose.test.yml\` now mount \`docker/postgis/init/\` into \`/docker-entrypoint-initdb.d/\`.

## Test plan

- [x] \`go test -short -race ./...\` green (unit tests unchanged)
- [x] \`golangci-lint run\` clean
- [x] **\`go test -tags=integration ./...\` green against GeoServer 2.28.0 locally (19.2s)**
- [ ] Same against GeoServer 2.27 LTS (will run via the manual workflow after merge)
- [ ] CI on this PR

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)