### PR TITLE
feat: port PR #15 features (security, ACL, JNDI datastore, CreateFeatureType)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — security, ACL, JNDI datastore, CreateFeatureType (port of PR #15)
+
+These features were originally proposed in PR #15 (Nov 2021) but landed only on a fork branch. They have been refactored to fit the v1.1 idiom (every method comes with a `*Context` sibling, typed-error sentinels via `errors.Is`, the `*Logger` wrapper, parallel `*Service` and `*ServiceWithContext` interfaces) and are now available on `master`.
+
+- **Security (users / groups / roles)** — new `security.go` and `SecurityService` / `SecurityServiceWithContext` interfaces:
+  - `GetUsers`, `CreateUser`, `DeleteUser` (under a named user-group service; empty service resolves to `"default"`)
+  - `GetGroups`, `CreateGroup`, `DeleteGroup`
+  - `GetRoles`, `GetUserRoles`, `CreateRole`, `DeleteRole`
+  - `AddUserRole`, `DeleteUserRole` (associate / disassociate role from user)
+  - All have `…Context` siblings.
+- **Layer ACL rules** — new `acl.go` and `ACLService` / `ACLServiceWithContext` interfaces:
+  - `ACLRule` type with `ACLOpRead` / `ACLOpWrite` / `ACLOpAdmin` operation constants
+  - `GetLayersACLRules`, `AddLayersACLRule`, `DeleteLayersACLRule` (+ `*Context` siblings)
+  - `ACLRule.ToStrings` and `StringToACLRule` round-trip helpers
+- **JNDI-backed datastores** — new `DatastoreJNDIConnection` struct + `CreateJNDIDatastore` / `CreateJNDIDatastoreContext`. Use when GeoServer is configured to look up its JDBC connection pool via JNDI (typically Tomcat-managed).
+- **`DatastoreConnector` interface** — `*DatastoreConnection` and `DatastoreJNDIConnection` both satisfy it. New methods `CreateDatastoreFromConnector` / `CreateDatastoreFromConnectorContext` accept any connector. Useful for callers that want a single code path or for plugging in custom connector types.
+- **`DatastoreConnection.Options []Entry`** — additional connection parameters (e.g., `"max connections"`, `"Expose primary keys"`). Field is appended at the end of the struct so v1.0 callers using positional struct literals continue to compile.
+- **`CreateFeatureType` / `CreateFeatureTypeContext`** — register a feature type against a database-backed datastore (PostGIS, Oracle, etc.) without going through `UploadShapeFile`.
+- `Catalog` interface now embeds `SecurityService` and `ACLService`.
+- httptest unit tests for every new method (`acl_unit_test.go`, `security_unit_test.go`, `datastores_unit_test.go`, `feature_types_unit_test.go`).
+- Integration tests covering ACL, security, datastore Options, JNDI request shape, and CreateFeatureType end-to-end against the docker-compose PostGIS + GeoServer stack (`acl_test.go`, `security_test.go`, additions to `datastores_test.go` and `feature_types_test.go`).
+- `utils_unit_test.go` `TestParseURL_NoDoubleEncoding` — regression guard for the URL builder fix described below.
+
+### Fixed
+
+- `ParseURL` no longer double-encodes path segments containing characters that `url.PathEscape` percent-encodes (e.g., `"*"` → `"%2A"` → previously `"%252A"`). The encoded path is now preserved through `url.URL.String()` by setting `RawPath` alongside `Path`. GeoServer's StrictHttpFirewall rejected the previously-emitted double-encoded URLs as "potentially malicious"; the new ACL `DELETE` path (where rule strings carry literal `*` wildcards) was the trigger that surfaced the bug.
+
+### Notes
+
+- `GetRoles`, `GetUserRoles`, and `GetGroups` decode both the GeoServer 2.28+ response keys (`roles`, `groups`) and the older 2.x keys (`roleNames`, `groupNames`) so they work across the supported version matrix.
+
 ## [1.1.0] — 2026-05-03
 
 This release modernizes the build, fixes long-standing bugs, and adds an idiomatic Go API surface alongside the existing one. Existing v1.0.x callers do not need source changes to upgrade.

--- a/acl.go
+++ b/acl.go
@@ -1,0 +1,176 @@
+package geoserver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ACLOperation is a GeoServer ACL operation kind.
+type ACLOperation string
+
+// ACL operation constants. GeoServer uses single-letter codes in the rule
+// string ("workspace.layer.r"), where "r" is read, "w" is write, "a" is
+// admin.
+const (
+	ACLOpRead  ACLOperation = "r"
+	ACLOpWrite ACLOperation = "w"
+	ACLOpAdmin ACLOperation = "a"
+)
+
+// ACLRule represents a GeoServer layer ACL rule.
+//
+// Workspace and Layer take an entity name or "*" for any entity. Operation is
+// one of [ACLOpRead], [ACLOpWrite], [ACLOpAdmin]. Roles is the list of role
+// names allowed to perform the operation; an empty list means "any role"
+// ("*").
+type ACLRule struct {
+	Workspace string       // workspace name or "*" for any workspace
+	Layer     string       // layer name or "*" for any layer
+	Operation ACLOperation // r / w / a
+	Roles     []string     // allowed roles; empty == "*"
+}
+
+// ACLService defines GeoServer ACL operations on layers.
+type ACLService interface {
+	GetLayersACLRules() (rules []ACLRule, err error)
+	AddLayersACLRule(rule ACLRule) (added bool, err error)
+	DeleteLayersACLRule(rule ACLRule) (deleted bool, err error)
+}
+
+// ACLServiceWithContext is the context-aware sibling of [ACLService].
+type ACLServiceWithContext interface {
+	GetLayersACLRulesContext(ctx context.Context) (rules []ACLRule, err error)
+	AddLayersACLRuleContext(ctx context.Context, rule ACLRule) (added bool, err error)
+	DeleteLayersACLRuleContext(ctx context.Context, rule ACLRule) (deleted bool, err error)
+}
+
+// ToStrings converts an ACLRule into the wire-format pair (rule, roles)
+// GeoServer's REST API expects: ("workspace.layer.op", "role1,role2"). Empty
+// fields default to "*" (any).
+func (rule ACLRule) ToStrings() (ruleString string, rolesString string) {
+	ws := rule.Workspace
+	if ws == "" {
+		ws = "*"
+	}
+	layer := rule.Layer
+	if layer == "" {
+		layer = "*"
+	}
+	op := rule.Operation
+	if op == "" {
+		op = ACLOpRead
+	}
+	roles := rule.Roles
+	if len(roles) == 0 {
+		roles = []string{"*"}
+	}
+	return fmt.Sprintf("%s.%s.%s", ws, layer, op), strings.Join(roles, ",")
+}
+
+// StringToACLRule parses GeoServer's wire format back into an ACLRule. The
+// rule string must be of the form "workspace.layer.op"; roles is a
+// comma-separated list.
+func StringToACLRule(rule string, roles string) (aclRule ACLRule, err error) {
+	parts := strings.Split(rule, ".")
+	if len(parts) != 3 {
+		return ACLRule{}, errors.New("acl: rule string must be 'workspace.layer.op'")
+	}
+	aclRule.Workspace = parts[0]
+	aclRule.Layer = parts[1]
+	aclRule.Operation = ACLOperation(parts[2])
+	if roles != "" {
+		aclRule.Roles = strings.Split(roles, ",")
+	}
+	return aclRule, nil
+}
+
+// GetLayersACLRules lists all registered layer ACL rules using context.Background.
+func (g *GeoServer) GetLayersACLRules() (rules []ACLRule, err error) {
+	return g.GetLayersACLRulesContext(context.Background())
+}
+
+// GetLayersACLRulesContext is the context-aware variant of [GeoServer.GetLayersACLRules].
+func (g *GeoServer) GetLayersACLRulesContext(ctx context.Context) (rules []ACLRule, err error) {
+	targetURL := g.ParseURL("rest", "security", "acl", "layers")
+	httpRequest := HTTPRequest{
+		Method: getMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  nil,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var aclResponse map[string]string
+	if err = g.DeSerializeJSON(response, &aclResponse); err != nil {
+		return nil, fmt.Errorf("GetLayersACLRules: decode response: %w", err)
+	}
+	rules = make([]ACLRule, 0, len(aclResponse))
+	for ruleStr, rolesStr := range aclResponse {
+		parsed, parseErr := StringToACLRule(ruleStr, rolesStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("GetLayersACLRules: %w", parseErr)
+		}
+		rules = append(rules, parsed)
+	}
+	return rules, nil
+}
+
+// AddLayersACLRule adds a layer ACL rule using context.Background.
+func (g *GeoServer) AddLayersACLRule(rule ACLRule) (added bool, err error) {
+	return g.AddLayersACLRuleContext(context.Background(), rule)
+}
+
+// AddLayersACLRuleContext is the context-aware variant of [GeoServer.AddLayersACLRule].
+//
+// GeoServer returns 200 OK (not 201 Created) for ACL additions.
+func (g *GeoServer) AddLayersACLRuleContext(ctx context.Context, rule ACLRule) (added bool, err error) {
+	targetURL := g.ParseURL("rest", "security", "acl", "layers")
+	ruleStr, rolesStr := rule.ToStrings()
+	body := map[string]string{ruleStr: rolesStr}
+	data, serErr := g.SerializeStruct(body)
+	if serErr != nil {
+		return false, fmt.Errorf("AddLayersACLRule: serialize: %w", serErr)
+	}
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		Data:     bytes.NewBuffer(data),
+		DataType: jsonType,
+		URL:      targetURL,
+		Query:    nil,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// DeleteLayersACLRule removes a layer ACL rule using context.Background.
+func (g *GeoServer) DeleteLayersACLRule(rule ACLRule) (deleted bool, err error) {
+	return g.DeleteLayersACLRuleContext(context.Background(), rule)
+}
+
+// DeleteLayersACLRuleContext is the context-aware variant of [GeoServer.DeleteLayersACLRule].
+func (g *GeoServer) DeleteLayersACLRuleContext(ctx context.Context, rule ACLRule) (deleted bool, err error) {
+	ruleStr, _ := rule.ToStrings()
+	targetURL := g.ParseURL("rest", "security", "acl", "layers", ruleStr)
+	httpRequest := HTTPRequest{
+		Method: deleteMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  nil,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}

--- a/acl_test.go
+++ b/acl_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+// +build integration
+
+package geoserver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACL_GetLayersACLRules(t *testing.T) {
+	before()
+	rules, err := gsCatalog.GetLayersACLRules()
+	assert.NoError(t, err)
+	// GeoServer's default config has a few rules out of the box, so the list
+	// should be non-empty. We don't pin exact contents because the default
+	// rule set varies between 2.27 and 2.28.
+	if len(rules) == 0 {
+		t.Logf("no ACL rules present — possible if GeoServer is reconfigured; not fatal")
+	}
+}
+
+func TestACL_AddDeleteLayersACLRule(t *testing.T) {
+	before()
+
+	rule := ACLRule{
+		Workspace: "acl_test_ws",
+		Layer:     "*",
+		Operation: ACLOpRead,
+		Roles:     []string{"acl_test_role"},
+	}
+
+	// Pre-conditions: workspace + role must exist for GeoServer to accept
+	// the ACL rule.
+	if _, err := gsCatalog.CreateWorkspace(rule.Workspace); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create workspace: %v", err)
+	}
+	if _, err := gsCatalog.CreateRole(rule.Roles[0]); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create role: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteRole(rule.Roles[0])
+		_, _ = gsCatalog.DeleteWorkspace(rule.Workspace, true)
+	})
+
+	// Best-effort prior cleanup so a previous failed run doesn't trip us.
+	_, _ = gsCatalog.DeleteLayersACLRule(rule)
+
+	added, err := gsCatalog.AddLayersACLRule(rule)
+	assert.NoError(t, err)
+	assert.True(t, added)
+
+	// Adding the same rule again should fail with conflict.
+	added, err = gsCatalog.AddLayersACLRule(rule)
+	assert.False(t, added)
+	if err != nil && !errors.Is(err, ErrConflict) && !strings.Contains(err.Error(), "exist") {
+		t.Logf("second AddLayersACLRule returned %v (not strictly ErrConflict, but non-nil — acceptable across versions)", err)
+	}
+
+	deleted, err := gsCatalog.DeleteLayersACLRule(rule)
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}

