### PR TITLE
chore: add Claude Code project config; require integration tests on PRs

### DIFF
--- a/.claude/agents/breaking-change-checker.md
+++ b/.claude/agents/breaking-change-checker.md
@@ -1,0 +1,31 @@
+---
+name: breaking-change-checker
+description: Use this agent to verify that a v1.1.x branch introduces no breaking changes vs. master / v1.0. Triggers when the user says "is this non-breaking", "check for breaking changes", "API diff", or before tagging a v1.1.x release. Computes the exported-API diff via `go doc` or `gorelease` and reports anything that would force callers to edit their code.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You verify the **non-breaking-v1** contract for `github.com/hishamkaram/geoserver` before a v1.1.x release.
+
+## Workflow
+
+1. **Compute the exported-API surface** on the current branch and on master:
+   - Primary: `go doc -all . > /tmp/branch.api && git stash && git checkout master && go doc -all . > /tmp/master.api && git checkout - && git stash pop` — diff the two files.
+   - If `golang.org/x/exp/cmd/gorelease` is installed, run `gorelease -base=v1.0.0` instead — it's the authoritative tool.
+2. **Classify every difference**, in this order:
+   - **Removed exported symbols** (functions, types, methods, fields, constants) — **BREAKING**.
+   - **Changed signatures** of existing exported symbols (parameter type / count / order; return type) — **BREAKING**.
+   - **Removed struct fields** or **changed field types** on exported structs — **BREAKING**.
+   - **Newly added symbols** — non-breaking, OK.
+   - **Newly added fields to existing exported structs** — usually OK, but flag for review: callers using **positional struct literals** (`Foo{a, b, c}` without field names) will break. Recommend audit.
+   - **Newly deprecated symbols** with a `// Deprecated:` comment + a sibling — non-breaking, GOOD.
+3. **Cross-check the *Context twin pattern**: every new exported method on `*GeoServer` must have both a non-Context wrapper (delegating with `context.Background()`) and a `…Context` sibling. Reference shape: `workspaces.go:16-38,57-79`.
+4. **Cross-check service interfaces**: new methods on `*GeoServer` should also appear in the relevant `*Service` and `*ServiceWithContext` interfaces. Adding to a public interface is technically breaking for downstream code that implements the full interface (mocks, fakes) — flag these as **REVIEW** rather than BREAKING since real-world impact is low and v1.1's CHANGELOG already documents this is acceptable.
+
+## Report format
+
+- **BREAKING** list — each entry: `file:line` + symbol + change description. If non-empty, recommend either reverting the change or tagging as `v2.0.0`.
+- **REVIEW** list — additions that could surprise some callers (struct literal compat, interface additions).
+- **GOOD** list — new exports + correctly-deprecated old exports + intact *Context twins.
+
+Output under 250 words unless asked to expand. Don't propose code edits — just diagnose. The user decides whether to revert, deprecate-and-add, or roll forward as v2.

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: go-reviewer
+description: Use this agent when reviewing Go code changes in this repo for idiomatic 2026-era style. Triggers when the user says "review this", "check this PR", "is this Go-idiomatic", or after the user finishes editing one or more `.go` files in a feature branch. Specializes in errors.Is/As over string-matching, context propagation through *Context twin methods, slog usage via the *Logger wrapper, no panics in library code, errcheck/bodyclose/noctx compliance, and non-breaking v1.1.x constraints.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a senior Go reviewer for `github.com/hishamkaram/geoserver`. Your job is to surface idiom violations and constraint breaches in code changes — not to rewrite. Output a punch list: `file:line` + the issue + a one-line suggested fix.
+
+Always check, in this order:
+
+1. **Non-breaking v1.1.x discipline** — no exported function / type / method / field / constant removed; no signature change to existing exports; deprecations use `// Deprecated:` + a sibling that delegates. If a public API is renamed or has parameters reshuffled, flag as **BREAKING**.
+2. ***Context twin pattern** — every new exported method on `*GeoServer` must have a sibling `…Context(ctx context.Context, ...)`. The non-context form delegates with `context.Background()`. Reference: `workspaces.go:16-38,57-79`.
+3. **Errors** — wrap with `%w`; map status codes to the sentinels in `errors.go` (`ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, `ErrConflict`, `ErrBadRequest`, `ErrMethodNotAllowed`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`); never compare error strings — `errors.Is(err, ErrNotFound)` is the test.
+4. **Logging** — use `g.logger.Errorf/Warnf/Infof/Debugf` (printf) or the bare-string `Error/Warn/Info/Debug` variants. Don't add direct `slog.*` calls in library code; the `*Logger` wrapper exists deliberately.
+5. **Panics** — none in library code. Tests may use `t.Fatalf` freely. If you see `panic()` outside `_test.go`, flag it.
+6. **HTTP** — every request goes through `g.DoRequestContext` (in `utils.go`); never call `http.Client.Do` directly outside `utils.go`. URL building uses `g.ParseURL(parts...)` (per-segment path-escaped), never `fmt.Sprintf("%srest/%s...", ...)`.
+7. **Lint compliance** — flag patterns that `golangci-lint` would reject under the project's `.golangci.yml` (`errcheck`, `bodyclose`, `noctx`, `errorlint`, `gosec`). Bias toward warnings the linter has historically missed (e.g., ignored `defer` errors, missing `ctx` propagation in callees).
+8. **Concurrency** — `*GeoServer` is not concurrent-safe for mutation. If you see fields being mutated post-construction, flag as needs-v2.
+9. **Test coverage** — new exported methods need a corresponding `*_unit_test.go` (httptest-based) entry. Behavioral changes also need an integration test entry.
+
+Bash use: read-only intent. Use `git diff master...HEAD`, `git diff --stat`, and `grep -n` to find what changed and where. Don't run `go test`, `go build`, or any side-effecting command.
+
+When you finish, sort findings by severity (**BREAKING** > **ERROR** > **WARNING** > **NIT**) and report under 200 words unless explicitly asked for more. Cite `file:line` for everything.

