### PR TITLE
feat: port GetFeatureTypeList from PR #17 (feature-type discovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — feature-type discovery (port of PR #17)
+
+- `GetFeatureTypeList` / `GetFeatureTypeListContext` — calls GeoServer's `?list=` discovery endpoint at `/rest/workspaces/{ws}/datastores/{ds}/featuretypes`. Returns the flat list of feature-type names filtered by `FeatureTypeListKind`:
+  - `FeatureTypeListConfigured` — only feature types already configured in GeoServer.
+  - `FeatureTypeListAvailable` — tables in the underlying datastore not yet published.
+  - `FeatureTypeListAvailableWithGeom` — like `available` but only tables carrying a geometry column.
+  - `FeatureTypeListAll` (default for empty kind) — configured ∪ available.
+- Added to the `FeatureTypeService` and `FeatureTypeServiceWithContext` interfaces.
+- httptest unit tests + integration test that creates a PostGIS datastore against the compose stack, asserts the seeded `public.lbldyt` table appears under `available`, and that `configured` is empty until something is published.
+
+This was originally proposed in #17 (Wichert Akkerman / Woven Planet, Feb 2022) but the PR was closed without merge. Refactored to fit the v1.1 idiom (`*Context` twin, typed `FeatureTypeListKind` enum, parallel `*WithContext` interface entry) before landing.
+
 ### Added — security, ACL, JNDI datastore, CreateFeatureType (port of PR #15)
 
 These features were originally proposed in PR #15 (Nov 2021) but landed only on a fork branch. They have been refactored to fit the v1.1 idiom (every method comes with a `*Context` sibling, typed-error sentinels via `errors.Is`, the `*Logger` wrapper, parallel `*Service` and `*ServiceWithContext` interfaces) and are now available on `master`.