--- a/acl_unit_test.go
+++ b/acl_unit_test.go
@@ -1,0 +1,156 @@
+package geoserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACLRule_ToStrings_Defaults(t *testing.T) {
+	r := ACLRule{}
+	rule, roles := r.ToStrings()
+	assert.Equal(t, "*.*.r", rule)
+	assert.Equal(t, "*", roles)
+}
+
+func TestACLRule_ToStrings_Populated(t *testing.T) {
+	r := ACLRule{Workspace: "topp", Layer: "states", Operation: ACLOpWrite, Roles: []string{"editor", "admin"}}
+	rule, roles := r.ToStrings()
+	assert.Equal(t, "topp.states.w", rule)
+	assert.Equal(t, "editor,admin", roles)
+}
+
+func TestStringToACLRule_OK(t *testing.T) {
+	r, err := StringToACLRule("topp.states.r", "viewer,editor")
+	assert.NoError(t, err)
+	assert.Equal(t, "topp", r.Workspace)
+	assert.Equal(t, "states", r.Layer)
+	assert.Equal(t, ACLOpRead, r.Operation)
+	assert.Equal(t, []string{"viewer", "editor"}, r.Roles)
+}
+
+func TestStringToACLRule_BadShape(t *testing.T) {
+	_, err := StringToACLRule("not-a-rule", "")
+	if err == nil {
+		t.Fatalf("expected error for malformed rule")
+	}
+}
+
+func TestACL_GetLayersACLRules_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/security/acl/layers", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"topp.states.r":"viewer","*.*.w":"admin"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	rules, err := gs.GetLayersACLRulesContext(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, rules, 2)
+
+	// Two-rule response: order is map-iteration so we look up by content.
+	var seenStates, seenAdmin bool
+	for _, rule := range rules {
+		if rule.Workspace == "topp" && rule.Layer == "states" {
+			seenStates = true
+			assert.Equal(t, ACLOpRead, rule.Operation)
+			assert.Equal(t, []string{"viewer"}, rule.Roles)
+		}
+		if rule.Workspace == "*" && rule.Layer == "*" {
+			seenAdmin = true
+			assert.Equal(t, ACLOpWrite, rule.Operation)
+		}
+	}
+	assert.True(t, seenStates)
+	assert.True(t, seenAdmin)
+}
+
+func TestACL_GetLayersACLRules_403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "denied")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	_, err := gs.GetLayersACLRulesContext(context.Background())
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestACL_AddLayersACLRule_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/security/acl/layers", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		// Expect JSON body of the form {"topp.states.r":"viewer"}.
+		assert.Contains(t, string(body), `"topp.states.r":"viewer"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	rule := ACLRule{Workspace: "topp", Layer: "states", Operation: ACLOpRead, Roles: []string{"viewer"}}
+	added, err := gs.AddLayersACLRuleContext(context.Background(), rule)
+	assert.NoError(t, err)
+	assert.True(t, added)
+}
+
+func TestACL_AddLayersACLRule_409(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, "rule exists")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	added, err := gs.AddLayersACLRuleContext(context.Background(), ACLRule{Workspace: "topp", Layer: "states", Operation: ACLOpRead, Roles: []string{"viewer"}})
+	assert.False(t, added)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestACL_DeleteLayersACLRule_URLPath(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RawPath
+		if capturedPath == "" {
+			capturedPath = r.URL.Path
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteLayersACLRuleContext(context.Background(), ACLRule{Workspace: "topp", Layer: "states", Operation: ACLOpRead})
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+	if !strings.HasSuffix(capturedPath, "/rest/security/acl/layers/topp.states.r") {
+		t.Fatalf("unexpected DELETE path %q", capturedPath)
+	}
+}
+
+func TestACL_DeleteLayersACLRule_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "rule not found")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteLayersACLRuleContext(context.Background(), ACLRule{Workspace: "topp", Layer: "states", Operation: ACLOpRead})
+	assert.False(t, deleted)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/catalog.go
+++ b/catalog.go
@@ -25,6 +25,8 @@ type Catalog interface {
 	CoverageService
 	FeatureTypeService
 	SettingsService
+	SecurityService
+	ACLService
 	UtilsInterface
 }
 

--- a/datastores.go
+++ b/datastores.go
@@ -22,6 +22,16 @@ type DatastoreService interface {
 	// CreateDatastore create a datastore under provided workspace
 	CreateDatastore(datastoreConnection DatastoreConnection, workspaceName string) (created bool, err error)
 
+	// CreateJNDIDatastore creates a datastore that uses a JNDI connection pool
+	// (e.g., a Tomcat-managed JDBC pool). See [GeoServer.CreateJNDIDatastoreContext].
+	CreateJNDIDatastore(connection DatastoreJNDIConnection, workspaceName string) (created bool, err error)
+
+	// CreateDatastoreFromConnector creates a datastore from any value
+	// implementing [DatastoreConnector]. Useful when callers want a single
+	// code path for both direct and JNDI connections, or for custom
+	// connector types.
+	CreateDatastoreFromConnector(connector DatastoreConnector, workspaceName string) (created bool, err error)
+
 	// DeleteDatastore deletes a datastore from geoserver else return error
 	DeleteDatastore(workspaceName string, datastoreName string, recurse bool) (deleted bool, err error)
 }
@@ -32,7 +42,22 @@ type DatastoreServiceWithContext interface {
 	GetDatastoresContext(ctx context.Context, workspaceName string) (datastores []*Resource, err error)
 	GetDatastoreDetailsContext(ctx context.Context, workspaceName string, datastoreName string) (datastore *Datastore, err error)
 	CreateDatastoreContext(ctx context.Context, datastoreConnection DatastoreConnection, workspaceName string) (created bool, err error)
+	CreateJNDIDatastoreContext(ctx context.Context, connection DatastoreJNDIConnection, workspaceName string) (created bool, err error)
+	CreateDatastoreFromConnectorContext(ctx context.Context, connector DatastoreConnector, workspaceName string) (created bool, err error)
 	DeleteDatastoreContext(ctx context.Context, workspaceName string, datastoreName string, recurse bool) (deleted bool, err error)
+}
+
+// DatastoreConnector produces the [Datastore] payload sent to GeoServer when
+// creating a datastore. Both [*DatastoreConnection] and [DatastoreJNDIConnection]
+// satisfy this interface.
+//
+// Note the receiver asymmetry: DatastoreConnection has a pointer-receiver
+// GetDatastoreObj method (preserved from v1.0), so its pointer type
+// (*DatastoreConnection) satisfies DatastoreConnector. DatastoreJNDIConnection
+// uses a value-receiver method, so both DatastoreJNDIConnection and
+// *DatastoreJNDIConnection satisfy. Pass &conn for the former, jndiConn (or &jndiConn) for the latter.
+type DatastoreConnector interface {
+	GetDatastoreObj() Datastore
 }
 
 // Datastore holds geoserver store information
@@ -52,7 +77,13 @@ type DatastoreDetails struct {
 	Datastore *Datastore `json:"dataStore"`
 }
 
-// DatastoreConnection holds parameters to create new datastore in geoserver
+// DatastoreConnection holds parameters to create new datastore in geoserver.
+//
+// The Options field (added in v1.1) carries arbitrary additional connection
+// parameters such as "max connections", "Expose primary keys", etc. — see the
+// GeoServer connection-parameters reference for valid keys per dbtype. New
+// fields are appended to preserve positional struct-literal compatibility for
+// v1.0 callers that named only the original fields.
 type DatastoreConnection struct {
 	Name     string
 	Host     string
@@ -62,6 +93,7 @@ type DatastoreConnection struct {
 	DBUser   string
 	DBPass   string
 	Type     string
+	Options  []Entry // additional connection parameters (v1.1+)
 }
 
 // DatastoreConnectionParams in datastore json
@@ -69,42 +101,55 @@ type DatastoreConnectionParams struct {
 	Entry []*Entry `json:"entry,omitempty"`
 }
 
-// GetDatastoreObj return datastore Object to send to geoserver rest
+// DatastoreJNDIConnection holds parameters to create a datastore that uses a
+// JNDI connection pool managed by the servlet container (typically Tomcat).
+// See https://docs.geoserver.org/stable/en/user/tutorials/tomcat-jndi/tomcat-jndi.html
+type DatastoreJNDIConnection struct {
+	Name              string  // datastore name
+	Type              string  // dbtype (e.g., "postgis")
+	JndiReferenceName string  // e.g., "java:comp/env/jdbc/postgres"
+	Options           []Entry // additional connection parameters
+}
+
+// GetDatastoreObj return datastore Object to send to geoserver rest.
+//
+// Options entries (v1.1+) are appended after the standard parameters; an
+// empty Options slice is a no-op so the byte-for-byte output is identical
+// to v1.0 for connections that don't use Options.
 func (connection *DatastoreConnection) GetDatastoreObj() (datastore Datastore) {
+	entries := make([]*Entry, 0, 7+len(connection.Options))
+	entries = append(entries,
+		&Entry{Key: "host", Value: connection.Host},
+		&Entry{Key: "port", Value: strconv.Itoa(connection.Port)},
+		&Entry{Key: "database", Value: connection.DBName},
+		&Entry{Key: "schema", Value: connection.DBSchema},
+		&Entry{Key: "user", Value: connection.DBUser},
+		&Entry{Key: "passwd", Value: connection.DBPass},
+		&Entry{Key: "dbtype", Value: connection.Type},
+	)
+	for i := range connection.Options {
+		entries = append(entries, &connection.Options[i])
+	}
 	datastore = Datastore{
-		Name: connection.Name,
-		ConnectionParameters: DatastoreConnectionParams{
-			Entry: []*Entry{
-				{
-					Key:   "host",
-					Value: connection.Host,
-				},
-				{
-					Key:   "port",
-					Value: strconv.Itoa(connection.Port),
-				},
-				{
-					Key:   "database",
-					Value: connection.DBName,
-				},
-				{
-					Key:   "schema",
-					Value: connection.DBSchema,
-				},
-				{
-					Key:   "user",
-					Value: connection.DBUser,
-				},
-				{
-					Key:   "passwd",
-					Value: connection.DBPass,
-				},
-				{
-					Key:   "dbtype",
-					Value: connection.Type,
-				},
-			},
-		},
+		Name:                 connection.Name,
+		ConnectionParameters: DatastoreConnectionParams{Entry: entries},
+	}
+	return
+}
+
+// GetDatastoreObj return datastore object for a JNDI-pool-backed datastore.
+func (connection DatastoreJNDIConnection) GetDatastoreObj() (datastore Datastore) {
+	entries := make([]*Entry, 0, 2+len(connection.Options))
+	entries = append(entries,
+		&Entry{Key: "jndiReferenceName", Value: connection.JndiReferenceName},
+		&Entry{Key: "dbtype", Value: connection.Type},
+	)
+	for i := range connection.Options {
+		entries = append(entries, &connection.Options[i])
+	}
+	datastore = Datastore{
+		Name:                 connection.Name,
+		ConnectionParameters: DatastoreConnectionParams{Entry: entries},
 	}
 	return
 }
@@ -204,17 +249,43 @@ func (g *GeoServer) CreateDatastore(datastoreConnection DatastoreConnection, wor
 
 // CreateDatastoreContext is the context-aware variant of [GeoServer.CreateDatastore].
 func (g *GeoServer) CreateDatastoreContext(ctx context.Context, datastoreConnection DatastoreConnection, workspaceName string) (created bool, err error) {
-	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "datastores")
 	if datastoreConnection.DBSchema == "" {
 		datastoreConnection.DBSchema = "public"
 	}
-	store := datastoreConnection.GetDatastoreObj()
-	datastore := DatastoreDetails{
-		Datastore: &store,
-	}
-	data, serErr := g.SerializeStruct(datastore)
+	return g.postDatastore(ctx, &datastoreConnection, workspaceName, "CreateDatastore")
+}
+
+// CreateJNDIDatastore creates a JNDI-pool-backed datastore using context.Background.
+func (g *GeoServer) CreateJNDIDatastore(connection DatastoreJNDIConnection, workspaceName string) (created bool, err error) {
+	return g.CreateJNDIDatastoreContext(context.Background(), connection, workspaceName)
+}
+
+// CreateJNDIDatastoreContext is the context-aware variant of [GeoServer.CreateJNDIDatastore].
+func (g *GeoServer) CreateJNDIDatastoreContext(ctx context.Context, connection DatastoreJNDIConnection, workspaceName string) (created bool, err error) {
+	return g.postDatastore(ctx, connection, workspaceName, "CreateJNDIDatastore")
+}
+
+// CreateDatastoreFromConnector creates a datastore from any [DatastoreConnector]
+// using context.Background.
+func (g *GeoServer) CreateDatastoreFromConnector(connector DatastoreConnector, workspaceName string) (created bool, err error) {
+	return g.CreateDatastoreFromConnectorContext(context.Background(), connector, workspaceName)
+}
+
+// CreateDatastoreFromConnectorContext is the context-aware variant of
+// [GeoServer.CreateDatastoreFromConnector]. The connector is responsible for
+// producing a fully-formed [Datastore] payload — no defaults are applied.
+func (g *GeoServer) CreateDatastoreFromConnectorContext(ctx context.Context, connector DatastoreConnector, workspaceName string) (created bool, err error) {
+	return g.postDatastore(ctx, connector, workspaceName, "CreateDatastoreFromConnector")
+}
+
+// postDatastore is the shared HTTP path for the Create*Datastore* methods.
+// op identifies the public entry point for error wrapping.
+func (g *GeoServer) postDatastore(ctx context.Context, connector DatastoreConnector, workspaceName, op string) (created bool, err error) {
+	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "datastores")
+	store := connector.GetDatastoreObj()
+	data, serErr := g.SerializeStruct(DatastoreDetails{Datastore: &store})
 	if serErr != nil {
-		return false, fmt.Errorf("CreateDatastore: serialize datastore: %w", serErr)
+		return false, fmt.Errorf("%s: serialize datastore: %w", op, serErr)
 	}
 	httpRequest := HTTPRequest{
 		Method:   postMethod,
@@ -227,13 +298,9 @@ func (g *GeoServer) CreateDatastoreContext(ctx context.Context, datastoreConnect
 	response, responseCode := g.DoRequestContext(ctx, httpRequest)
 	if responseCode != statusCreated {
 		g.logger.Warn(string(response))
-		created = false
-		err = g.GetError(responseCode, response)
-		return
+		return false, g.GetError(responseCode, response)
 	}
-	created = true
-	return
-
+	return true, nil
 }
 
 // DeleteDatastore deletes a datastore using context.Background.

--- a/datastores_test.go
+++ b/datastores_test.go
@@ -5,6 +5,7 @@ package geoserver
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,4 +107,82 @@ func TestGeoserverImplementDatastoreService(t *testing.T) {
 	CatalogType := reflect.TypeOf((*DatastoreService)(nil)).Elem()
 	check := gsCatalog.Implements(CatalogType)
 	assert.True(t, check)
+}
+
+// TestCreateDatastoreWithOptions verifies the v1.1 Options field is accepted
+// by GeoServer. The compose stack runs PostGIS at the docker-network host
+// `postgis:5432` (DB `gis`, user/pass `golang`), seeded with the lbldyt
+// table (see docker/postgis/init/01-lbldyt.sql).
+func TestCreateDatastoreWithOptions(t *testing.T) {
+	before()
+	const ws = "ds_options_ws"
+	const ds = "ds_options_ds"
+
+	if _, err := gsCatalog.CreateWorkspace(ws); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteWorkspace(ws, true)
+	})
+
+	conn := DatastoreConnection{
+		Name:   ds,
+		Host:   "postgis", // docker-network hostname seen from the GeoServer container
+		Port:   5432,
+		Type:   "postgis",
+		DBName: "gis",
+		DBUser: "golang",
+		DBPass: "golang",
+		Options: []Entry{
+			{Key: "Expose primary keys", Value: "true"},
+			{Key: "max connections", Value: "5"},
+		},
+	}
+
+	created, err := gsCatalog.CreateDatastore(conn, ws)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := gsCatalog.GetDatastoreDetails(ws, ds)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	// Verify Options entries were persisted.
+	keys := map[string]string{}
+	for _, e := range got.ConnectionParameters.Entry {
+		keys[e.Key] = e.Value
+	}
+	assert.Equal(t, "true", keys["Expose primary keys"])
+	assert.Equal(t, "5", keys["max connections"])
+}
+
+// TestCreateJNDIDatastore_BadJNDIRef sanity-checks that the JNDI request shape
+// reaches GeoServer; we don't have a configured JNDI resource in the compose
+// stack, so the request is expected to be rejected with a non-2xx response —
+// we just verify no transport-level failure and a typed error is returned.
+func TestCreateJNDIDatastore_BadJNDIRef(t *testing.T) {
+	before()
+	const ws = "jndi_smoke_ws"
+	if _, err := gsCatalog.CreateWorkspace(ws); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteWorkspace(ws, true)
+	})
+
+	conn := DatastoreJNDIConnection{
+		Name:              "jndi_smoke_ds",
+		Type:              "postgis",
+		JndiReferenceName: "java:comp/env/jdbc/nonexistent",
+	}
+	created, err := gsCatalog.CreateJNDIDatastore(conn, ws)
+	// Either GeoServer rejects (most common) or it accepts the metadata but
+	// cannot resolve at use time. Both are valid; the smoke is that the
+	// request path and JSON shape are correct.
+	if created {
+		t.Logf("GeoServer accepted JNDI metadata; cleanup")
+		_, _ = gsCatalog.DeleteDatastore(ws, conn.Name, true)
+		return
+	}
+	assert.Error(t, err)
 }

--- a/datastores_unit_test.go
+++ b/datastores_unit_test.go
@@ -1,0 +1,166 @@
+package geoserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatastores_DatastoreConnection_GetDatastoreObj_BasicEntries(t *testing.T) {
+	conn := DatastoreConnection{
+		Name: "ds", Host: "localhost", Port: 5432, DBName: "gis",
+		DBSchema: "public", DBUser: "u", DBPass: "p", Type: "postgis",
+	}
+	got := conn.GetDatastoreObj()
+	assert.Equal(t, "ds", got.Name)
+	keys := map[string]string{}
+	for _, e := range got.ConnectionParameters.Entry {
+		keys[e.Key] = e.Value
+	}
+	assert.Equal(t, "localhost", keys["host"])
+	assert.Equal(t, "5432", keys["port"])
+	assert.Equal(t, "gis", keys["database"])
+	assert.Equal(t, "public", keys["schema"])
+	assert.Equal(t, "postgis", keys["dbtype"])
+}
+
+func TestDatastores_DatastoreConnection_GetDatastoreObj_AppendsOptions(t *testing.T) {
+	conn := DatastoreConnection{
+		Name: "ds", Type: "postgis", Host: "h", Port: 1, DBName: "d", DBSchema: "s", DBUser: "u", DBPass: "p",
+		Options: []Entry{
+			{Key: "max connections", Value: "20"},
+			{Key: "Expose primary keys", Value: "true"},
+		},
+	}
+	got := conn.GetDatastoreObj()
+	keys := map[string]string{}
+	for _, e := range got.ConnectionParameters.Entry {
+		keys[e.Key] = e.Value
+	}
+	assert.Equal(t, "20", keys["max connections"])
+	assert.Equal(t, "true", keys["Expose primary keys"])
+}
+
+func TestDatastores_JNDI_GetDatastoreObj(t *testing.T) {
+	conn := DatastoreJNDIConnection{
+		Name:              "ds-jndi",
+		Type:              "postgis",
+		JndiReferenceName: "java:comp/env/jdbc/postgres",
+		Options:           []Entry{{Key: "Expose primary keys", Value: "true"}},
+	}
+	got := conn.GetDatastoreObj()
+	assert.Equal(t, "ds-jndi", got.Name)
+	keys := map[string]string{}
+	for _, e := range got.ConnectionParameters.Entry {
+		keys[e.Key] = e.Value
+	}
+	assert.Equal(t, "java:comp/env/jdbc/postgres", keys["jndiReferenceName"])
+	assert.Equal(t, "postgis", keys["dbtype"])
+	assert.Equal(t, "true", keys["Expose primary keys"])
+	// JNDI must NOT carry host/port/passwd/etc.
+	for _, k := range []string{"host", "port", "passwd", "user"} {
+		_, present := keys[k]
+		assert.False(t, present, "JNDI datastore should not include %q", k)
+	}
+}
+
+func TestDatastores_JNDI_SatisfiesConnector(t *testing.T) {
+	var _ DatastoreConnector = DatastoreJNDIConnection{}
+	// Pointer-to-DatastoreConnection satisfies the interface; the value form
+	// does not because GetDatastoreObj has a pointer receiver on
+	// DatastoreConnection. Documented in the interface docstring.
+	var _ DatastoreConnector = (*DatastoreConnection)(nil)
+}
+
+func TestDatastores_CreateJNDIDatastore_201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/workspaces/topp/datastores", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		assert.Contains(t, string(body), `"jndiReferenceName"`)
+		assert.Contains(t, string(body), `"dbtype"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateJNDIDatastoreContext(context.Background(), DatastoreJNDIConnection{
+		Name:              "ds",
+		Type:              "postgis",
+		JndiReferenceName: "java:comp/env/jdbc/postgres",
+	}, "topp")
+	assert.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestDatastores_CreateJNDIDatastore_409(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, "datastore exists")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateJNDIDatastoreContext(context.Background(), DatastoreJNDIConnection{Name: "ds", Type: "postgis", JndiReferenceName: "ref"}, "topp")
+	assert.False(t, created)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestDatastores_CreateDatastoreFromConnector_DispatchesByImpl(t *testing.T) {
+	var capturedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+
+	// JNDI path
+	created, err := gs.CreateDatastoreFromConnectorContext(context.Background(), DatastoreJNDIConnection{
+		Name: "ds-jndi", Type: "postgis", JndiReferenceName: "java:comp/env/jdbc/x",
+	}, "topp")
+	assert.NoError(t, err)
+	assert.True(t, created)
+	assert.Contains(t, capturedBody, `"jndiReferenceName"`)
+
+	// Direct path through the same entry point — pointer required.
+	conn := DatastoreConnection{
+		Name: "ds-direct", Host: "h", Port: 1, DBName: "d",
+		DBSchema: "public", DBUser: "u", DBPass: "p", Type: "postgis",
+	}
+	created, err = gs.CreateDatastoreFromConnectorContext(context.Background(), &conn, "topp")
+	assert.NoError(t, err)
+	assert.True(t, created)
+	assert.Contains(t, capturedBody, `"host"`)
+	assert.Contains(t, capturedBody, `"dbtype"`)
+}
+
+func TestDatastores_CreateDatastore_AppliesDBSchemaDefault(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured = string(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	// Pass empty DBSchema; CreateDatastoreContext should default it to
+	// "public" (preserves v1.0 behavior).
+	created, err := gs.CreateDatastoreContext(context.Background(), DatastoreConnection{
+		Name: "ds", Host: "h", Port: 1, DBName: "d", DBSchema: "",
+		DBUser: "u", DBPass: "p", Type: "postgis",
+	}, "topp")
+	assert.NoError(t, err)
+	assert.True(t, created)
+	assert.Contains(t, captured, `"$":"public"`)
+}

--- a/feature_types.go
+++ b/feature_types.go
@@ -1,6 +1,7 @@
 package geoserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -60,6 +61,12 @@ func (u *CRSType) MarshalJSON() ([]byte, error) {
 type FeatureTypeService interface {
 	GetFeatureTypes(workspaceName string, datastoreName string) (featureTypes []*Resource, err error)
 	GetFeatureType(workspaceName string, datastoreName string, featureTypeName string) (featureType *FeatureType, err error)
+
+	// CreateFeatureType creates a featureType in workspace and datastore.
+	// Only valid for database-backed datastores (PostGIS, etc.) — for
+	// shapefile/geopackage stores use UploadShapeFile or PublishPostgisLayer.
+	CreateFeatureType(workspaceName string, datastoreName string, featureType *FeatureType) (created bool, err error)
+
 	DeleteFeatureType(workspaceName string, datastoreName string, featureTypeName string, recurse bool) (deleted bool, err error)
 }
 
@@ -67,6 +74,7 @@ type FeatureTypeService interface {
 type FeatureTypeServiceWithContext interface {
 	GetFeatureTypesContext(ctx context.Context, workspaceName string, datastoreName string) (featureTypes []*Resource, err error)
 	GetFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureTypeName string) (featureType *FeatureType, err error)
+	CreateFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureType *FeatureType) (created bool, err error)
 	DeleteFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureTypeName string, recurse bool) (deleted bool, err error)
 }
 
@@ -230,6 +238,41 @@ func (g *GeoServer) GetFeatureTypesContext(ctx context.Context, workspaceName st
 	}
 	featureTypes = featureTypesResponse.FeatureTypes.FeatureType
 	return
+}
+
+// CreateFeatureType creates a featureType in workspace and datastore using context.Background.
+//
+// Only valid for database-backed datastores (PostGIS, Oracle, etc.). For
+// shapefile-based stores, prefer [GeoServer.UploadShapeFile] which creates
+// the underlying datastore and feature type in one step.
+func (g *GeoServer) CreateFeatureType(workspaceName string, datastoreName string, featureType *FeatureType) (created bool, err error) {
+	return g.CreateFeatureTypeContext(context.Background(), workspaceName, datastoreName, featureType)
+}
+
+// CreateFeatureTypeContext is the context-aware variant of [GeoServer.CreateFeatureType].
+func (g *GeoServer) CreateFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureType *FeatureType) (created bool, err error) {
+	targetURL := g.featureTypesURL(workspaceName, datastoreName)
+	body := struct {
+		FeatureType *FeatureType `json:"featureType"`
+	}{featureType}
+	data, serErr := g.SerializeStruct(body)
+	if serErr != nil {
+		return false, fmt.Errorf("CreateFeatureType: serialize feature type: %w", serErr)
+	}
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		Data:     bytes.NewBuffer(data),
+		DataType: jsonType,
+		URL:      targetURL,
+		Query:    nil,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusCreated {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
 }
 
 // DeleteFeatureType deletes a feature type using context.Background.

--- a/feature_types_test.go
+++ b/feature_types_test.go
@@ -6,6 +6,7 @@ package geoserver
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,4 +91,49 @@ func TestGeoserverImplemetFeatureTypeService(t *testing.T) {
 	FeatureTypeServiceType := reflect.TypeOf((*FeatureTypeService)(nil)).Elem()
 	check := gsCatalog.Implements(FeatureTypeServiceType)
 	assert.True(t, check)
+}
+
+// TestCreateFeatureType creates a workspace + PostGIS datastore (against the
+// compose-managed PostGIS host `postgis:5432`, DB `gis`) then registers a
+// feature type pointing at the seeded `public.lbldyt` table.
+func TestCreateFeatureType(t *testing.T) {
+	before()
+	const ws = "ft_create_ws"
+	const ds = "ft_create_pg"
+	const ftName = "lbldyt"
+
+	if _, err := gsCatalog.CreateWorkspace(ws); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteWorkspace(ws, true)
+	})
+
+	conn := DatastoreConnection{
+		Name:   ds,
+		Host:   "postgis",
+		Port:   5432,
+		Type:   "postgis",
+		DBName: "gis",
+		DBUser: "golang",
+		DBPass: "golang",
+	}
+	created, err := gsCatalog.CreateDatastore(conn, ws)
+	if !created || err != nil {
+		t.Fatalf("preconditions: create postgis datastore: created=%v err=%v", created, err)
+	}
+
+	ft := &FeatureType{
+		Name:       ftName,
+		NativeName: ftName,
+		Title:      "lbldyt sample",
+		Srs:        "EPSG:4326",
+	}
+	created, err = gsCatalog.CreateFeatureType(ws, ds, ft)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := gsCatalog.GetFeatureType(ws, ds, ftName)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
 }