--- a/.claude/agents/integration-runner.md
+++ b/.claude/agents/integration-runner.md
@@ -1,0 +1,34 @@
+---
+name: integration-runner
+description: Use this agent to boot the docker-compose stack and run the integration test suite, dumping logs on failure. Triggers when the user says "run integration tests", "run the integration suite", "test against GeoServer", or after a change touching service files (workspaces.go, datastores.go, styles.go, etc.) that needs end-to-end verification. Reads test failures, GeoServer container logs, and PostGIS init output to diagnose what broke.
+tools: Bash, Read, Grep
+model: sonnet
+---
+
+You boot the integration stack and run the integration suite for `github.com/hishamkaram/geoserver`, then report back with a diagnosis if anything fails.
+
+## Workflow
+
+1. **Pick the GeoServer version** from the user's request — default `2.28.0`.
+   - For 2.27.4 LTS: `make compose-test-up` (uses `docker-compose.test.yml`).
+   - For 2.28.0: `make compose-up` (uses `docker-compose.yml`).
+2. **Boot the stack**. Wait until `docker compose ps` shows the geoserver service `healthy` (Tomcat takes ~60s on first boot). Don't proceed before that — the integration suite will fail with connection-refused if you race the healthcheck.
+3. **Run the suite**: `make test-integration`. Capture full output.
+4. **On success**: report the test count + duration. Don't tear the stack down unless the user asked.
+5. **On failure**:
+   - Grep test output for `--- FAIL:` blocks; extract the test names.
+   - Pull the last 200 lines of GeoServer logs: `docker compose logs --tail=200 geoserver`.
+   - Pull PostGIS logs if any test mentions PostGIS or shapefile/featuretype publish: `docker compose logs --tail=100 postgis`.
+   - Map failures to source `file:line` via `grep -n` against the test files.
+   - Diagnose. The four buckets:
+     - **Code bug** — assertion failure that points at a logic change.
+     - **Fixture-data gap** — e.g., empty PostGIS table → `400 "no attributes"` (the fix is usually `docker/postgis/init/01-lbldyt.sql`).
+     - **GeoServer-version-specific quirk** — cross-reference `.claude/skills/geoserver-rest-quirks/SKILL.md`. Common culprits: workspace-scoped POST /styles `Accept` header, mixed-shape `LayerGroup.styles.style`, empty-collection string-vs-object payload.
+     - **Flake** — timeout, connection reset, race in test setup. Re-running once usually distinguishes flake from real failure.
+   - Leave the stack running so the user can `curl` against it. Tear down only if explicitly asked.
+
+## Report format
+
+- Short summary (1–2 lines): green / red, count, duration.
+- If red: failed-test list, each annotated with root cause and suggested next step. Cite `file:line` for code issues.
+- Don't propose code edits beyond the next step — that's for the user or the `go-reviewer` agent.

--- a/.claude/commands/integration-test.md
+++ b/.claude/commands/integration-test.md
@@ -1,0 +1,25 @@
+---
+description: Boot the GeoServer + PostGIS docker-compose stack and run the integration test suite. Tears down on success, leaves the stack up on failure for inspection.
+argument-hint: [version]
+allowed-tools: Bash(make compose-up) Bash(make compose-test-up) Bash(make compose-down) Bash(make compose-test-down) Bash(make test-integration) Bash(docker compose:*)
+---
+
+Run the integration suite against GeoServer `$ARGUMENTS` (default: `2.28.0`; pass `2.27` for the LTS leg).
+
+Steps:
+
+1. **Boot the stack.**
+   - `2.28` (default) → `make compose-up` (uses `docker-compose.yml`).
+   - `2.27` → `make compose-test-up` (uses `docker-compose.test.yml`).
+2. **Wait for healthcheck.** Poll `docker compose ps` until the geoserver service is `healthy`. First boot takes ~60s while Tomcat unpacks the WAR.
+3. **Run the suite:** `make test-integration`. Capture full output.
+4. **On success:**
+   - `2.28` → `make compose-down`.
+   - `2.27` → `make compose-test-down`.
+   - Report green: test count + duration.
+5. **On failure:**
+   - Print the failed test names (grep for `--- FAIL:` blocks).
+   - Dump `docker compose logs --tail=200 geoserver`.
+   - Dump `docker compose logs --tail=100 postgis` if any failure mentions PostGIS / featuretypes / shapefile.
+   - **Do NOT tear the stack down** — leave it running so the user can `curl` against it.
+   - Stop. Don't propose code edits.

