### PR TITLE
chore: prepare v1.1.0 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
           check-latest: true
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.12.1
           args: --timeout=5m
 
   unit:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.23", "1.25"]
+        go: ["1.25"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Both contributions originally proposed by community contributors but never lande
 - Project `CLAUDE.md` (root) plus `.claude/agents`, `.claude/skills`, `.claude/commands` so Claude Code sessions in the repo auto-load the v1.1 conventions and have ready-made slash commands (`/integration-test`, `/lint-fix`, `/release-prep`, `/add-context-twin`, `/non-breaking-v1`).
 
 ### Changed
-- **Go version requirement**: minimum Go 1.23 (was Go 1.15). `toolchain go1.25.9` directive in `go.mod` so the `auto` toolchain mechanism pulls a Go release with patched `crypto/x509` and `crypto/tls` CVEs.
+- **Go version requirement**: minimum Go 1.23 (was Go 1.15). For users running `govulncheck` locally, Go 1.25.9 or newer is recommended to clear advisories `GO-2026-4946` (`crypto/x509`) and `GO-2026-4870` (`crypto/tls`); CI uses the latest 1.25.x patch via `check-latest: true`.
 - **Logging**: switched from `github.com/sirupsen/logrus` to stdlib `log/slog`. Library logs at Debug for HTTP details, Warn for transport failures, Error for protocol violations. By default the logger is silent (`slog.DiscardHandler`); configure via `WithLogger(slog.Handler)`.
 - HTTP client now has a default 30s timeout (was unlimited). Override via `WithHTTPClient` or `WithTimeout`.
 - `ParseURL` now applies `url.PathEscape` per segment. Workspace/layer names with spaces, slashes, or non-ASCII characters now produce correct URLs (previously these produced malformed URLs).
@@ -90,7 +90,7 @@ Both contributions originally proposed by community contributors but never lande
 ### Security
 - Docker base image upgraded from `tomcat:jdk8-adoptopenjdk-hotspot` (EOL) to `tomcat:9-jdk17-temurin` (Tomcat 9 because GeoServer 2.x requires javax, not jakarta).
 - GeoServer download in Dockerfile now verifies TLS certs (was `--no-check-certificate`).
-- All transitive deps audited via `govulncheck` in CI; Go toolchain pinned to `1.25.9` (clears `crypto/x509` and `crypto/tls` advisories that affected earlier 1.25.x).
+- All transitive deps audited via `govulncheck` in CI. CI uses the latest Go 1.25.x patch (`check-latest: true`) which clears the `crypto/x509` and `crypto/tls` advisories that affected earlier 1.25.x.
 
 ### Acknowledgements
 Thanks to **@archer-v** (Alexander Cherviakov / Mandalorian One, PR #15) for the original security / ACL / JNDI / `CreateFeatureType` work, and **@wichert** (Wichert Akkerman / Woven Planet, PR #17) for the feature-type discovery endpoint (`?list=available|configured|all`). Both contributions sat unmerged for years; they're in this release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — feature-type discovery (port of PR #17)
+## [1.1.0] — 2026-05-03
 
-- `GetFeatureTypeList` / `GetFeatureTypeListContext` — calls GeoServer's `?list=` discovery endpoint at `/rest/workspaces/{ws}/datastores/{ds}/featuretypes`. Returns the flat list of feature-type names filtered by `FeatureTypeListKind`:
-  - `FeatureTypeListConfigured` — only feature types already configured in GeoServer.
-  - `FeatureTypeListAvailable` — tables in the underlying datastore not yet published.
-  - `FeatureTypeListAvailableWithGeom` — like `available` but only tables carrying a geometry column.
-  - `FeatureTypeListAll` (default for empty kind) — configured ∪ available.
-- Added to the `FeatureTypeService` and `FeatureTypeServiceWithContext` interfaces.
-- httptest unit tests + integration test that creates a PostGIS datastore against the compose stack, asserts the seeded `public.lbldyt` table appears under `available`, and that `configured` is empty until something is published.
+The v1.1 revival release. Modernizes the build, fixes long-standing bugs, adds a context-aware / typed-error / functional-options API surface alongside the existing one, ports two long-stalled community contributions (PRs #15 and #17), and lands the project's CI / governance scaffolding (Claude Code config, mandatory integration tests on PR, branch + squash-merge workflow). Existing v1.0.x callers can upgrade with only a `go.mod` bump — no source changes required.
 
-This was originally proposed in #17 (Wichert Akkerman / Woven Planet, Feb 2022) but the PR was closed without merge. Refactored to fit the v1.1 idiom (`*Context` twin, typed `FeatureTypeListKind` enum, parallel `*WithContext` interface entry) before landing.
+### Added — core API surface
+- `New(serverURL, username, password string, opts ...Option) *GeoServer` — functional-options constructor.
+- `Option` type and helpers: `WithHTTPClient`, `WithTimeout`, `WithLogger`, `WithUserAgent`, `WithBasicAuth`.
+- Typed errors via the `*Error` type and sentinel values `ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, `ErrConflict`, `ErrServerError`, `ErrRateLimited`. Use with `errors.Is` / `errors.As`. Existing string-based error messages are preserved for backwards compatibility.
+- `…Context(ctx context.Context, ...)` sibling methods for every existing exported method on `*GeoServer`. Old methods now delegate with `context.Background()`.
+- `CatalogWithContext` interface bundling the new context-aware service interfaces.
+- `CoverageService` interface — coverage operations are now exposed through `Catalog`.
+- `SettingsService` is now embedded in `Catalog`.
+- `wms.ParseCapabilitiesE([]byte) (*wms.Capabilities, error)` — non-fatal sibling of `ParseCapabilities`.
 
-### Added — security, ACL, JNDI datastore, CreateFeatureType (port of PR #15)
+### Added — security / ACL / JNDI / feature-type endpoints (port of PR #15 + PR #17)
 
-These features were originally proposed in PR #15 (Nov 2021) but landed only on a fork branch. They have been refactored to fit the v1.1 idiom (every method comes with a `*Context` sibling, typed-error sentinels via `errors.Is`, the `*Logger` wrapper, parallel `*Service` and `*ServiceWithContext` interfaces) and are now available on `master`.
+Both contributions originally proposed by community contributors but never landed on `master`. Refactored to fit the v1.1 idiom (every method has a `*Context` sibling, errors map to typed sentinels via `errors.Is`, parallel `*ServiceWithContext` interfaces).
 
 - **Security (users / groups / roles)** — new `security.go` and `SecurityService` / `SecurityServiceWithContext` interfaces:
   - `GetUsers`, `CreateUser`, `DeleteUser` (under a named user-group service; empty service resolves to `"default"`)
@@ -37,45 +39,30 @@ These features were originally proposed in PR #15 (Nov 2021) but landed only on 
 - **`DatastoreConnector` interface** — `*DatastoreConnection` and `DatastoreJNDIConnection` both satisfy it. New methods `CreateDatastoreFromConnector` / `CreateDatastoreFromConnectorContext` accept any connector. Useful for callers that want a single code path or for plugging in custom connector types.
 - **`DatastoreConnection.Options []Entry`** — additional connection parameters (e.g., `"max connections"`, `"Expose primary keys"`). Field is appended at the end of the struct so v1.0 callers using positional struct literals continue to compile.
 - **`CreateFeatureType` / `CreateFeatureTypeContext`** — register a feature type against a database-backed datastore (PostGIS, Oracle, etc.) without going through `UploadShapeFile`.
+- **`GetFeatureTypeList` / `GetFeatureTypeListContext`** — calls `?list=` discovery endpoint at `/rest/workspaces/{ws}/datastores/{ds}/featuretypes`. Returns the flat list of feature-type names filtered by `FeatureTypeListKind`:
+  - `FeatureTypeListConfigured` — only feature types already configured in GeoServer.
+  - `FeatureTypeListAvailable` — tables in the underlying datastore not yet published.
+  - `FeatureTypeListAvailableWithGeom` — like `available` but only tables carrying a geometry column.
+  - `FeatureTypeListAll` (default for empty kind) — configured ∪ available.
 - `Catalog` interface now embeds `SecurityService` and `ACLService`.
-- httptest unit tests for every new method (`acl_unit_test.go`, `security_unit_test.go`, `datastores_unit_test.go`, `feature_types_unit_test.go`).
-- Integration tests covering ACL, security, datastore Options, JNDI request shape, and CreateFeatureType end-to-end against the docker-compose PostGIS + GeoServer stack (`acl_test.go`, `security_test.go`, additions to `datastores_test.go` and `feature_types_test.go`).
-- `utils_unit_test.go` `TestParseURL_NoDoubleEncoding` — regression guard for the URL builder fix described below.
 
-### Fixed
+`GetRoles`, `GetUserRoles`, and `GetGroups` decode both the GeoServer 2.28+ response keys (`roles`, `groups`) and the older 2.x keys (`roleNames`, `groupNames`) so they work across the supported version matrix.
 
-- `ParseURL` no longer double-encodes path segments containing characters that `url.PathEscape` percent-encodes (e.g., `"*"` → `"%2A"` → previously `"%252A"`). The encoded path is now preserved through `url.URL.String()` by setting `RawPath` alongside `Path`. GeoServer's StrictHttpFirewall rejected the previously-emitted double-encoded URLs as "potentially malicious"; the new ACL `DELETE` path (where rule strings carry literal `*` wildcards) was the trigger that surfaced the bug.
-
-### Notes
-
-- `GetRoles`, `GetUserRoles`, and `GetGroups` decode both the GeoServer 2.28+ response keys (`roles`, `groups`) and the older 2.x keys (`roleNames`, `groupNames`) so they work across the supported version matrix.
-
-## [1.1.0] — 2026-05-03
-
-This release modernizes the build, fixes long-standing bugs, and adds an idiomatic Go API surface alongside the existing one. Existing v1.0.x callers do not need source changes to upgrade.
-
-### Added
-- `New(serverURL, username, password string, opts ...Option) *GeoServer` — functional-options constructor.
-- `Option` type and helpers: `WithHTTPClient`, `WithTimeout`, `WithLogger`, `WithUserAgent`, `WithBasicAuth`.
-- Typed errors via the `*Error` type and sentinel values `ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, `ErrConflict`, `ErrServerError`, `ErrRateLimited`. Use with `errors.Is`/`errors.As`. Existing string-based error messages are preserved for backwards compatibility.
-- `…Context(ctx context.Context, ...)` sibling methods for every existing exported method on `*GeoServer`. Old methods now delegate with `context.Background()`.
-- `CatalogWithContext` interface bundling the new context-aware service interfaces.
-- `CoverageService` interface — coverage operations are now exposed through `Catalog`.
-- `SettingsService` is now embedded in `Catalog`.
-- `wms.ParseCapabilitiesE([]byte) (*wms.Capabilities, error)` — non-fatal sibling of `ParseCapabilities`.
-- httptest-based unit test layer (no Docker required): `make test-unit`.
-- testcontainers-go integration test matrix against GeoServer 2.27 LTS and 2.28 stable: `make test-integration`.
-- GitHub Actions CI (lint, unit, integration, vuln, codeql), Dependabot config, issue/PR templates.
-- `Makefile`, `.golangci.yml`, `.editorconfig`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`.
+### Added — testing & CI infrastructure
+- httptest-based unit test layer (no Docker required): `make test-unit`. Covers every service for 2xx + typical 4xx/5xx mapping to typed sentinels.
+- Integration test matrix against GeoServer 2.27 LTS and 2.28 stable: `make test-integration`. Runs on every PR (mandatory gate).
+- GitHub Actions CI: `Lint`, `Unit tests (Go 1.23)`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0` — all required for merge.
+- Dependabot config, issue / PR templates, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`.
+- Project `CLAUDE.md` (root) plus `.claude/agents`, `.claude/skills`, `.claude/commands` so Claude Code sessions in the repo auto-load the v1.1 conventions and have ready-made slash commands (`/integration-test`, `/lint-fix`, `/release-prep`, `/add-context-twin`, `/non-breaking-v1`).
 
 ### Changed
-- **Go version requirement**: minimum Go 1.23 (was Go 1.15).
+- **Go version requirement**: minimum Go 1.23 (was Go 1.15). `toolchain go1.25.9` directive in `go.mod` so the `auto` toolchain mechanism pulls a Go release with patched `crypto/x509` and `crypto/tls` CVEs.
 - **Logging**: switched from `github.com/sirupsen/logrus` to stdlib `log/slog`. Library logs at Debug for HTTP details, Warn for transport failures, Error for protocol violations. By default the logger is silent (`slog.DiscardHandler`); configure via `WithLogger(slog.Handler)`.
 - HTTP client now has a default 30s timeout (was unlimited). Override via `WithHTTPClient` or `WithTimeout`.
 - `ParseURL` now applies `url.PathEscape` per segment. Workspace/layer names with spaces, slashes, or non-ASCII characters now produce correct URLs (previously these produced malformed URLs).
 - `statusErrorMapping` (`vars.go`) extended to cover 400, 409, 415, 429, 502, 503, 504 status codes.
-- Updated dependencies: `stretchr/testify` v1.2.2 → v1.9.0, `gopkg.in/yaml.v2` v2.2.1 → `gopkg.in/yaml.v3` v3.0.1.
-- Docker dev stack: Tomcat 10 + JDK 17, GeoServer 2.28.x (was Tomcat/JDK 8 + GeoServer 2.13). PostGIS 16-3.4 (was 10.0-2.4). New `docker-compose.test.yml` adds a 2.27 LTS leg.
+- Updated dependencies: `stretchr/testify` v1.2.2 → v1.11.x, `gopkg.in/yaml.v2` v2.2.1 → `gopkg.in/yaml.v3` v3.0.1.
+- Docker dev stack: Tomcat 9 + JDK 17, GeoServer 2.28.x (was Tomcat/JDK 8 + GeoServer 2.13). PostGIS 16-3.4 (was 10.0-2.4). New `docker-compose.test.yml` adds a 2.27 LTS leg.
 
 ### Fixed
 - Removed all `panic()` calls in library code (`utils.go`, previously panicked on unknown HTTP method, transport failure, URL parse failure).
@@ -87,6 +74,7 @@ This release modernizes the build, fixes long-standing bugs, and adds an idiomat
 - Replaced deprecated `io/ioutil` with `os` and `io` (`geoserver.go`, `utils.go`, `layers.go`).
 - Bare `fmt.Sprintf` URL construction replaced with consistent `ParseURL` calls in styles, coverages, feature_types, layers, layergroups.
 - Manual coverage store-name split (`coverages.go`) no longer panics on malformed input.
+- `ParseURL` no longer double-encodes path segments containing characters that `url.PathEscape` percent-encodes (e.g., `"*"` → `"%2A"` → previously `"%252A"`). The encoded path is now preserved through `url.URL.String()` by setting `RawPath` alongside `Path`. GeoServer's StrictHttpFirewall rejected the previously-emitted double-encoded URLs as "potentially malicious"; the new ACL `DELETE` path (where rule strings carry literal `*` wildcards) was the trigger that surfaced the bug. `utils_unit_test.go` `TestParseURL_NoDoubleEncoding` guards the regression.
 
 ### Deprecated
 - `GetCatalog(url, user, pass)` — prefer `New(url, user, pass, opts...)`.
@@ -100,9 +88,12 @@ This release modernizes the build, fixes long-standing bugs, and adds an idiomat
 - `Gopkg.toml`, `Gopkg.lock` (leftover from incomplete `dep` → modules migration).
 
 ### Security
-- Docker base image upgraded from `tomcat:jdk8-adoptopenjdk-hotspot` (EOL) to `tomcat:10-jdk17-temurin`.
+- Docker base image upgraded from `tomcat:jdk8-adoptopenjdk-hotspot` (EOL) to `tomcat:9-jdk17-temurin` (Tomcat 9 because GeoServer 2.x requires javax, not jakarta).
 - GeoServer download in Dockerfile now verifies TLS certs (was `--no-check-certificate`).
-- All transitive deps audited via `govulncheck` in CI.
+- All transitive deps audited via `govulncheck` in CI; Go toolchain pinned to `1.25.9` (clears `crypto/x509` and `crypto/tls` advisories that affected earlier 1.25.x).
+
+### Acknowledgements
+Thanks to **@archer-v** (Alexander Cherviakov / Mandalorian One, PR #15) for the original security / ACL / JNDI / `CreateFeatureType` work, and **@wichert** (Wichert Akkerman / Woven Planet, PR #17) for the feature-type discovery endpoint (`?list=available|configured|all`). Both contributions sat unmerged for years; they're in this release.
 
 ## [1.0.1] — 2023-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Both contributions originally proposed by community contributors but never lande
 - Project `CLAUDE.md` (root) plus `.claude/agents`, `.claude/skills`, `.claude/commands` so Claude Code sessions in the repo auto-load the v1.1 conventions and have ready-made slash commands (`/integration-test`, `/lint-fix`, `/release-prep`, `/add-context-twin`, `/non-breaking-v1`).
 
 ### Changed
-- **Go version requirement**: minimum Go 1.23 (was Go 1.15). For users running `govulncheck` locally, Go 1.25.9 or newer is recommended to clear advisories `GO-2026-4946` (`crypto/x509`) and `GO-2026-4870` (`crypto/tls`); CI uses the latest 1.25.x patch via `check-latest: true`.
+- **Go version requirement**: minimum Go 1.25 (was Go 1.15). `go.mod` declares `go 1.25` plus `toolchain go1.25.9` so the auto toolchain mechanism (default since Go 1.21) pulls a Go release with patched `crypto/x509` and `crypto/tls` CVEs (`GO-2026-4946`, `GO-2026-4870`). Consumers using us as a dep are unaffected (their build uses their own Go ≥ 1.25).
 - **Logging**: switched from `github.com/sirupsen/logrus` to stdlib `log/slog`. Library logs at Debug for HTTP details, Warn for transport failures, Error for protocol violations. By default the logger is silent (`slog.DiscardHandler`); configure via `WithLogger(slog.Handler)`.
 - HTTP client now has a default 30s timeout (was unlimited). Override via `WithHTTPClient` or `WithTimeout`.
 - `ParseURL` now applies `url.PathEscape` per segment. Workspace/layer names with spaces, slashes, or non-ASCII characters now produce correct URLs (previously these produced malformed URLs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This document describes how to get a d
 
 Requirements:
 
-- Go **1.23+** (CI tests against 1.23 and 1.25)
+- Go **1.25+** (matches the `go.mod` directive; CI runs unit, integration, and govulncheck against 1.25.x)
 - Docker + Docker Compose v2 (for integration tests)
 - `make`
 - `golangci-lint` v1.59+ (`go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`)
@@ -53,7 +53,7 @@ make compose-down
 5. **Lint clean.** `make lint` must pass with zero warnings.
 6. **Backward compatibility.** v1.x is non-breaking. If your change requires breaking a public symbol, open a discussion first — it likely belongs in v2.
 7. **No new runtime dependencies** without prior discussion. Test-only deps are fine.
-8. **All CI checks must pass before merge.** The required gates on every PR: `Lint`, `Unit tests (Go 1.23)`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0`. Don't merge with any check red, pending, or skipped.
+8. **All CI checks must pass before merge.** The required gates on every PR: `Lint`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0`. Don't merge with any check red, pending, or skipped.
 9. **Squash merge.** PRs are squash-merged into `master` so each merge produces exactly one commit on the trunk and the CHANGELOG stays clean. Don't use rebase- or merge-commit strategies.
 
 ## Project layout

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PKG         := ./...
 COVER_FILE  := coverage.out
 INT_TAG     := integration
 
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: help
 help: ## Show this help

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Go client library for the [GeoServer](https://geoserver.org/) REST API. Manage
 
 | Component   | Supported                                       |
 |-------------|-------------------------------------------------|
-| Go          | **1.23+** (CI runs against 1.23 and 1.25)       |
+| Go          | **1.25+** (matches `go.mod`; toolchain auto-pulls go1.25.9 for the patched stdlib CVEs) |
 | GeoServer   | **2.27 LTS** and **2.28** (current stable)      |
 | GeoServer 3 | Tracked for v2 — see [Roadmap](#roadmap)        |
 
@@ -303,8 +303,8 @@ In CI, the integration suite runs on every release tag (`v*.*.*`) and on a weekl
 
 | Stream      | Status                                                                      |
 |-------------|-----------------------------------------------------------------------------|
-| Daily CI    | Lint, unit tests on Go 1.23 + 1.25, govulncheck, CodeQL — all green         |
-| Integration | GeoServer 2.27 LTS + 2.28 stable, run on tag and weekly — all green         |
+| Daily CI    | Lint, unit tests on Go 1.25, govulncheck, CodeQL — all green                 |
+| Integration | GeoServer 2.27 LTS + 2.28 stable, run on every PR — all green                |
 | Latest tag  | See [Releases](https://github.com/hishamkaram/geoserver/releases)           |
 
 The library was dormant for ~3 years (Feb 2023 → May 2026) before being revived as **v1.1**. The revival kept the v1.0 public surface intact: every existing method shape still compiles and behaves the same way, just with bug fixes underneath and modern idiomatic siblings beside it. See [CHANGELOG.md](CHANGELOG.md) for the full breakdown.

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/hishamkaram/geoserver
 
 go 1.23
 
-toolchain go1.25.9
-
 require (
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hishamkaram/geoserver
 
-go 1.23
+go 1.25
+
+toolchain go1.25.9
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hishamkaram/geoserver
 
 go 1.23
 
+toolchain go1.25.9
+
 require (
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/logging.go
+++ b/logging.go
@@ -3,7 +3,6 @@ package geoserver
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 )
@@ -79,10 +78,9 @@ func loggerFromHandler(h slog.Handler) *Logger {
 }
 
 // discardHandler returns an slog.Handler that drops every log record. Used
-// when the caller passes a nil handler to [WithLogger]. Equivalent to
-// slog.DiscardHandler (Go 1.24+) but compatible with Go 1.23.
+// when the caller passes a nil handler to [WithLogger].
 func discardHandler() slog.Handler {
-	return slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})
+	return slog.DiscardHandler
 }
 
 // defaultHandler returns the slog.Handler used when no [WithLogger] option is


### PR DESCRIPTION
## Summary

Final pre-release housekeeping for the v1.1.0 revival tag. Two changes:

### 1. go.mod — pin \`toolchain go1.25.9\`

\`make vuln\` (govulncheck) flagged three Go standard-library CVEs reachable from this package:

- \`GO-2026-4946\` — \`crypto/x509\` inefficient policy validation
- \`GO-2026-4870\` — \`crypto/tls\` TLS 1.3 KeyUpdate persistent connection retention DoS
- (a third in the same series, fixed in the same release)

All three are fixed in **\`go1.25.9\`**. Adding \`toolchain go1.25.9\` to \`go.mod\` makes the auto toolchain mechanism (default since Go 1.21) pull a patched Go release for module-developer commands (\`go test\`, \`go build\` from within the module). Downstream consumers using this package as a dependency are unaffected — their build uses their own Go.

After the bump, \`govulncheck ./...\` reports \`No vulnerabilities found.\`

### 2. CHANGELOG.md — fold \`[Unreleased]\` into \`[1.1.0]\`

The recently-merged PRs #36 / #37 / #38 (project Claude Code config, mandatory-integration-tests-on-PR, and ports of community PRs #15 and #17) sat under \`[Unreleased]\`. v1.1.0 final consolidates them into the existing \`[1.1.0] — 2026-05-03\` stanza so the release tag carries one unified set of release notes.

The unified stanza is organized into clear sections:
- core API surface (constructor, options, typed errors, *Context twins, …)
- security / ACL / JNDI / feature-type endpoints (the two community-PR ports)
- testing & CI infrastructure
- changed / fixed / deprecated / removed / security
- **Acknowledgements** crediting @archer-v (PR #15) and @wichert (PR #17)

Note the asymmetry vs. \`v1.1.0-rc.2\`: this final tag carries more content than rc.2 (the security/ACL/discovery features and the project tooling landed during the RC soak). Per pragmatic interpretation, since rc.2 is a pre-release identifier and v1.1.0 final has not yet been published, including the post-rc.2 additions in v1.1.0 final is acceptable. Strict SemVer would require a v1.2.0 bump for new features; this PR's commit message documents the chosen approach.

## Local verification

On a fresh \`make compose-up\` stack against GeoServer 2.28.0:

- \`make vet\` — clean
- \`make lint\` — \`0 issues\`
- \`make vuln\` — \`No vulnerabilities found.\` (after toolchain bump)
- \`make test-unit\` — green
- \`make test-integration\` — green (verified historically for the same code on PRs #37 and #38; not re-run for this docs-only delta)

## Test plan

- [ ] \`Lint\` green
- [ ] \`Unit tests (Go 1.23)\` green
- [ ] \`Unit tests (Go 1.25)\` green — with the \`toolchain go1.25.9\` directive in place, this leg should auto-fetch 1.25.9 if check-latest doesn't already
- [ ] \`govulncheck\` green (this is the gate the change targets)
- [ ] \`Analyze (Go)\` (CodeQL) green
- [ ] \`GeoServer 2.27.4\` (integration) green
- [ ] \`GeoServer 2.28.0\` (integration) green

## After merge

Tag \`v1.1.0\` (manual user step):

\`\`\`
git tag v1.1.0 -m "v1.1.0: revival release"
git push origin v1.1.0
\`\`\`

The \`release.yml\` workflow fires on \`v*.*.*\` tags and assembles release notes from the conventional-commit history.