--- a/feature_types_unit_test.go
+++ b/feature_types_unit_test.go
@@ -1,0 +1,65 @@
+package geoserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureTypes_CreateFeatureType_201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/workspaces/topp/datastores/states_pg/featuretypes", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		assert.Contains(t, string(body), `"featureType"`)
+		assert.Contains(t, string(body), `"name":"polygon"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	ft := &FeatureType{Name: "polygon", Title: "polygon", Srs: "EPSG:4326"}
+	created, err := gs.CreateFeatureTypeContext(context.Background(), "topp", "states_pg", ft)
+	assert.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestFeatureTypes_CreateFeatureType_400(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "no attributes")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateFeatureTypeContext(context.Background(), "topp", "states_pg", &FeatureType{Name: "polygon"})
+	assert.False(t, created)
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("expected ErrBadRequest, got %v", err)
+	}
+}
+
+func TestFeatureTypes_CreateFeatureType_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "datastore not found")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateFeatureTypeContext(context.Background(), "missing-ws", "missing-ds", &FeatureType{Name: "x"})
+	assert.False(t, created)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFeatureTypes_FeatureTypeServiceImpl(t *testing.T) {
+	var _ FeatureTypeService = (*GeoServer)(nil)
+	var _ FeatureTypeServiceWithContext = (*GeoServer)(nil)
+}

--- a/security.go
+++ b/security.go
@@ -1,0 +1,402 @@
+package geoserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+)
+
+// defaultUserGroupService is the GeoServer default user/group service name
+// used when callers pass an empty service name.
+const defaultUserGroupService = "default"
+
+// User represents a GeoServer user record.
+//
+// Password is write-only — GeoServer never returns the password hash on GET,
+// so this field is empty on values returned from list / fetch operations.
+type User struct {
+	Name     string `json:"userName"`
+	Enabled  bool   `json:"enabled"`
+	Password string `json:"password,omitempty"`
+}
+
+// Group represents a GeoServer user group.
+type Group struct {
+	Name string `json:"groupName"`
+}
+
+// SecurityService defines GeoServer security operations covering users,
+// groups, and roles.
+type SecurityService interface {
+	// Users
+	GetUsers(serviceName string) (users []User, err error)
+	CreateUser(userName string, password string, serviceName string) (created bool, err error)
+	DeleteUser(userName string, serviceName string) (deleted bool, err error)
+
+	// Groups
+	GetGroups(serviceName string) (groups []Group, err error)
+	CreateGroup(groupName string, serviceName string) (created bool, err error)
+	DeleteGroup(groupName string, serviceName string) (deleted bool, err error)
+
+	// Roles
+	GetRoles() (roles []string, err error)
+	GetUserRoles(userName string) (roles []string, err error)
+	CreateRole(roleName string) (created bool, err error)
+	DeleteRole(roleName string) (deleted bool, err error)
+
+	// User <-> Role association
+	AddUserRole(roleName string, userName string) (added bool, err error)
+	DeleteUserRole(roleName string, userName string) (deleted bool, err error)
+}
+
+// SecurityServiceWithContext is the context-aware sibling of [SecurityService].
+type SecurityServiceWithContext interface {
+	GetUsersContext(ctx context.Context, serviceName string) (users []User, err error)
+	CreateUserContext(ctx context.Context, userName string, password string, serviceName string) (created bool, err error)
+	DeleteUserContext(ctx context.Context, userName string, serviceName string) (deleted bool, err error)
+
+	GetGroupsContext(ctx context.Context, serviceName string) (groups []Group, err error)
+	CreateGroupContext(ctx context.Context, groupName string, serviceName string) (created bool, err error)
+	DeleteGroupContext(ctx context.Context, groupName string, serviceName string) (deleted bool, err error)
+
+	GetRolesContext(ctx context.Context) (roles []string, err error)
+	GetUserRolesContext(ctx context.Context, userName string) (roles []string, err error)
+	CreateRoleContext(ctx context.Context, roleName string) (created bool, err error)
+	DeleteRoleContext(ctx context.Context, roleName string) (deleted bool, err error)
+
+	AddUserRoleContext(ctx context.Context, roleName string, userName string) (added bool, err error)
+	DeleteUserRoleContext(ctx context.Context, roleName string, userName string) (deleted bool, err error)
+}
+
+// resolveService returns the user-group service name to address, defaulting
+// to "default" when serviceName is empty. GeoServer's default service is
+// "default" out of the box.
+func resolveService(serviceName string) string {
+	if serviceName == "" {
+		return defaultUserGroupService
+	}
+	return serviceName
+}
+
+// usersURL builds /rest/security/usergroup/service/{service}/users[/{user}].
+func (g *GeoServer) usersURL(serviceName string, extra ...string) string {
+	parts := make([]string, 0, 5+len(extra))
+	parts = append(parts, "rest", "security", "usergroup", "service", resolveService(serviceName))
+	parts = append(parts, extra...)
+	return g.ParseURL(parts...)
+}
+
+// groupsURL builds /rest/security/usergroup/service/{service}/groups[...].
+func (g *GeoServer) groupsURL(serviceName string, extra ...string) string {
+	parts := make([]string, 0, 5+len(extra))
+	parts = append(parts, "rest", "security", "usergroup", "service", resolveService(serviceName))
+	parts = append(parts, extra...)
+	return g.ParseURL(parts...)
+}
+
+// rolesURL builds /rest/security/roles[/...].
+func (g *GeoServer) rolesURL(extra ...string) string {
+	parts := make([]string, 0, 3+len(extra))
+	parts = append(parts, "rest", "security", "roles")
+	parts = append(parts, extra...)
+	return g.ParseURL(parts...)
+}
+
+// ---- Users ---------------------------------------------------------------
+
+// GetUsers returns users for the named user-group service using context.Background.
+// An empty serviceName resolves to "default".
+func (g *GeoServer) GetUsers(serviceName string) (users []User, err error) {
+	return g.GetUsersContext(context.Background(), serviceName)
+}
+
+// GetUsersContext is the context-aware variant of [GeoServer.GetUsers].
+func (g *GeoServer) GetUsersContext(ctx context.Context, serviceName string) (users []User, err error) {
+	targetURL := g.usersURL(serviceName, "users")
+	httpRequest := HTTPRequest{Method: getMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var body struct {
+		Users []User `json:"users"`
+	}
+	if err = g.DeSerializeJSON(response, &body); err != nil {
+		return nil, fmt.Errorf("GetUsers: decode: %w", err)
+	}
+	return body.Users, nil
+}
+
+// CreateUser creates a user under the named service using context.Background.
+// An empty serviceName resolves to "default".
+func (g *GeoServer) CreateUser(userName string, password string, serviceName string) (created bool, err error) {
+	return g.CreateUserContext(context.Background(), userName, password, serviceName)
+}
+
+// CreateUserContext is the context-aware variant of [GeoServer.CreateUser].
+func (g *GeoServer) CreateUserContext(ctx context.Context, userName string, password string, serviceName string) (created bool, err error) {
+	targetURL := g.usersURL(serviceName, "users")
+	body := struct {
+		User User `json:"user"`
+	}{User{Name: userName, Enabled: true, Password: password}}
+	data, serErr := g.SerializeStruct(body)
+	if serErr != nil {
+		return false, fmt.Errorf("CreateUser: serialize: %w", serErr)
+	}
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		Data:     bytes.NewBuffer(data),
+		DataType: jsonType,
+		URL:      targetURL,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusCreated {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// DeleteUser deletes a user from the named service using context.Background.
+func (g *GeoServer) DeleteUser(userName string, serviceName string) (deleted bool, err error) {
+	return g.DeleteUserContext(context.Background(), userName, serviceName)
+}
+
+// DeleteUserContext is the context-aware variant of [GeoServer.DeleteUser].
+func (g *GeoServer) DeleteUserContext(ctx context.Context, userName string, serviceName string) (deleted bool, err error) {
+	targetURL := g.usersURL(serviceName, "user", userName)
+	httpRequest := HTTPRequest{Method: deleteMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// ---- Groups --------------------------------------------------------------
+
+// GetGroups returns groups for the named user-group service using context.Background.
+func (g *GeoServer) GetGroups(serviceName string) (groups []Group, err error) {
+	return g.GetGroupsContext(context.Background(), serviceName)
+}
+
+// GetGroupsContext is the context-aware variant of [GeoServer.GetGroups].
+//
+// Decodes both `{"groups": [...]}` (GeoServer 2.28+) and `{"groupNames": [...]}`
+// (older 2.x). Each entry is a bare group name string; we normalize to [Group].
+func (g *GeoServer) GetGroupsContext(ctx context.Context, serviceName string) (groups []Group, err error) {
+	targetURL := g.groupsURL(serviceName, "groups")
+	httpRequest := HTTPRequest{Method: getMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var body struct {
+		Groups     []string `json:"groups,omitempty"`
+		GroupNames []string `json:"groupNames,omitempty"`
+	}
+	if err = g.DeSerializeJSON(response, &body); err != nil {
+		return nil, fmt.Errorf("GetGroups: decode: %w", err)
+	}
+	names := body.Groups
+	if len(names) == 0 {
+		names = body.GroupNames
+	}
+	groups = make([]Group, 0, len(names))
+	for _, name := range names {
+		groups = append(groups, Group{Name: name})
+	}
+	return groups, nil
+}
+
+// CreateGroup creates a group under the named service using context.Background.
+func (g *GeoServer) CreateGroup(groupName string, serviceName string) (created bool, err error) {
+	return g.CreateGroupContext(context.Background(), groupName, serviceName)
+}
+
+// CreateGroupContext is the context-aware variant of [GeoServer.CreateGroup].
+func (g *GeoServer) CreateGroupContext(ctx context.Context, groupName string, serviceName string) (created bool, err error) {
+	targetURL := g.groupsURL(serviceName, "group", groupName)
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		DataType: jsonType,
+		URL:      targetURL,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusCreated {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// DeleteGroup deletes a group from the named service using context.Background.
+func (g *GeoServer) DeleteGroup(groupName string, serviceName string) (deleted bool, err error) {
+	return g.DeleteGroupContext(context.Background(), groupName, serviceName)
+}
+
+// DeleteGroupContext is the context-aware variant of [GeoServer.DeleteGroup].
+func (g *GeoServer) DeleteGroupContext(ctx context.Context, groupName string, serviceName string) (deleted bool, err error) {
+	targetURL := g.groupsURL(serviceName, "group", groupName)
+	httpRequest := HTTPRequest{Method: deleteMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// ---- Roles ---------------------------------------------------------------
+
+// GetRoles returns all role names defined in GeoServer using context.Background.
+func (g *GeoServer) GetRoles() (roles []string, err error) {
+	return g.GetRolesContext(context.Background())
+}
+
+// GetRolesContext is the context-aware variant of [GeoServer.GetRoles].
+//
+// Decodes both `{"roles":[...]}` (GeoServer 2.28+) and `{"roleNames":[...]}`
+// (older 2.x) response shapes; whichever is non-empty wins.
+func (g *GeoServer) GetRolesContext(ctx context.Context) (roles []string, err error) {
+	targetURL := g.rolesURL()
+	httpRequest := HTTPRequest{Method: getMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var body struct {
+		Roles     []string `json:"roles,omitempty"`
+		RoleNames []string `json:"roleNames,omitempty"`
+	}
+	if err = g.DeSerializeJSON(response, &body); err != nil {
+		return nil, fmt.Errorf("GetRoles: decode: %w", err)
+	}
+	if len(body.Roles) > 0 {
+		return body.Roles, nil
+	}
+	return body.RoleNames, nil
+}
+
+// GetUserRoles returns the role names assigned to userName using context.Background.
+//
+// GeoServer returns an empty role list (not 404) for users that do not exist;
+// callers wanting to validate user existence should use [GeoServer.GetUsers].
+func (g *GeoServer) GetUserRoles(userName string) (roles []string, err error) {
+	return g.GetUserRolesContext(context.Background(), userName)
+}
+
+// GetUserRolesContext is the context-aware variant of [GeoServer.GetUserRoles].
+//
+// Decodes both `{"roles":[...]}` (GeoServer 2.28+) and `{"roleNames":[...]}`
+// (older 2.x) response shapes.
+func (g *GeoServer) GetUserRolesContext(ctx context.Context, userName string) (roles []string, err error) {
+	targetURL := g.rolesURL("user", userName)
+	httpRequest := HTTPRequest{Method: getMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var body struct {
+		Roles     []string `json:"roles,omitempty"`
+		RoleNames []string `json:"roleNames,omitempty"`
+	}
+	if err = g.DeSerializeJSON(response, &body); err != nil {
+		return nil, fmt.Errorf("GetUserRoles: decode: %w", err)
+	}
+	if len(body.Roles) > 0 {
+		return body.Roles, nil
+	}
+	return body.RoleNames, nil
+}
+
+// CreateRole creates a role using context.Background.
+func (g *GeoServer) CreateRole(roleName string) (created bool, err error) {
+	return g.CreateRoleContext(context.Background(), roleName)
+}
+
+// CreateRoleContext is the context-aware variant of [GeoServer.CreateRole].
+func (g *GeoServer) CreateRoleContext(ctx context.Context, roleName string) (created bool, err error) {
+	targetURL := g.rolesURL("role", roleName)
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		DataType: jsonType,
+		URL:      targetURL,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusCreated {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// DeleteRole deletes a role using context.Background.
+func (g *GeoServer) DeleteRole(roleName string) (deleted bool, err error) {
+	return g.DeleteRoleContext(context.Background(), roleName)
+}
+
+// DeleteRoleContext is the context-aware variant of [GeoServer.DeleteRole].
+func (g *GeoServer) DeleteRoleContext(ctx context.Context, roleName string) (deleted bool, err error) {
+	targetURL := g.rolesURL("role", roleName)
+	httpRequest := HTTPRequest{Method: deleteMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// ---- User <-> Role association ------------------------------------------
+
+// AddUserRole associates roleName with userName using context.Background.
+//
+// GeoServer returns 200 OK (not 201 Created) for role assignments.
+// Re-assigning a role that is already attached is idempotent — GeoServer
+// returns 200 OK without an error.
+func (g *GeoServer) AddUserRole(roleName string, userName string) (added bool, err error) {
+	return g.AddUserRoleContext(context.Background(), roleName, userName)
+}
+
+// AddUserRoleContext is the context-aware variant of [GeoServer.AddUserRole].
+func (g *GeoServer) AddUserRoleContext(ctx context.Context, roleName string, userName string) (added bool, err error) {
+	targetURL := g.rolesURL("role", roleName, "user", userName)
+	httpRequest := HTTPRequest{
+		Method:   postMethod,
+		Accept:   jsonType,
+		DataType: jsonType,
+		URL:      targetURL,
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}
+
+// DeleteUserRole disassociates roleName from userName using context.Background.
+//
+// GeoServer returns 200 OK whether or not the user actually had the role
+// assigned, as long as both the role and user exist. If either is missing,
+// the response is non-2xx and a typed error is returned.
+func (g *GeoServer) DeleteUserRole(roleName string, userName string) (deleted bool, err error) {
+	return g.DeleteUserRoleContext(context.Background(), roleName, userName)
+}
+
+// DeleteUserRoleContext is the context-aware variant of [GeoServer.DeleteUserRole].
+func (g *GeoServer) DeleteUserRoleContext(ctx context.Context, roleName string, userName string) (deleted bool, err error) {
+	targetURL := g.rolesURL("role", roleName, "user", userName)
+	httpRequest := HTTPRequest{Method: deleteMethod, Accept: jsonType, URL: targetURL}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		g.logger.Warn(string(response))
+		return false, g.GetError(responseCode, response)
+	}
+	return true, nil
+}

--- a/security_test.go
+++ b/security_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+// +build integration
+
+package geoserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecurity_GetUsers(t *testing.T) {
+	before()
+	users, err := gsCatalog.GetUsers("")
+	assert.NoError(t, err)
+	// Default GeoServer always has at least the admin user.
+	assert.NotEmpty(t, users)
+	_, err = gsCatalog.GetUsers("nonExistentService")
+	assert.Error(t, err)
+}
+
+func TestSecurity_GetGroups(t *testing.T) {
+	before()
+	groups, err := gsCatalog.GetGroups("")
+	assert.NoError(t, err)
+	// Out of the box, no groups are defined — assertion is on no-error, not count.
+	_ = groups
+	_, err = gsCatalog.GetGroups("nonExistentService")
+	assert.Error(t, err)
+}
+
+func TestSecurity_GetRoles(t *testing.T) {
+	before()
+	roles, err := gsCatalog.GetRoles()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, roles, "default GeoServer should have at least ROLE_ADMINISTRATOR")
+}
+
+func TestSecurity_GetUserRoles_Admin(t *testing.T) {
+	before()
+	roles, err := gsCatalog.GetUserRoles("admin")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, roles)
+}
+
+func TestSecurity_CreateDeleteUser(t *testing.T) {
+	before()
+	const user = "secTestUser"
+
+	// Cleanup from any previous failed run.
+	_, _ = gsCatalog.DeleteUser(user, "")
+
+	created, err := gsCatalog.CreateUser(user, "p@ss", "")
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	// Duplicate create should fail.
+	created, err = gsCatalog.CreateUser(user, "p@ss", "")
+	assert.False(t, created)
+	assert.Error(t, err)
+
+	deleted, err := gsCatalog.DeleteUser(user, "")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_CreateDeleteGroup(t *testing.T) {
+	before()
+	const group = "secTestGroup"
+
+	_, _ = gsCatalog.DeleteGroup(group, "")
+
+	created, err := gsCatalog.CreateGroup(group, "")
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	deleted, err := gsCatalog.DeleteGroup(group, "")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_CreateDeleteRole(t *testing.T) {
+	before()
+	const role = "secTestRole"
+
+	_, _ = gsCatalog.DeleteRole(role)
+
+	created, err := gsCatalog.CreateRole(role)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	created, err = gsCatalog.CreateRole(role)
+	assert.False(t, created)
+	assert.Error(t, err)
+
+	deleted, err := gsCatalog.DeleteRole(role)
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_AddDeleteUserRole(t *testing.T) {
+	before()
+	const role = "secTestRole2"
+	const user = "secTestUser2"
+
+	// Pre-conditions: role + user must exist (GeoServer 2.27+ requires user
+	// to exist for the role association; 2.28 may accept either way).
+	if _, err := gsCatalog.CreateRole(role); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create role: %v", err)
+	}
+	if _, err := gsCatalog.CreateUser(user, "p@ss", ""); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteUserRole(role, user)
+		_, _ = gsCatalog.DeleteUser(user, "")
+		_, _ = gsCatalog.DeleteRole(role)
+	})
+
+	added, err := gsCatalog.AddUserRole(role, user)
+	assert.NoError(t, err)
+	assert.True(t, added)
+
+	// Adding the same association again is idempotent.
+	added, err = gsCatalog.AddUserRole(role, user)
+	assert.NoError(t, err)
+	assert.True(t, added)
+
+	deleted, err := gsCatalog.DeleteUserRole(role, user)
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}

--- a/security_unit_test.go
+++ b/security_unit_test.go
@@ -1,0 +1,230 @@
+package geoserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecurity_GetUsers_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/security/usergroup/service/default/users", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"users":[{"userName":"admin","enabled":true},{"userName":"viewer","enabled":true}]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	users, err := gs.GetUsersContext(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, "admin", users[0].Name)
+}
+
+func TestSecurity_GetUsers_NamedService_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/service/customService/")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "service not found")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	_, err := gs.GetUsersContext(context.Background(), "customService")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestSecurity_CreateUser_201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/security/usergroup/service/default/users", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		assert.Contains(t, string(body), `"userName":"alice"`)
+		assert.Contains(t, string(body), `"password":"secret"`)
+		assert.Contains(t, string(body), `"enabled":true`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateUserContext(context.Background(), "alice", "secret", "")
+	assert.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestSecurity_CreateUser_409(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, "user already exists")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateUserContext(context.Background(), "alice", "secret", "")
+	assert.False(t, created)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestSecurity_DeleteUser_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/service/default/user/alice"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteUserContext(context.Background(), "alice", "")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_GetGroups_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/security/usergroup/service/default/groups", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		// GeoServer 2.28 uses "groups"; pre-2.28 used "groupNames".
+		_, _ = io.WriteString(w, `{"groups":["editors","viewers"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	groups, err := gs.GetGroupsContext(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, groups, 2)
+	assert.Equal(t, "editors", groups[0].Name)
+	assert.Equal(t, "viewers", groups[1].Name)
+}
+
+func TestSecurity_CreateGroup_201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/service/default/group/editors"))
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateGroupContext(context.Background(), "editors", "")
+	assert.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestSecurity_DeleteGroup_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteGroupContext(context.Background(), "editors", "")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_GetRoles_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/security/roles", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		// GeoServer 2.28 uses "roles"; pre-2.28 used "roleNames".
+		_, _ = io.WriteString(w, `{"roles":["ROLE_ADMINISTRATOR","ROLE_VIEWER"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	roles, err := gs.GetRolesContext(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"ROLE_ADMINISTRATOR", "ROLE_VIEWER"}, roles)
+}
+
+func TestSecurity_GetUserRoles_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/rest/security/roles/user/admin"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"roles":["ROLE_ADMINISTRATOR"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	roles, err := gs.GetUserRolesContext(context.Background(), "admin")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"ROLE_ADMINISTRATOR"}, roles)
+}
+
+func TestSecurity_CreateRole_201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/rest/security/roles/role/ROLE_X"))
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	created, err := gs.CreateRoleContext(context.Background(), "ROLE_X")
+	assert.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestSecurity_DeleteRole_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "role missing")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteRoleContext(context.Background(), "ROLE_GONE")
+	assert.False(t, deleted)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestSecurity_AddUserRole_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/rest/security/roles/role/ROLE_VIEWER/user/alice"))
+		// GeoServer returns 200 (not 201) for role assignments.
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	added, err := gs.AddUserRoleContext(context.Background(), "ROLE_VIEWER", "alice")
+	assert.NoError(t, err)
+	assert.True(t, added)
+}
+
+func TestSecurity_DeleteUserRole_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	deleted, err := gs.DeleteUserRoleContext(context.Background(), "ROLE_VIEWER", "alice")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSecurity_ServiceImpl(t *testing.T) {
+	// Compile-time + runtime check that *GeoServer satisfies SecurityService
+	// and SecurityServiceWithContext.
+	var _ SecurityService = (*GeoServer)(nil)
+	var _ SecurityServiceWithContext = (*GeoServer)(nil)
+	var _ ACLService = (*GeoServer)(nil)
+	var _ ACLServiceWithContext = (*GeoServer)(nil)
+}

--- a/utils.go
+++ b/utils.go
@@ -174,6 +174,12 @@ func (g *GeoServer) getGoGeoserverPackageDir() (string, error) {
 // workspace/layer names containing spaces, slashes, or non-ASCII characters
 // produce correct URLs instead of malformed ones. Previously such inputs
 // silently produced bad URLs.
+//
+// Bug fix in v1.1.1: the encoded path is preserved through url.URL.String()
+// by setting [url.URL.RawPath] alongside [url.URL.Path]. Without RawPath,
+// segments that PathEscape'd to a sequence containing "%" (e.g., "*" → "%2A")
+// were re-encoded by String() to "%252A", which GeoServer's request firewall
+// rejects as a potentially malicious URL.
 func (g *GeoServer) ParseURL(urlParts ...string) (parsedURL string) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -201,6 +207,14 @@ func (g *GeoServer) ParseURL(urlParts ...string) (parsedURL string) {
 		}
 		escaped = append(escaped, url.PathEscape(p))
 	}
-	geoserverURL.Path = path.Join(escaped...)
+	rawPath := path.Join(escaped...)
+	decoded, decodeErr := url.PathUnescape(rawPath)
+	if decodeErr != nil {
+		// Should be unreachable since we built rawPath from PathEscape outputs.
+		g.logger.Errorf("ParseURL: cannot unescape built path %q: %v", rawPath, decodeErr)
+		return ""
+	}
+	geoserverURL.Path = decoded
+	geoserverURL.RawPath = rawPath
 	return geoserverURL.String()
 }

--- a/utils_unit_test.go
+++ b/utils_unit_test.go
@@ -1,0 +1,67 @@
+package geoserver
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseURL_NoDoubleEncoding is a regression guard for the v1.1.x bug
+// where url.URL.String() re-encoded already-PathEscape'd segments — e.g.
+// "*" → "%2A" → "%252A" — which GeoServer's StrictHttpFirewall then
+// rejected. The fix sets [url.URL.RawPath] alongside [url.URL.Path] so the
+// encoding is preserved verbatim.
+func TestParseURL_NoDoubleEncoding(t *testing.T) {
+	gs := New("http://localhost:8080/geoserver/", "u", "p", WithLogger(nil))
+
+	cases := []struct {
+		name        string
+		segments    []string
+		mustContain string
+		mustNot     string
+	}{
+		{
+			name:        "asterisk in segment",
+			segments:    []string{"rest", "security", "acl", "layers", "ws.*.r"},
+			mustContain: "ws.%2A.r",
+			mustNot:     "%252A",
+		},
+		{
+			name:        "space in workspace name",
+			segments:    []string{"rest", "workspaces", "my workspace"},
+			mustContain: "my%20workspace",
+			mustNot:     "%2520",
+		},
+		{
+			name:        "non-ASCII",
+			segments:    []string{"rest", "workspaces", "café"},
+			mustContain: "%C3%A9",
+			mustNot:     "%25",
+		},
+		{
+			name:        "plain ASCII unaffected",
+			segments:    []string{"rest", "workspaces", "topp"},
+			mustContain: "/rest/workspaces/topp",
+			mustNot:     "%",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gs.ParseURL(tc.segments...)
+			if !strings.Contains(got, tc.mustContain) {
+				t.Fatalf("URL %q must contain %q", got, tc.mustContain)
+			}
+			if strings.Contains(got, tc.mustNot) {
+				t.Fatalf("URL %q must NOT contain %q (regression: double-encoded)", got, tc.mustNot)
+			}
+		})
+	}
+}
+
+func TestParseURL_DropsEmptySegments(t *testing.T) {
+	gs := New("http://localhost:8080/geoserver/", "u", "p", WithLogger(nil))
+	got := gs.ParseURL("rest", "workspaces", "", "topp")
+	if got != "http://localhost:8080/geoserver/rest/workspaces/topp" {
+		t.Fatalf("unexpected URL: %q", got)
+	}
+}

--- a/workspaces_unit_test.go
+++ b/workspaces_unit_test.go
@@ -99,14 +99,13 @@ func TestWorkspaces_DeleteWorkspace_recurseQuery(t *testing.T) {
 
 // TestWorkspaces_URLEscaping verifies the v1.1 PathEscape fix: workspace
 // names with spaces / non-ASCII chars produce correctly-escaped URLs rather
-// than malformed ones.
+// than malformed ones, AND the encoding is single (not double) — see the
+// ParseURL RawPath fix.
 func TestWorkspaces_URLEscaping(t *testing.T) {
-	var captured string
+	var capturedRequestURI, capturedEscaped string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		captured = r.URL.RawPath
-		if captured == "" {
-			captured = r.URL.Path
-		}
+		capturedRequestURI = r.RequestURI     // raw bytes from the wire
+		capturedEscaped = r.URL.EscapedPath() // canonical encoded form
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, `{"workspace":{"name":"my workspace"}}`)
 	}))
@@ -115,8 +114,15 @@ func TestWorkspaces_URLEscaping(t *testing.T) {
 	gs := newTestCatalog(srv)
 	_, err := gs.GetWorkspaceContext(context.Background(), "my workspace")
 	assert.NoError(t, err)
-	if !strings.Contains(captured, "my%20workspace") {
-		t.Fatalf("expected URL to contain percent-encoded space, got %q", captured)
+	if !strings.Contains(capturedRequestURI, "my%20workspace") {
+		t.Fatalf("expected wire URI to contain percent-encoded space, got %q", capturedRequestURI)
+	}
+	if !strings.Contains(capturedEscaped, "my%20workspace") {
+		t.Fatalf("expected EscapedPath to contain percent-encoded space, got %q", capturedEscaped)
+	}
+	// Regression guard: must NOT be double-encoded (would yield "%2520").
+	if strings.Contains(capturedRequestURI, "%2520") {
+		t.Fatalf("URL is double-encoded: %q", capturedRequestURI)
 	}
 }
 


### PR DESCRIPTION
## Summary

Backports the feature set from closed PR #15 (mandalorian-one / archer-v, Nov 2021) which landed only on a fork branch (\`origin/merge-mandalorian-one/master\`). All code is refactored to fit the v1.1 idiom: every method comes with a \`*Context\` sibling, errors map to typed sentinels via \`errors.Is\`, the \`*Logger\` wrapper is used, and parallel \`*Service\` / \`*ServiceWithContext\` interfaces are defined.

Closes the gap noted in the project memory file \`project_unmerged_forks.md\`.

## What's added

### Security (users / groups / roles) — \`security.go\`

\`SecurityService\` and \`SecurityServiceWithContext\` interfaces. Empty \`serviceName\` resolves to \`\"default\"\`.

| Method | Endpoint |
|---|---|
| \`GetUsers\`, \`CreateUser\`, \`DeleteUser\` | \`/rest/security/usergroup/service/{svc}/users\` |
| \`GetGroups\`, \`CreateGroup\`, \`DeleteGroup\` | \`/rest/security/usergroup/service/{svc}/group[s]\` |
| \`GetRoles\`, \`GetUserRoles\`, \`CreateRole\`, \`DeleteRole\` | \`/rest/security/roles\` |
| \`AddUserRole\`, \`DeleteUserRole\` | \`/rest/security/roles/role/{role}/user/{user}\` |

### Layer ACL — \`acl.go\`

\`ACLService\` / \`ACLServiceWithContext\`. \`ACLRule\` with \`ACLOpRead\` / \`ACLOpWrite\` / \`ACLOpAdmin\` constants. Round-trip via \`ACLRule.ToStrings\` and \`StringToACLRule\`.

### Datastore enhancements — \`datastores.go\`

- New \`DatastoreConnector\` interface — both \`*DatastoreConnection\` and \`DatastoreJNDIConnection\` satisfy it.
- New \`DatastoreJNDIConnection\` struct for Tomcat-JNDI-pool-backed PostGIS connections.
- New \`DatastoreConnection.Options []Entry\` field for arbitrary connection params (\`\"max connections\"\`, \`\"Expose primary keys\"\`, …). Appended at end so v1.0 positional struct literals still compile.
- New methods (with Context twins): \`CreateJNDIDatastore\`, \`CreateDatastoreFromConnector\`.
- Existing \`CreateDatastore\` signature unchanged.

### Feature types — \`feature_types.go\`

\`CreateFeatureType\` / \`CreateFeatureTypeContext\` — register a feature type against a database-backed datastore without going through \`UploadShapeFile\`.

### Catalog — \`catalog.go\`

\`Catalog\` interface now embeds \`SecurityService\` and \`ACLService\`.

## Bug fixed along the way

\`ParseURL\` was double-encoding path segments containing characters that \`url.PathEscape\` percent-encodes — e.g. \`\"*\"\` → \`\"%2A\"\` → previously \`\"%252A\"\`. \`url.URL.String()\` re-encoded the \`%\` in the already-escaped \`Path\`. The fix sets \`RawPath\` alongside \`Path\` so the encoding is preserved verbatim through \`String()\`. GeoServer's \`StrictHttpFirewall\` rejects \`%25\` as potentially malicious, and the new ACL \`DELETE\` path (rule strings contain literal \`*\` wildcards) was what surfaced the bug. \`utils_unit_test.go\` \`TestParseURL_NoDoubleEncoding\` guards the regression.

## Cross-version compatibility

\`GetRoles\`, \`GetUserRoles\`, and \`GetGroups\` decode both the GeoServer 2.28+ keys (\`roles\`, \`groups\`) and older 2.x keys (\`roleNames\`, \`groupNames\`) so they work across the supported version matrix.

## Verification

Locally — all gates green on a fresh \`make compose-up\` stack against GeoServer 2.28.0:

- \`make vet\`, \`make lint\`, \`make test-unit\` — clean
- Full \`make test-integration\` — green in 18s, including the new ACL / security / Options / JNDI / CreateFeatureType tests

## Test plan

- [ ] \`Lint\` green
- [ ] \`Unit tests (Go 1.23)\` green
- [ ] \`Unit tests (Go 1.25)\` green
- [ ] \`govulncheck\` green
- [ ] \`Analyze (Go)\` (CodeQL) green
- [ ] \`GeoServer 2.27.4\` (integration) green — exercises the new endpoints plus the cross-version response-shape decoders
- [ ] \`GeoServer 2.28.0\` (integration) green