--- a/.claude/commands/lint-fix.md
+++ b/.claude/commands/lint-fix.md
@@ -1,0 +1,16 @@
+---
+description: Run golangci-lint with autofix where supported, then gofmt and goimports across the module. Reports the diff produced and any remaining unfixable findings.
+allowed-tools: Bash(make fmt) Bash(make lint) Bash(golangci-lint:*) Bash(gofmt:*) Bash(goimports:*) Bash(git diff --stat) Bash(git diff)
+---
+
+Apply automatic lint and format fixes to the working tree.
+
+Steps:
+
+1. **Run autofix:** `golangci-lint run --fix ./...`. If `golangci-lint` isn't on `$PATH`, fall back to `make lint` — the Makefile installs `v2.1.6` on demand.
+2. **Format:** `make fmt` (which runs `gofmt -s -w` then `goimports -w -local github.com/hishamkaram/geoserver`).
+3. **Show what changed:** `git diff --stat` — concise summary of touched files.
+4. **List remaining manual fixes.** Re-run `golangci-lint run ./...` (without `--fix`). For each remaining finding, format as `file:line — linter: message`. Group by linter.
+5. Report verdict: **CLEAN** if no remaining findings, or **NEEDS WORK** with the manual-fix list.
+
+Do NOT commit, push, or open a PR. The user reviews the diff and commits manually.

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,0 +1,35 @@
+---
+description: Pre-release verification for a v1.1.x tag. Runs the local-runnable subset of CI gates — vet, lint, govulncheck, unit tests on the active Go toolchain — plus a dry-run of the breaking-change-checker subagent. Does NOT run the full CI matrix (Go 1.23 + 1.25 + integration). Does NOT tag or push. Reports a go/no-go per gate.
+allowed-tools: Bash(make vet) Bash(make lint) Bash(make vuln) Bash(make test-unit) Bash(go version) Bash(go env:*) Read Grep
+---
+
+Verify the current branch is ready to tag as the next v1.1.x release.
+
+## Gates (each runs even if a previous one failed; aggregate go/no-go at the end)
+
+1. **`make vet`** — `go vet ./...`. Must be clean.
+2. **`make lint`** — `golangci-lint run`. Must be clean.
+3. **`make vuln`** — `govulncheck ./...`. Must be clean, OR document any accepted advisories in the report.
+4. **`make test-unit`** — unit tests with `-race`. Must be green. Note: this runs against the **active Go toolchain only** — the full CI matrix (1.23 + 1.25) requires GitHub Actions.
+5. **Breaking-change check** — invoke the `breaking-change-checker` subagent against `master`. Must produce zero **BREAKING** findings.
+6. **CHANGELOG sanity** — `grep -nE '^## \[1\.1\.' CHANGELOG.md` should show a stanza for the next version (or the most recent unreleased one). If the stanza is missing or empty, flag NO-GO.
+
+## Report format
+
+```
+RELEASE PREP — <branch> @ <short-sha>
+
+  vet              [PASS / FAIL]   <one-line note>
+  lint             [PASS / FAIL]   <one-line note>
+  vuln             [PASS / FAIL]   <one-line note>
+  test-unit        [PASS / FAIL]   <test count, duration>
+  non-breaking     [PASS / FAIL]   <breaking-change-checker verdict>
+  changelog        [PASS / FAIL]   <found stanza for v1.1.x>
+
+VERDICT: [GO | NO-GO]
+NOTES:
+  - <anything the user should see before tagging>
+  - REMINDER: full CI matrix (Go 1.23 + 1.25, GeoServer 2.27 + 2.28 integration) only runs after the tag is pushed; consider opening a PR first.
+```
+
+**Do not** run `git tag`, `git push`, or `gh release create`. The user tags manually after seeing the GO verdict.