--- a/feature_types.go
+++ b/feature_types.go
@@ -60,6 +60,14 @@ func (u *CRSType) MarshalJSON() ([]byte, error) {
 // FeatureTypeService define all geoserver featuretype operations
 type FeatureTypeService interface {
 	GetFeatureTypes(workspaceName string, datastoreName string) (featureTypes []*Resource, err error)
+
+	// GetFeatureTypeList lists feature-type names in a datastore filtered
+	// by `kind`: "configured" (default), "available", "available_with_geom",
+	// or "all". The "available" variants are useful for discovering tables
+	// in the underlying datastore that have not yet been published as
+	// GeoServer feature types.
+	GetFeatureTypeList(workspaceName string, datastoreName string, kind FeatureTypeListKind) (names []string, err error)
+
 	GetFeatureType(workspaceName string, datastoreName string, featureTypeName string) (featureType *FeatureType, err error)
 
 	// CreateFeatureType creates a featureType in workspace and datastore.
@@ -73,10 +81,28 @@ type FeatureTypeService interface {
 // FeatureTypeServiceWithContext is the context-aware sibling of [FeatureTypeService].
 type FeatureTypeServiceWithContext interface {
 	GetFeatureTypesContext(ctx context.Context, workspaceName string, datastoreName string) (featureTypes []*Resource, err error)
+	GetFeatureTypeListContext(ctx context.Context, workspaceName string, datastoreName string, kind FeatureTypeListKind) (names []string, err error)
 	GetFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureTypeName string) (featureType *FeatureType, err error)
 	CreateFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureType *FeatureType) (created bool, err error)
 	DeleteFeatureTypeContext(ctx context.Context, workspaceName string, datastoreName string, featureTypeName string, recurse bool) (deleted bool, err error)
 }
+
+// FeatureTypeListKind is the GeoServer `?list=` query value for the feature
+// types listing endpoint. It controls which subset of tables / configured
+// types is returned.
+type FeatureTypeListKind string
+
+// Recognized FeatureTypeListKind values. GeoServer's REST API:
+//   - configured (default): only feature types that already have a GeoServer config
+//   - available:            tables in the datastore not yet configured
+//   - available_with_geom:  same as available, but only tables with a geometry column
+//   - all:                  configured ∪ available
+const (
+	FeatureTypeListConfigured        FeatureTypeListKind = "configured"
+	FeatureTypeListAvailable         FeatureTypeListKind = "available"
+	FeatureTypeListAvailableWithGeom FeatureTypeListKind = "available_with_geom"
+	FeatureTypeListAll               FeatureTypeListKind = "all"
+)
 
 // Entry is geoserver Entry
 type Entry struct {
@@ -210,6 +236,47 @@ func (g *GeoServer) featureTypesURL(workspaceName, datastoreName string, extra .
 	parts = append(parts, "featuretypes")
 	parts = append(parts, extra...)
 	return g.ParseURL(parts...)
+}
+
+// featureTypeListResponse models GeoServer's `?list=...` response shape:
+//
+//	{"list":{"string":["table1","table2"]}}
+type featureTypeListResponse struct {
+	List struct {
+		Strings []string `json:"string"`
+	} `json:"list"`
+}
+
+// GetFeatureTypeList lists feature-type names in a datastore using context.Background.
+// See [GeoServer.GetFeatureTypeListContext].
+func (g *GeoServer) GetFeatureTypeList(workspaceName string, datastoreName string, kind FeatureTypeListKind) (names []string, err error) {
+	return g.GetFeatureTypeListContext(context.Background(), workspaceName, datastoreName, kind)
+}
+
+// GetFeatureTypeListContext is the context-aware variant of [GeoServer.GetFeatureTypeList].
+//
+// kind controls the GeoServer `?list=` query parameter; if empty it defaults
+// to [FeatureTypeListAll].
+func (g *GeoServer) GetFeatureTypeListContext(ctx context.Context, workspaceName string, datastoreName string, kind FeatureTypeListKind) (names []string, err error) {
+	if kind == "" {
+		kind = FeatureTypeListAll
+	}
+	targetURL := g.featureTypesURL(workspaceName, datastoreName)
+	httpRequest := HTTPRequest{
+		Method: getMethod,
+		Accept: jsonType,
+		URL:    targetURL,
+		Query:  map[string]string{"list": string(kind)},
+	}
+	response, responseCode := g.DoRequestContext(ctx, httpRequest)
+	if responseCode != statusOk {
+		return nil, g.GetError(responseCode, response)
+	}
+	var body featureTypeListResponse
+	if err = g.DeSerializeJSON(response, &body); err != nil {
+		return nil, fmt.Errorf("GetFeatureTypeList: decode: %w", err)
+	}
+	return body.List.Strings, nil
 }
 
 // GetFeatureTypes lists feature types using context.Background.

--- a/feature_types_test.go
+++ b/feature_types_test.go
@@ -93,6 +93,53 @@ func TestGeoserverImplemetFeatureTypeService(t *testing.T) {
 	assert.True(t, check)
 }
 
+// TestGetFeatureTypeList_Available verifies that a freshly-created PostGIS
+// datastore reports its tables under the `available` listing (tables present
+// in the DB but not yet configured as feature types in GeoServer).
+func TestGetFeatureTypeList_Available(t *testing.T) {
+	before()
+	const ws = "ftlist_ws"
+	const ds = "ftlist_pg"
+
+	if _, err := gsCatalog.CreateWorkspace(ws); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("preconditions: create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = gsCatalog.DeleteWorkspace(ws, true)
+	})
+
+	conn := DatastoreConnection{
+		Name:   ds,
+		Host:   "postgis",
+		Port:   5432,
+		Type:   "postgis",
+		DBName: "gis",
+		DBUser: "golang",
+		DBPass: "golang",
+	}
+	created, err := gsCatalog.CreateDatastore(conn, ws)
+	if !created || err != nil {
+		t.Fatalf("preconditions: create datastore: created=%v err=%v", created, err)
+	}
+
+	available, err := gsCatalog.GetFeatureTypeList(ws, ds, FeatureTypeListAvailable)
+	assert.NoError(t, err)
+	// The seeded `public.lbldyt` table should be in the available list.
+	found := false
+	for _, n := range available {
+		if n == "lbldyt" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected seeded `lbldyt` in available list, got %v", available)
+
+	// configured should be empty (nothing has been published yet).
+	configured, err := gsCatalog.GetFeatureTypeList(ws, ds, FeatureTypeListConfigured)
+	assert.NoError(t, err)
+	assert.Empty(t, configured)
+}
+
 // TestCreateFeatureType creates a workspace + PostGIS datastore (against the
 // compose-managed PostGIS host `postgis:5432`, DB `gis`) then registers a
 // feature type pointing at the seeded `public.lbldyt` table.

--- a/feature_types_unit_test.go
+++ b/feature_types_unit_test.go
@@ -63,3 +63,48 @@ func TestFeatureTypes_FeatureTypeServiceImpl(t *testing.T) {
 	var _ FeatureTypeService = (*GeoServer)(nil)
 	var _ FeatureTypeServiceWithContext = (*GeoServer)(nil)
 }
+
+func TestFeatureTypes_GetFeatureTypeList_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/workspaces/topp/datastores/states_pg/featuretypes", r.URL.Path)
+		assert.Equal(t, "available", r.URL.Query().Get("list"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"list":{"string":["counties","cities","states"]}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	got, err := gs.GetFeatureTypeListContext(context.Background(), "topp", "states_pg", FeatureTypeListAvailable)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"counties", "cities", "states"}, got)
+}
+
+func TestFeatureTypes_GetFeatureTypeList_DefaultKind(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Empty kind must default to "all".
+		assert.Equal(t, "all", r.URL.Query().Get("list"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"list":{"string":[]}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	got, err := gs.GetFeatureTypeListContext(context.Background(), "topp", "states_pg", "")
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestFeatureTypes_GetFeatureTypeList_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "no such datastore")
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	_, err := gs.GetFeatureTypeListContext(context.Background(), "topp", "missing_ds", FeatureTypeListAll)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Ports the feature-type discovery endpoint that #17 (Wichert Akkerman / Woven Planet, Feb 2022) proposed but never landed. Refactored to fit the v1.1 idiom: \`*Context\` twin, typed \`FeatureTypeListKind\` enum, parallel \`*WithContext\` interface entry.

After deduplicating PR #17 against what v1.1 + #37 already delivered (stdlib \`http.MethodGet\`/\`StatusOK\`, logger architecture, go modules, Docker modernization, \`DatastoreConnection.Options\` for arbitrary connection params), this single endpoint is the only piece of new functionality worth bringing forward.

## What's added

\`\`\`go
gs.GetFeatureTypeList(ws, ds, geoserver.FeatureTypeListAvailable)
gs.GetFeatureTypeListContext(ctx, ws, ds, geoserver.FeatureTypeListAll)
\`\`\`

Calls \`GET /rest/workspaces/{ws}/datastores/{ds}/featuretypes?list={kind}\` and returns the flat list of feature-type names. \`FeatureTypeListKind\` values:

| Constant | \`?list=\` | Meaning |
|---|---|---|
| \`FeatureTypeListConfigured\` | \`configured\` | Feature types already published in GeoServer |
| \`FeatureTypeListAvailable\` | \`available\` | Tables in the underlying datastore not yet published |
| \`FeatureTypeListAvailableWithGeom\` | \`available_with_geom\` | Like \`available\` but only tables with a geometry column |
| \`FeatureTypeListAll\` (default for empty) | \`all\` | configured ∪ available |

Used together with \`CreateFeatureType\` (added in #37), this gives callers a discover-and-publish workflow:

\`\`\`go
available, _ := gs.GetFeatureTypeList(ws, ds, geoserver.FeatureTypeListAvailable)
for _, table := range available {
    _, _ = gs.CreateFeatureType(ws, ds, &geoserver.FeatureType{Name: table, NativeName: table, Srs: "EPSG:4326"})
}
\`\`\`

## What's NOT ported

PR #17 also touched:

- \`getMethod\` → \`http.MethodGet\`, \`statusOk\` → \`http.StatusOK\` — already done in v1.1.
- Logger removal — v1.1 has its own \`*Logger\` slog wrapper.
- Travis → GitHub Actions, Gopkg → go modules, Docker simplification — already done in v1.1.
- \`DatastoreConnection.Schema, MinConnections, MaxConnections\` typed fields — redundant with the \`Options []Entry\` mechanism added in #37 for the same use case (\`{Key: \"max connections\", Value: \"5\"}\`).
- \`wms.ParseCapabilities\` returning \`error\` — v1.1 has \`ParseCapabilitiesE\`.

## Test plan

- httptest unit tests cover OK / 404 / empty-kind-defaults-to-all / request-shape (URL path, \`list\` query param).
- Integration test creates a workspace + PostGIS datastore against the compose stack and asserts:
  - the seeded \`public.lbldyt\` table appears under \`FeatureTypeListAvailable\`
  - \`FeatureTypeListConfigured\` returns empty (nothing published yet)

Local verification on a fresh \`make compose-up\` stack: lint clean, \`make test-unit\` green, \`make test-integration\` green.

- [ ] \`Lint\`
- [ ] \`Unit tests (Go 1.23)\`
- [ ] \`Unit tests (Go 1.25)\`
- [ ] \`govulncheck\`
- [ ] \`Analyze (Go)\`
- [ ] \`GeoServer 2.27.4\`
- [ ] \`GeoServer 2.28.0\`