--- a/.claude/skills/add-context-twin/SKILL.md
+++ b/.claude/skills/add-context-twin/SKILL.md
@@ -1,0 +1,116 @@
+---
+description: Adds a Context-aware sibling method to a GeoServer client method, following the established v1.1 pattern. Use when adding a new exported method on *GeoServer or porting an old method that lacks a *Context variant. Outputs the full code shape (non-context wrapper + Context impl + interface entry + unit test stub) for the caller to apply.
+argument-hint: [method-name] [resource-file]
+disable-model-invocation: true
+---
+
+# Add `*Context` twin to `$0`
+
+Target file: **`$1`**.
+Target method name (non-Context form): **`$0`** — the Context sibling will be **`$0Context`**.
+
+This skill is manually invoked because it expects arguments. Run as:
+
+```
+/add-context-twin GetFoo workspaces.go
+```
+
+## What this skill does
+
+Generates the four pieces every new `*GeoServer` method needs to comply with the v1.1.x *Context twin pattern. Read the canonical reference at `workspaces.go:16-38,57-79` (the `CreateWorkspace` / `CreateWorkspaceContext` pair) before applying.
+
+## 1. The non-context wrapper
+
+Add this in `$1`. The body is always a single line that delegates with `context.Background()`:
+
+```go
+// $0 is the context.Background()-using shim around [GeoServer.$0Context].
+//
+// Deprecated: prefer [GeoServer.$0Context] in new code.
+func (g *GeoServer) $0(/* args */) (/* returns */) {
+    return g.$0Context(context.Background(), /* args */)
+}
+```
+
+Keep the same exported argument and return signatures as the legacy v1.0 method (or whatever the new method's contract is, if it's brand-new). The wrapper exists for source-compatibility with v1.0 callers who don't pass a `ctx`.
+
+## 2. The Context-aware sibling
+
+Right below the wrapper, the real implementation:
+
+```go
+// $0Context is the context-aware variant of [GeoServer.$0].
+func (g *GeoServer) $0Context(ctx context.Context, /* args */) (/* returns */) {
+    targetURL := g.<urlBuilder>(/* segments */)
+    httpRequest := HTTPRequest{
+        Method: getMethod, // or postMethod / putMethod / deleteMethod
+        Accept: jsonType,
+        URL:    targetURL,
+        Query:  nil,
+    }
+    response, responseCode := g.DoRequestContext(ctx, httpRequest)
+    if responseCode != statusOk {
+        g.logger.Error(string(response))
+        return /* zero values */, g.GetError(responseCode, response)
+    }
+    /* deserialize response, return */
+    return
+}
+```
+
+**Constraints:**
+- The first parameter is `ctx context.Context`.
+- Use `g.DoRequestContext(ctx, ...)` — never `g.DoRequest` (which exists only as the `context.Background()` shim).
+- URL building: prefer the per-resource helper if one exists (`g.workspacesURL`, `g.stylesURL`, etc.) over raw `g.ParseURL("rest", ...)`. Both are correct; helpers reduce duplication.
+- Errors via `g.GetError(responseCode, response)` — that returns a `*Error` with the right sentinel mapped via `errors.Is`.
+
+## 3. Add the new method to the parallel `*ServiceWithContext` interface
+
+Find the resource's interface declaration in `$1` (e.g., `WorkspaceServiceWithContext` near the top). Add an entry mirroring `$0Context`. Also add the non-context form to the legacy `*Service` interface so the `Catalog` interface (in `catalog.go`) keeps embedding both cleanly.
+
+## 4. Unit test (`$1` → strip `.go` → append `_unit_test.go`)
+
+Pattern from `workspaces_unit_test.go`:
+
+```go
+func Test$0Context_Success(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // assert request shape: method, URL path, headers
+        if r.Method != http.MethodGet { t.Fatalf("method = %s", r.Method) }
+        // ...
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{ /* canned response */ }`))
+    }))
+    defer server.Close()
+
+    gs := New(server.URL+"/", "u", "p")
+    got, err := gs.$0Context(context.Background(), /* args */)
+    if err != nil { t.Fatalf("unexpected error: %v", err) }
+    // assert got is what we expect
+}
+
+func Test$0Context_NotFound(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+        w.WriteHeader(http.StatusNotFound)
+        _, _ = w.Write([]byte(`{"abstract":"x","details":"y"}`))
+    }))
+    defer server.Close()
+
+    gs := New(server.URL+"/", "u", "p")
+    _, err := gs.$0Context(context.Background(), /* args */)
+    if !errors.Is(err, ErrNotFound) {
+        t.Fatalf("got %v, want ErrNotFound", err)
+    }
+}
+```
+
+At minimum cover: 2xx happy path, 404, plus one of {401, 403, 409, 500} appropriate to the resource.
+
+## 5. Sanity checks
+
+After applying:
+
+- `go build ./...` clean.
+- `go vet ./...` clean.
+- `make test-unit` green.
+- The reference pair (`workspaces.go:16-38,57-79`) and your new pair both compile cleanly under `golangci-lint run`.

--- a/.claude/skills/geoserver-rest-quirks/SKILL.md
+++ b/.claude/skills/geoserver-rest-quirks/SKILL.md
@@ -1,0 +1,72 @@
+---
+description: GeoServer 2.27 / 2.28 REST API quirks that this client works around — workspace-scoped POST /styles Accept-header dispatch, mixed-shape JSON arrays, empty-collection string-vs-object payloads, version-specific endpoint differences. Reference content; loaded automatically when working on REST code or debugging GeoServer responses.
+when_to_use: User mentions "GeoServer returned 500", "unmarshal error", "unexpected JSON shape", "Accept header", "why does this style endpoint behave differently", "no attributes", or is implementing a new REST endpoint client.
+---
+
+# GeoServer 2.x REST API quirks
+
+This is reference material. Each quirk lists the symptom, the root cause as understood, and the file:line in this repo where the workaround lives. Whenever you change any code that talks to GeoServer, scan this list for relevance.
+
+## 1. Workspace-scoped `POST /workspaces/{ws}/styles` requires `Accept: */*`
+
+- **Symptom:** GeoServer 2.28 returns `500 "No such style handler: format = application/json"` if you send `Accept: application/json`.
+- **Root cause:** GeoServer dispatches on the Accept header looking for a "style format handler" that matches that media type. There is no JSON style handler, so it 500s.
+- **Workaround:** Send `Accept: "*/*"` to disable the dispatch and route to the metadata-creation path. The body's `Content-Type` should also be `application/json; charset=utf-8` — bare `application/json` 500s in some older 2.x versions.
+- **Where:** `styles.go:178-186` (`CreateStyleContext`).
+
+## 2. Empty styles collection comes back as `{"styles":""}` (bare string)
+
+- **Symptom:** `GetStyles` against a fresh / empty workspace fails to unmarshal because GeoServer returns a JSON object whose `styles` field is the empty string instead of an object.
+- **Workaround:** Decode into `json.RawMessage` first; branch on the first byte (`'"'` ⇒ empty list; `'{'` ⇒ decode as `{"style": [...]}`).
+- **Where:** `styles.go:93-104` (`GetStylesContext`).
+
+## 3. `LayerGroup.styles.style` is a mixed `[string|object]` array
+
+- **Symptom:** `GET /layergroups/{name}` for any layer group with default-styled members produces `"styles": {"style": ["", "", {...}, ""]}` — string entries (often empty) interspersed with style objects. Standard JSON decoder errors with `cannot unmarshal string into Go struct field LayerGroupStyles.style`.
+- **Workaround:** Custom `UnmarshalJSON` on `LayerGroupStyles` that decodes the inner `style` array via `[]json.RawMessage`, then per-element handles `'"'` (string) vs `'{'` (object) and produces `[]*Resource`. String entries are stored as `&Resource{Name: stringValue}` to preserve the `[]*Resource` field type.
+- **Where:** `layergroups.go` `LayerGroupStyles.UnmarshalJSON`.
+
+## 4. POST style endpoints need explicit `; charset=utf-8`
+
+- **Symptom:** Bare `Content-Type: application/json` 500s in some 2.x versions.
+- **Workaround:** Send `Content-Type: application/json; charset=utf-8`.
+- **Where:** Same site as quirk #1 — `styles.go:189` (`DataType: jsonType + "; charset=utf-8"`).
+
+## 5. PostGIS publish requires the table to exist with attributes
+
+- **Symptom:** `POST /workspaces/{ws}/datastores/{ds}/featuretypes` returns `400 "no attributes"` if the named table is empty or doesn't exist.
+- **Workaround:** Tests bootstrap a real PostGIS table via `docker/postgis/init/01-lbldyt.sql` (creates `public.lbldyt(gid, name, label, geom)` with sample rows + GIST index). Production callers must ensure their target table exists.
+- **Where:** `docker/postgis/init/01-lbldyt.sql`; tested in `layers_test.go` (integration).
+
+## 6. `Settings.contact` is `interface{}` in v1
+
+- **Symptom:** Type assertions on `Settings.Contact` panic in v1.0; in v1.1 they return zero values silently.
+- **Root cause:** v1.0 modeled the contact subdocument loosely. `Contact` *type* is defined in `settings.go:15` but never wired up; the field is `interface{}` (`settings.go:27`).
+- **Workaround:** Don't trust the field type for new code. v2 will make this concrete.
+- **Where:** `settings.go:27`.
+
+## 7. Pagination drift across versions
+
+- **Symptom:** `GET /rest/layers` and `GET /rest/styles` paginate via `?startIndex=&count=` on GeoServer 2.18+ but return everything on older versions.
+- **Workaround:** Send pagination params and tolerate them being ignored on older servers. v2 wraps this in `iter.Seq2[T, error]` with single-page fallback.
+- **Where:** Not currently mitigated in v1; documented for awareness.
+
+## 8. `ParseURL` must escape per segment, not the whole path
+
+- **Symptom:** Workspace / layer names with spaces, slashes, or non-ASCII characters produced malformed URLs in v1.0.
+- **Workaround:** `g.ParseURL(parts...)` applies `url.PathEscape` to each segment before `path.Join`. Use multi-arg `ParseURL("rest", "workspaces", ws, "styles")` instead of `fmt.Sprintf("%srest/%s/styles", server, ws)`.
+- **Where:** `utils.go` `ParseURL`.
+
+## 9. Empty `wfs:FeatureType` lists in capabilities
+
+- **Symptom:** Older GeoServer versions emit `<FeatureTypeList></FeatureTypeList>` (empty) while newer ones omit the element entirely.
+- **Workaround:** XML parser treats both as empty list; no caller-visible difference. WMS capabilities parser uses `wms.ParseCapabilitiesE` which returns `(*Capabilities, error)` — prefer it over the deprecated `ParseCapabilities` that swallowed errors.
+- **Where:** `wms/wms.go` `ParseCapabilitiesE`.
+
+---
+
+## When this skill is most useful
+
+- Implementing a new REST resource client — scan the list before writing the request to avoid re-discovering quirk 1, 4, or 8.
+- Debugging an integration-test failure with `unmarshal` or `5xx` in the message.
+- Reading a PR that touches `styles.go`, `layergroups.go`, or `utils.go` `ParseURL` — verify the quirk-handling code wasn't naively "simplified" away.

--- a/.claude/skills/non-breaking-v1/SKILL.md
+++ b/.claude/skills/non-breaking-v1/SKILL.md
@@ -1,0 +1,86 @@
+---
+description: Verifies that a change preserves the v1.1.x non-breaking contract. Run before opening a PR to master or before tagging a v1.1.x release. Walks through the exported-API surface, *Context twin pattern, deprecation discipline, and concurrency constraints.
+disable-model-invocation: true
+allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(go doc:*) Bash(grep:*) Read Grep Glob
+---
+
+# Non-breaking v1.1.x checklist
+
+Run this before opening a PR to `master` or before tagging a v1.1.x release. The contract: **a caller pinned to v1.0 must be able to upgrade to v1.1.x by changing only their `go.mod` version and running `go mod tidy`. No source edits.**
+
+This skill is manually-invoked (`/non-breaking-v1`) — Claude won't auto-trigger it because the workflow has timing implications (run it at PR / release time, not mid-edit).
+
+## Steps
+
+### 1. Compute exported-API diff against `master`
+
+```
+git diff master...HEAD -- '*.go' ':!*_test.go' | grep -E '^[-+](func|type|var|const)' || echo "no exported diffs"
+```
+
+If `gorelease` is available, prefer the authoritative tool:
+
+```
+gorelease -base=v1.0.0
+```
+
+### 2. Inspect every `-` line in the diff
+
+For each removed or signature-changed exported symbol:
+
+- **REMOVED?** That's BREAKING. Either restore the symbol (with a `// Deprecated:` annotation that delegates to its replacement) or escalate to v2.
+- **SIGNATURE CHANGE?** That's BREAKING. Add a sibling with the new signature; keep the old one delegating.
+- **STRUCT FIELD REMOVED OR RETYPED?** That's BREAKING. Restore.
+
+### 3. Inspect every `+` exported symbol
+
+For each new exported symbol:
+
+- Is it a method on `*GeoServer`? Then it must come in a *Context twin pair — both `Foo(...)` and `FooContext(ctx, ...)`. Verify both exist:
+  `grep -n 'func (g \*GeoServer) Foo[^a-zA-Z]' *.go` and the same for `FooContext`.
+- Is it a method? Add it to the relevant `*Service` and `*ServiceWithContext` interface.
+- Is it a struct field added to an existing exported struct? OK in principle, but if any caller uses **positional struct literals** (`Foo{a, b, c}` without field names), they break. Audit `_test.go` and known consumers; flag for the CHANGELOG.
+
+### 4. Verify `// Deprecated:` discipline
+
+```
+grep -nB2 'Deprecated:' *.go
+```
+
+For every `// Deprecated:` marker, confirm:
+- The replacement function / method exists.
+- The deprecated form delegates to the replacement (doesn't reimplement).
+- The CHANGELOG entry exists and explains the migration.
+
+### 5. Concurrency check
+
+`*GeoServer` exported fields must not be mutated post-construction in library code. Search for assignments to exported fields in non-test files:
+
+```
+grep -nE '^[^/]*g\.[A-Z][a-zA-Z]+\s*=' *.go | grep -v _test.go
+```
+
+If you see something like `g.HttpClient = ...` outside the constructor or option-application path, that's a smell (v1's compromise is: accept reads, document non-mutability — but don't mutate from inside the library).
+
+### 6. CHANGELOG
+
+Confirm `CHANGELOG.md` has a `## [1.1.x] — YYYY-MM-DD` section listing all additions, deprecations, and any non-breaking-but-noteworthy behavior changes (e.g., `ParseURL` now path-escapes per segment — documented as a silent behavior change for malformed inputs).
+
+## Output
+
+Report in this shape:
+
+```
+NON-BREAKING CHECK — <branch> vs master
+
+BREAKING (n):
+  <empty list ⇒ ✅ OK; non-empty ⇒ ❌ block release>
+
+REVIEW (m):
+  - <symbol> — <why this needs a human eyeball>
+
+GOOD (k):
+  - <new exports + correctly-paired *Context twins + correctly-marked deprecations>
+
+VERDICT: [GO | NO-GO]
+```

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,15 @@
 name: Integration tests
 
 # Integration tests boot a real GeoServer + PostGIS via docker compose and
-# exercise the package against it. The build is heavy (downloads GeoServer
-# WAR from SourceForge and waits for Tomcat to start), so we don't run it
-# on every push — only on demand and on a weekly schedule.
+# exercise the package against it. They are MANDATORY on every PR targeting
+# master: the matrix runs both GeoServer 2.27.4 LTS and 2.28.0 stable, and
+# both legs must pass for the PR to merge. The same workflow also runs on
+# demand, on a weekly schedule, and on release tags.
 
 on:
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       geoserver:
@@ -28,7 +32,9 @@ permissions:
 
 concurrency:
   group: integration-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Cancel stale runs on the same PR (push churn). Don't cancel scheduled
+  # or release-tag runs — those should always complete.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ _testmain.go
 uploaded
 vendor
 examples
+
+# Claude Code per-machine state
+.claude/settings.local.json
+.claude/.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# Project memory for `github.com/hishamkaram/geoserver`
+
+This file is auto-loaded by Claude Code at the start of every session in this repository. Keep it concise (~150 lines, hard cap 200) and focused on **what cannot be derived from the code itself**.
+
+## Project identity
+
+- **Module**: `github.com/hishamkaram/geoserver`
+- **Purpose**: Go client library for the GeoServer REST API (workspaces, datastores, feature types, layers, layer groups, styles, coverages, namespaces, settings).
+- **Maintainer / display name**: **Hesham Karm** (note: no trailing 'a'; first name is "Hesham" not "Hisham"). Use this exact spelling in LICENSE, README authorship, AUTHORS files, commit signatures, and any user-facing credits. The legacy GitHub handle `hishamkaram` and the email `hishamwaleedkaram@gmail.com` are historical identity handles — do not "correct" them.
+
+## Versioning regime
+
+- **v1.1.x is non-breaking.** No removed exports. No signature changes to existing public APIs. Deprecate via `// Deprecated:` and add a sibling that delegates to the replacement. **Why:** v1.0 callers must be able to upgrade with only a `go.mod` bump.
+- **v2 lives at module path `github.com/hishamkaram/geoserver/v2`** under a `/v2/` subdirectory once it begins. v2 will fix the v1 wounds that cannot be healed without breaking changes (exported mutable fields, four-positional-arg `PublishPostgisLayer`, etc.).
+- **Don't auto-tag releases.** Tagging is an explicit user action — never run `git tag` or push tags from a Claude session without explicit user authorization.
+
+## Test split
+
+- `*_unit_test.go` (no build tag) — **fast, hermetic, httptest-based.** Run by default.
+- `*_test.go` with `//go:build integration` — **integration tests against a real GeoServer + PostGIS stack.** Never invoke without `--tags=integration` AND a live compose stack.
+- The `make test-unit` and `make test-integration` targets are the canonical entry points; CI mirrors them exactly.
+- **Both unit and integration tests are mandatory on every PR.** Integration runs against GeoServer 2.27.4 LTS and 2.28.0 stable; both legs must pass for the PR to merge.
+
+## *Context twin pattern (mandatory for new exports)
+
+Every exported method on `*GeoServer` has a `…Context(ctx context.Context, …)` sibling. The non-context form delegates with `context.Background()`. New methods MUST follow this. Canonical shape: `workspaces.go:16-38,57-79`.
+
+```go
+func (g *GeoServer) GetFoo(args...) (...)        { return g.GetFooContext(context.Background(), args...) }
+func (g *GeoServer) GetFooContext(ctx context.Context, args...) (...) { /* real impl uses ctx */ }
+```
+
+Each service interface has a parallel `…WithContext` interface (e.g., `WorkspaceServiceWithContext`). The legacy interface stays alongside.
+
+## Typed errors
+
+- All HTTP errors return `*Error` (defined in `errors.go`).
+- Status codes map to sentinels via `errors.Is` (`ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, `ErrConflict`, `ErrBadRequest`, `ErrMethodNotAllowed`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`).
+- **Never compare error strings.** `errors.Is(err, ErrNotFound)` is the only correct test.
+- The `*Error.Error()` string preserves v1.0's `"abstract:%s\ndetails:%s\n"` format so existing string-matchers don't break.
+
+## Logging
+
+- `g.logger` is a `*Logger` wrapper (defined in `logging.go`) over `*slog.Logger`.
+- Exposes printf-style: `Errorf`, `Warnf`, `Infof`, `Debugf`. Plus Sprint-style: `Error`, `Warn`, `Info`, `Debug`. This shape exists for v1.0-source compatibility.
+- Configure via the `WithLogger(slog.Handler)` option. **Never mutate fields** to swap the logger.
+- Library logs Debug for HTTP details, Warn for retry-exhausted, Error for protocol violations. No Info chatter.
+
+## Concurrency
+
+- `*GeoServer` exported fields are **not safe for concurrent mutation.** Construct once with `New(...)` and treat as immutable.
+- Concurrent reads on the same instance are safe.
+- Don't add concurrency hardening (locks, atomic swaps) to v1 — that is a v2 redesign concern.
+
+## GeoServer version matrix
+
+- **Supported: 2.27 LTS + 2.28 stable.** Integration tests run against both via the CI matrix (`integration.yml`).
+- Don't add code paths gated on other GeoServer versions without adding a corresponding CI matrix entry.
+- GeoServer 3.0 (April 2026 GA, Jakarta EE / Tomcat 11 / ImageN) is parked for a v2.x point release after the migration settles.
+
+## Common GeoServer REST quirks (cross-reference)
+
+- Workspace-scoped `POST /workspaces/{ws}/styles` requires `Accept: */*`, not `application/json` — see `styles.go:178-186`.
+- Empty styles collection comes back as `{"styles":""}` (bare string, not object) — see `styles.go:93-104`.
+- `LayerGroup.styles.style` is a mixed `[string|object]` array — custom `UnmarshalJSON` in `layergroups.go`.
+- Full quirk reference: `/skill geoserver-rest-quirks` or read `.claude/skills/geoserver-rest-quirks/SKILL.md`.
+
+## Build & lint surfaces
+
+- `make` is the canonical entry point. CI workflow names match Make targets exactly. Don't bypass `make` with raw `go test`/`golangci-lint` invocations in scripts.
+- `.golangci.yml` enables: errcheck, govet, staticcheck, ineffassign, unused, bodyclose, errorlint, noctx, copyloopvar, revive, gocritic, misspell, unconvert, prealloc, gosec.
+- Don't add `//nolint:` comments outside the existing exemptions in `.golangci.yml` (which cover v1.x compat-frozen field names like `HttpClient`/`Id`/`XmlPostRequestLogBufferSize` and historic error string capitalization in `vars.go`).
+
+## HTTP & URL hygiene
+
+- Every request goes through `g.DoRequestContext` (in `utils.go`). Don't call `http.Client.Do` directly outside `utils.go`.
+- URL building uses `g.ParseURL(parts...)` which path-escapes each segment. Never `fmt.Sprintf("%srest/%s...", ...)` — that pattern was the source of multiple v1.0 bugs.
+
+## Conventions and don'ts
+
+- **Never commit directly to `master`.** Always create a feature branch, push it, open a PR, wait for CI to go green, then squash-merge.
+- **Never add Claude (or any AI assistant) as a git co-author.** Do not append `Co-Authored-By: Claude ...` trailers. Commit messages are authored by the user only.
+- **Never commit planning markdowns** — design docs, revival plans, research notes belong in `~/.claude/plans/`, not in this repo.
+- **No panics in library code.** The v1.0 audit removed five (`utils.go:49,60,119,134`; `wms/wms.go:213`); don't reintroduce. Tests may use `t.Fatalf` freely.
+- **No new runtime dependencies** without prior discussion — keep `go.mod` minimal (currently only stdlib + `testify` test-only + `yaml.v3` for `LoadConfig`).
+- **Don't auto-tag releases** and don't merge a PR with red or pending CI — both are explicit user actions.
+
+## Index of project Claude config
+
+Subagents (delegated workers, own context window):
+
+- `go-reviewer` — surfaces idiom violations and v1.1.x non-breaking constraint breaches
+- `integration-runner` — boots compose, runs integration suite, dumps logs on failure
+- `breaking-change-checker` — verifies non-breaking-v1 contract before tagging
+
+Skills (loadable knowledge / procedures):
+
+- `/geoserver-rest-quirks` — GeoServer 2.x REST API quirks reference (auto-loads when relevant)
+- `/non-breaking-v1` — pre-PR checklist for v1.1.x non-breaking contract (manual)
+- `/add-context-twin <method-name> <file>` — adds a *Context sibling method following the canonical pattern
+
+Slash commands (callable recipes):
+
+- `/integration-test [version]` — boot compose stack and run integration suite
+- `/lint-fix` — golangci-lint with autofix + gofmt + goimports
+- `/release-prep` — local-runnable subset of CI gates for a v1.1.x tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,15 @@ make compose-down
 
 ## Pull requests
 
-1. **Branch from `master`.** Use a short descriptive name (`fix/url-escape`, `feat/context-methods`).
+1. **Branch from `master`.** Use a short descriptive name (`fix/url-escape`, `feat/context-methods`). Never commit directly to `master`.
 2. **One concern per PR.** Smaller PRs review faster.
 3. **Conventional Commits.** Commit messages follow [Conventional Commits 1.0](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, `build:`, `ci:`). The CHANGELOG is generated from these.
-4. **Tests.** New code needs unit tests (`*_unit_test.go`, `httptest`-based). Behavioral changes also need an integration test entry.
+4. **Tests are mandatory.** New code needs unit tests (`*_unit_test.go`, `httptest`-based). Behavioral changes also need an integration test entry. **Integration tests run on every PR** against both GeoServer 2.27.4 LTS and 2.28.0 stable — both legs must pass.
 5. **Lint clean.** `make lint` must pass with zero warnings.
 6. **Backward compatibility.** v1.x is non-breaking. If your change requires breaking a public symbol, open a discussion first — it likely belongs in v2.
 7. **No new runtime dependencies** without prior discussion. Test-only deps are fine.
+8. **All CI checks must pass before merge.** The required gates on every PR: `Lint`, `Unit tests (Go 1.23)`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0`. Don't merge with any check red, pending, or skipped.
+9. **Squash merge.** PRs are squash-merged into `master` so each merge produces exactly one commit on the trunk and the CHANGELOG stays clean. Don't use rebase- or merge-commit strategies.
 
 ## Project layout
 
@@ -76,3 +78,23 @@ make compose-down
 ## Releasing
 
 Releases are cut by maintainers via tags (`v1.x.y`). The `release.yml` workflow assembles release notes from Conventional Commit messages.
+
+## Working with Claude Code in this repo
+
+The repo ships project-scoped Claude Code config so any contributor using Claude Code (CLI, IDE extensions, web app) gets the same conventions and shortcuts. Auto-loaded from `CLAUDE.md` (root) and `.claude/`.
+
+Available helpers:
+
+| Type | Name | Purpose |
+|---|---|---|
+| Slash command | `/integration-test [version]` | Boot the docker-compose stack and run the integration suite (default 2.28; `2.27` for the LTS leg). |
+| Slash command | `/lint-fix` | Run `golangci-lint --fix` + `gofmt` + `goimports`, report the diff and any remaining manual fixes. |
+| Slash command | `/release-prep` | Local-runnable subset of CI gates for a v1.1.x tag. |
+| Skill | `/add-context-twin <method> <file>` | Apply the *Context twin pattern to a new method on `*GeoServer`. |
+| Skill | `/non-breaking-v1` | Pre-PR checklist for the v1.1.x non-breaking contract. |
+| Skill | `/geoserver-rest-quirks` | Reference for GeoServer 2.x REST quirks the client works around (auto-loads when relevant). |
+| Subagent | `go-reviewer` | Idiom + non-breaking review of changed Go files. |
+| Subagent | `integration-runner` | Boots the stack, runs integration tests, diagnoses failures from container logs. |
+| Subagent | `breaking-change-checker` | Computes the exported-API diff against `master` / `v1.0.0` and classifies each change. |
+
+Personal per-machine settings live in `.claude/settings.local.json` (gitignored). The team baseline (permissions, attribution, hooks) is intentionally **not** committed yet — see `~/.claude/plans/tranquil-hatching-rabin.md` for the design if we decide to add it later.


### PR DESCRIPTION
## Summary

Adds project-scoped Claude Code config (CLAUDE.md, agents, skills, commands) so any contributor running Claude Code in this repo gets the same conventions and shortcuts auto-loaded. Also makes the integration suite mandatory on every PR.

## What changes

### Claude Code project config (new)

- `CLAUDE.md` (root) — project memory: v1.1.x non-breaking regime, *Context twin pattern, typed-error sentinels, *Logger wrapper, GeoServer 2.27/2.28 REST quirks, conventions (no co-author, no planning markdowns, no direct master)
- `.claude/agents/` — `go-reviewer`, `integration-runner`, `breaking-change-checker`
- `.claude/skills/` — `geoserver-rest-quirks` (auto-loads when relevant), `non-breaking-v1` (manual checklist), `add-context-twin` (recipe with arguments)
- `.claude/commands/` — `/integration-test [version]`, `/lint-fix`, `/release-prep`
- \`CONTRIBUTING.md\` — \"Working with Claude Code in this repo\" section pointing at all of the above
- \`.gitignore\` — \`.claude/settings.local.json\` and \`.claude/.cache/\` (per-machine state)

A team-baseline \`.claude/settings.json\` is **not** included this round; it was deferred and can be added later.

### Integration tests now mandatory on PRs

- \`.github/workflows/integration.yml\` — adds \`pull_request: branches: [master]\` trigger; \`cancel-in-progress\` is now \`true\` only for PR events so push churn cancels stale runs while scheduled and tag runs still complete.
- \`CONTRIBUTING.md\` Pull requests checklist — adds **#8** (all CI checks must pass before merge: Lint, Unit tests Go 1.23 + 1.25, govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0) and **#9** (squash-merge only).

This is the first PR where the integration matrix runs as part of the merge gate, so it doubles as a smoke test of the new wiring.

## Test plan

- [ ] \`Lint\` green
- [ ] \`Unit tests (Go 1.23)\` green
- [ ] \`Unit tests (Go 1.25)\` green
- [ ] \`govulncheck\` green
- [ ] \`Analyze (Go)\` (CodeQL) green
- [ ] \`GeoServer 2.27.4\` (integration) green
- [ ] \`GeoServer 2.28.0\` (integration) green
- [ ] After merge: project memory + new helpers visible to Claude Code sessions opened in this repo

## Follow-ups (not in this PR)

- Branch protection on \`master\` to require the seven checks listed above. Run via the GitHub web UI (Settings → Branches) or \`gh api repos/:owner/:repo/branches/master/protection -X PUT\`.
- Optional team-baseline \`.claude/settings.json\` (permissions allowlist for go/docker/gh, gofmt PostToolUse hook). Designed in the planning doc; not committed.