### PR TITLE
feat(v2): scaffold v2 module with workspaces reference resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,28 @@ jobs:
           path: coverage.out
           retention-days: 14
 
+  unit-v2:
+    name: Unit tests v2 (Go 1.25)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./v2
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          check-latest: true
+          cache: true
+          cache-dependency-path: v2/go.sum
+      - run: go mod download
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Unit tests
+        run: go test -race -short ./...
+
   vuln:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file is auto-loaded by Claude Code at the start of every session in this re
 ## Versioning regime
 
 - **v1.1.x is non-breaking.** No removed exports. No signature changes to existing public APIs. Deprecate via `// Deprecated:` and add a sibling that delegates to the replacement. **Why:** v1.0 callers must be able to upgrade with only a `go.mod` bump.
-- **v2 lives at module path `github.com/hishamkaram/geoserver/v2`** under a `/v2/` subdirectory once it begins. v2 will fix the v1 wounds that cannot be healed without breaking changes (exported mutable fields, four-positional-arg `PublishPostgisLayer`, etc.).
+- **v2 lives at module path `github.com/hishamkaram/geoserver/v2`** under the `/v2/` subdirectory (its own `go.mod`). Currently in development with the `Workspaces` resource as a reference; other resources port in subsequent PRs. Run `make test-v2-unit` for v2 tests (separate from `make test-unit`, which is v1 only). v2 fixes the v1 wounds that cannot be healed without breaking changes (exported mutable fields, four-positional-arg `PublishPostgisLayer`, etc.).
 - **Don't auto-tag releases.** Tagging is an explicit user action — never run `git tag` or push tags from a Claude session without explicit user authorization.
 
 ## Test split

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,14 @@ compose-test-down: ## tear down integration-test compose
 examples: ## compile-check every example under examples/
 	$(GO) build -o /dev/null ./examples/...
 
+.PHONY: test-v2-unit
+test-v2-unit: ## v2 module unit tests (no Docker)
+	cd v2 && $(GO) test -race -short -timeout=60s ./...
+
+.PHONY: build-v2
+build-v2: ## v2 module build + vet
+	cd v2 && $(GO) build ./... && $(GO) vet ./...
+
 .PHONY: docs-check
 docs-check: ## sanity-check that README and docs/ cross-reference each other
 	@grep -q 'docs/architecture.md' README.md || { echo "README.md should link to docs/architecture.md"; exit 1; }

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — v2
+
+All notable changes to `github.com/hishamkaram/geoserver/v2` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). v2 ships independently of v1 (separate go.mod, separate `v2.x.y` tags).
+
+## [Unreleased]
+
+### Added
+
+- Initial scaffold. `*Client` immutable constructor (`New`) with functional options (`WithHTTPClient`, `WithTransport`, `WithBasicAuth`, `WithBearerToken`, `WithLogger`, `WithUserAgent`, `WithTimeout`, `WithHeader`).
+- Single error type `*APIError` with package sentinels: `ErrBadRequest`, `ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrMethodNotAllowed`, `ErrConflict`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`, `ErrBadGateway`, `ErrServiceUnavailable`, `ErrGatewayTimeout`. Match via `errors.Is` and `errors.As`.
+- `internal/transport/` package: `BuildURL` (PathEscape + RawPath preservation, ported from v1.1's bug-fixed algorithm), `DoJSON` (single chokepoint for REST calls), `AuthRoundTripper` and `HeaderRoundTripper` (auth and User-Agent attached via the transport stack rather than per-request).
+- `rest/workspaces/` reference sub-client: `List`, `Iter` (`iter.Seq2`), `Get`, `Create`, `Update`, `Delete`. httptest unit tests cover 2xx happy paths and 401/404/409/500 sentinel mapping plus the URL-escaping regression guard.
+
+No release tag yet; the module's first published tag will be `v2.0.0-alpha.1` when the surface is wide enough to warrant a soak.

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,99 @@
+# geoserver/v2
+
+> ⚠️ **In development.** v2 is a clean redesign of `github.com/hishamkaram/geoserver` for 2026-era idiomatic Go. The public API is not yet stable; only the `Workspaces` resource is implemented as a reference. **For production use today, use the v1 line:**
+>
+> ```go
+> import "github.com/hishamkaram/geoserver"          // v1 — stable, full surface
+> import "github.com/hishamkaram/geoserver/v2"       // v2 — in development
+> ```
+
+This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).
+
+## Design tenets
+
+v2 breaks v1's monolithic `*GeoServer` surface into a sub-client per resource, with a few lock-in decisions documented in `../ROADMAP.md`:
+
+- **Immutable `*Client`.** All fields private; no post-construction mutation. Concurrent use is safe.
+- **Mandatory `context.Context`** as first arg on every public method. No `Background` shims.
+- **Sub-client pattern.** `c.Workspaces.List(ctx, opts)` instead of v1's `gs.GetWorkspacesContext(ctx)`.
+- **Single error type** (`*APIError`) with package sentinels (`ErrNotFound`, `ErrConflict`, …). `errors.Is` and `errors.As` are the supported match styles.
+- **Auth via `http.RoundTripper`.** Basic / bearer auth attaches at construction; per-call paths don't re-authenticate. Custom RoundTrippers (OpenTelemetry, Vault-rotated creds, retry libs) layer naturally.
+- **Pagination via `iter.Seq2`.** `c.Workspaces.Iter(ctx, opts)` returns a `iter.Seq2[Workspace, error]`. Non-paginating endpoints fall back to single-page Seq2.
+- **Zero runtime third-party deps.** stdlib `net/http`, `encoding/json`, `encoding/xml`, `log/slog`, `context`, `iter` only.
+
+## Quick start
+
+```go
+package main
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "log/slog"
+    "os"
+    "time"
+
+    geoserver "github.com/hishamkaram/geoserver/v2"
+    "github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func main() {
+    c, err := geoserver.New("http://localhost:8080/geoserver/",
+        geoserver.WithBasicAuth("admin", "geoserver"),
+        geoserver.WithTimeout(10*time.Second),
+        geoserver.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, nil))),
+    )
+    if err != nil {
+        panic(err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    list, err := c.Workspaces.List(ctx, workspaces.ListOptions{})
+    if err != nil {
+        panic(err)
+    }
+    for _, ws := range list {
+        fmt.Println(ws.Name)
+    }
+
+    _, err = c.Workspaces.Get(ctx, "doesnotexist")
+    if errors.Is(err, geoserver.ErrNotFound) {
+        fmt.Println("workspace doesn't exist")
+    }
+}
+```
+
+## Resource status
+
+| Resource | v1 | v2 |
+|---|---|---|
+| Workspaces | full | **scaffolded** (reference resource) |
+| Datastores | full | not yet ported |
+| Coverages, coverage stores | full | not yet ported |
+| Feature types | full | not yet ported |
+| Layers, layer groups | full | not yet ported |
+| Styles | full | not yet ported |
+| Namespaces | full | not yet ported |
+| Settings | full | not yet ported |
+| Security (users, groups, roles) | full | not yet ported |
+| ACL | full | not yet ported |
+| About, capabilities | full | not yet ported |
+| WMS / WFS / WCS (OWS) | partial (WMS XML) | not yet ported |
+
+See [`../ROADMAP.md`](../ROADMAP.md) for the milestone checklist.
+
+## Contributing to v2
+
+Each resource port is its own PR. Use `rest/workspaces/` as the reference pattern:
+
+1. Define `types.go` — wire-format request/response structs, public option types.
+2. Define `<resource>.go` — `type Client struct{ core Core }`, `func New(core Core)`, methods (`List`, `Get`, `Create`, `Update`, `Delete`, optional `Iter`).
+3. Define `<resource>_test.go` — `httptest.Server`-based unit tests for 2xx + each relevant 4xx/5xx mapping.
+4. Wire into `*Client` in `../geoserver.go`.
+
+The `Core` interface in each subpackage is the abstraction over the parent `*Client`'s plumbing — it lets sub-clients issue requests without importing the root package (which would create an import cycle).
+
+See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for the general PR workflow.

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -1,0 +1,62 @@
+// Package geoserver is a Go client for the GeoServer REST API (v2 line).
+//
+// # Status
+//
+// v2 is in development. Only the Workspaces resource is currently
+// implemented as a reference; other resources (datastores, styles, layers,
+// layergroups, coverages, namespaces, settings, security, ACL, about,
+// capabilities, feature types) port in subsequent PRs following the same
+// pattern. Until v2 reaches v2.0.0, the v1 line remains the recommended
+// import for production use:
+//
+//	import "github.com/hishamkaram/geoserver"        // v1: stable, full surface
+//	import "github.com/hishamkaram/geoserver/v2"     // v2: in development
+//
+// See ../ROADMAP.md for the v2 milestones and ../docs/migration-v1-to-v2.md
+// for the v1 → v2 migration guide.
+//
+// # Design tenets
+//
+// v2 is a clean redesign that breaks v1's monolithic *GeoServer surface
+// into a sub-client per resource:
+//
+//   - Immutable [*Client]. All fields private. Configured via functional
+//     options at construction; no post-construction mutation. Concurrent
+//     use is safe.
+//   - Mandatory [context.Context] as first arg on every public method. No
+//     Background shims, no twin pairs.
+//   - Sub-client pattern. (*Client).Workspaces returns a per-resource
+//     client whose methods follow a consistent List / Get / Exists /
+//     Create / Update / Delete / Iter shape.
+//   - Single error type. Every HTTP error is a [*APIError] wrapping one
+//     of the package sentinels ([ErrNotFound], [ErrConflict], …) so
+//     errors.Is and errors.As are the supported match styles.
+//   - Auth via http.RoundTripper. Basic / bearer auth attaches to the
+//     transport layer once at construction; per-call paths don't
+//     re-authenticate. Custom RoundTrippers (OpenTelemetry, retry libs,
+//     Vault-rotated creds) layer naturally.
+//   - Streaming uploads. Resources that accept binary payloads take
+//     [io.Reader] and never slurp into memory.
+//   - Pagination via [iter.Seq2]. List endpoints expose Iter for
+//     range-over-func; non-paginating endpoints fall back to a
+//     single-page Seq2.
+//   - Zero runtime third-party dependencies. stdlib net/http,
+//     encoding/json, encoding/xml, log/slog, context, iter only.
+//     Test deps allowed.
+//
+// # Quick start
+//
+//	c, err := geoserver.New("http://localhost:8080/geoserver/",
+//	    geoserver.WithBasicAuth("admin", "geoserver"),
+//	    geoserver.WithTimeout(10*time.Second),
+//	)
+//	if err != nil {
+//	    return err
+//	}
+//
+//	ctx := context.Background()
+//	workspaces, err := c.Workspaces.List(ctx, workspaces.ListOptions{})
+//	if errors.Is(err, geoserver.ErrUnauthorized) {
+//	    // handle bad credentials
+//	}
+package geoserver

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -1,0 +1,122 @@
+package geoserver
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Sentinel errors. APIError.Is wraps these so callers can match status
+// codes via errors.Is(err, ErrNotFound) etc.
+//
+// The set mirrors v1's sentinel list; the Error type itself is renamed
+// (v1: *Error → v2: *APIError) and tightened — v2 does not preserve v1's
+// "abstract:%s\ndetails:%s\n" format because v2 is a clean break.
+var (
+	ErrBadRequest           = errors.New("geoserver: bad request")
+	ErrUnauthorized         = errors.New("geoserver: unauthorized")
+	ErrForbidden            = errors.New("geoserver: forbidden")
+	ErrNotFound             = errors.New("geoserver: not found")
+	ErrMethodNotAllowed     = errors.New("geoserver: method not allowed")
+	ErrConflict             = errors.New("geoserver: conflict")
+	ErrUnsupportedMediaType = errors.New("geoserver: unsupported media type")
+	ErrRateLimited          = errors.New("geoserver: rate limited")
+	ErrServerError          = errors.New("geoserver: internal server error")
+	ErrBadGateway           = errors.New("geoserver: bad gateway")
+	ErrServiceUnavailable   = errors.New("geoserver: service unavailable")
+	ErrGatewayTimeout       = errors.New("geoserver: gateway timeout")
+)
+
+// statusToSentinel maps HTTP status codes to package sentinel errors.
+var statusToSentinel = map[int]error{
+	http.StatusBadRequest:           ErrBadRequest,
+	http.StatusUnauthorized:         ErrUnauthorized,
+	http.StatusForbidden:            ErrForbidden,
+	http.StatusNotFound:             ErrNotFound,
+	http.StatusMethodNotAllowed:     ErrMethodNotAllowed,
+	http.StatusConflict:             ErrConflict,
+	http.StatusUnsupportedMediaType: ErrUnsupportedMediaType,
+	http.StatusTooManyRequests:      ErrRateLimited,
+	http.StatusInternalServerError:  ErrServerError,
+	http.StatusBadGateway:           ErrBadGateway,
+	http.StatusServiceUnavailable:   ErrServiceUnavailable,
+	http.StatusGatewayTimeout:       ErrGatewayTimeout,
+}
+
+// APIError represents a non-2xx response from GeoServer. The single error
+// type for the v2 module — every wire-level failure surfaces as
+// *APIError so callers can match either by sentinel ([errors.Is]) or by
+// inspecting fields ([errors.As]).
+type APIError struct {
+	// Op identifies the public operation that produced the error
+	// (e.g., "Workspaces.Create"). Set by the resource-client
+	// wrapper. Useful for logging.
+	Op string
+
+	// URL is the request URL.
+	URL string
+
+	// Method is the HTTP method.
+	Method string
+
+	// StatusCode is the HTTP status code from GeoServer.
+	StatusCode int
+
+	// Body is the response body, truncated to a fixed cap (8 KiB)
+	// to avoid unbounded retention. Useful for diagnostics; do not
+	// parse for control flow — use errors.Is against the package
+	// sentinels instead.
+	Body []byte
+}
+
+// Error returns a stable, parseable message of the form
+//
+//	geoserver: <Op> <Method> <URL>: <statusCode> <statusText>: <body-preview>
+//
+// Body preview is truncated to ~120 bytes.
+func (e *APIError) Error() string {
+	preview := string(e.Body)
+	if len(preview) > 120 {
+		preview = preview[:120] + "…"
+	}
+	op := e.Op
+	if op == "" {
+		op = "request"
+	}
+	return fmt.Sprintf("geoserver: %s %s %s: %d %s: %s",
+		op, e.Method, e.URL, e.StatusCode, http.StatusText(e.StatusCode), preview)
+}
+
+// Unwrap returns the sentinel for this status code, enabling errors.Is.
+func (e *APIError) Unwrap() error {
+	if sentinel, ok := statusToSentinel[e.StatusCode]; ok {
+		return sentinel
+	}
+	return nil
+}
+
+// Is reports whether target matches the sentinel for this APIError's
+// status code. Lets callers use errors.Is(err, ErrNotFound) directly on
+// an *APIError.
+func (e *APIError) Is(target error) bool {
+	if sentinel, ok := statusToSentinel[e.StatusCode]; ok && sentinel == target {
+		return true
+	}
+	return false
+}
+
+// newAPIError constructs an *APIError, truncating the body to bodyCap.
+const bodyCap = 8 << 10 // 8 KiB
+
+func newAPIError(op, method, url string, statusCode int, body []byte) *APIError {
+	if len(body) > bodyCap {
+		body = body[:bodyCap]
+	}
+	return &APIError{
+		Op:         op,
+		URL:        url,
+		Method:     method,
+		StatusCode: statusCode,
+		Body:       body,
+	}
+}

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -1,0 +1,208 @@
+package geoserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hishamkaram/geoserver/v2/internal/transport"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+const (
+	defaultUserAgent = "geoserver-go/v2"
+	defaultTimeout   = 30 * time.Second
+)
+
+// Client is the v2 GeoServer REST client. All fields are private; the
+// client is configured at construction via [Option] values and is
+// immutable thereafter. Concurrent use across goroutines is safe.
+//
+// Resource methods live on sub-clients accessed via the public fields:
+//
+//	Workspaces — workspace CRUD
+//	(more sub-clients as resources port; see ROADMAP.md)
+type Client struct {
+	core *clientCore
+
+	// Workspaces is the entry point for workspace operations.
+	Workspaces *workspaces.Client
+}
+
+// clientCore is the plumbing shared with every sub-client. Sub-clients
+// receive a pointer to this and call Do() to issue requests.
+type clientCore struct {
+	baseURL    string // ends with "/"
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// New constructs an immutable [*Client] for the GeoServer instance at
+// serverURL. serverURL must be a valid http:// or https:// URL, with or
+// without a trailing slash. Apply options for HTTP client, auth,
+// timeout, logging, headers.
+//
+// Returns an error if any option is invalid or serverURL fails to
+// parse — misconfiguration surfaces immediately rather than at
+// first-call time.
+func New(serverURL string, opts ...Option) (*Client, error) {
+	if serverURL == "" {
+		return nil, errors.New("geoserver: empty server URL")
+	}
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("geoserver: parse server URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("geoserver: server URL scheme must be http or https, got %q", parsed.Scheme)
+	}
+
+	cfg := &clientConfig{
+		timeout:   defaultTimeout,
+		userAgent: defaultUserAgent,
+		logger:    slog.New(slog.DiscardHandler),
+	}
+	for _, opt := range opts {
+		if optErr := opt(cfg); optErr != nil {
+			return nil, optErr
+		}
+	}
+
+	httpClient := buildHTTPClient(cfg)
+
+	base := serverURL
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+
+	core := &clientCore{
+		baseURL:    base,
+		httpClient: httpClient,
+		logger:     cfg.logger,
+	}
+
+	c := &Client{core: core}
+	c.Workspaces = workspaces.New(coreAdapter{core: core})
+	return c, nil
+}
+
+// buildHTTPClient resolves the user's transport options into a single
+// *http.Client whose Transport stack is:
+//
+//	HeaderRoundTripper(user-agent + extra headers) →
+//	    AuthRoundTripper(basic | bearer | none) →
+//	        cfg.transport or cfg.httpClient.Transport or http.DefaultTransport
+//
+// If cfg.httpClient is supplied, its Transport is the base and Timeout
+// carries through. Otherwise a fresh client is created with cfg.timeout.
+func buildHTTPClient(cfg *clientConfig) *http.Client {
+	var base http.RoundTripper
+	switch {
+	case cfg.transport != nil:
+		base = cfg.transport
+	case cfg.httpClient != nil && cfg.httpClient.Transport != nil:
+		base = cfg.httpClient.Transport
+	default:
+		base = http.DefaultTransport
+	}
+
+	// Auth layer (innermost on the request side, outermost on response).
+	authed := &transport.AuthRoundTripper{
+		Apply: applyAuth(cfg.auth),
+		Base:  base,
+	}
+
+	// Default headers layer (User-Agent + WithHeader entries).
+	headers := http.Header{}
+	if cfg.userAgent != "" {
+		headers.Set("User-Agent", cfg.userAgent)
+	}
+	for k, vs := range cfg.defaultHeader {
+		for _, v := range vs {
+			headers.Add(k, v)
+		}
+	}
+	headed := &transport.HeaderRoundTripper{
+		Headers: headers,
+		Base:    authed,
+	}
+
+	if cfg.httpClient != nil {
+		c := *cfg.httpClient
+		c.Transport = headed
+		if c.Timeout == 0 {
+			c.Timeout = cfg.timeout
+		}
+		return &c
+	}
+	return &http.Client{Transport: headed, Timeout: cfg.timeout}
+}
+
+// applyAuth returns the func attached to the AuthRoundTripper, or nil
+// if no auth was configured.
+func applyAuth(auth authCredentials) func(*http.Request) {
+	switch auth.kind {
+	case authBasic:
+		username, password := auth.username, auth.password
+		return func(r *http.Request) {
+			r.SetBasicAuth(username, password)
+		}
+	case authBearer:
+		token := auth.bearer
+		return func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+token)
+		}
+	case authNone:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// coreAdapter exposes [*clientCore] via the [workspaces.Core] interface
+// without the resource subpackage having to import the root package
+// (which would create an import cycle since the root imports
+// rest/workspaces).
+type coreAdapter struct {
+	core *clientCore
+}
+
+// URL builds a fully-qualified URL by joining segments onto the
+// configured base URL.
+func (a coreAdapter) URL(parts ...string) (string, error) {
+	return transport.BuildURL(a.core.baseURL, parts)
+}
+
+// Do issues a request, decoding the JSON response into out (if non-nil).
+// On non-2xx responses, returns a *APIError wrapping the transport-layer
+// error. On transport failure, returns the wrapped transport error.
+func (a coreAdapter) Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error {
+	_, err := transport.DoJSON(ctx, a.core.httpClient, a.core.logger, op, transport.Request{
+		Method: method,
+		URL:    requestURL,
+		Body:   body,
+		Query:  query,
+	}, out)
+	if err == nil {
+		return nil
+	}
+	var tErr *transport.Error
+	if errors.As(err, &tErr) {
+		return newAPIError(tErr.Op, tErr.Method, tErr.URL, tErr.StatusCode, tErr.Body)
+	}
+	return err
+}
+
+// DoStream issues a request whose response is a stream (e.g., an SLD
+// download). The caller owns the returned ReadCloser and must close it.
+// Reserved for future resource ports; not used by Workspaces.
+func (a coreAdapter) DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error) {
+	// Placeholder; expand when the first streaming resource ports.
+	return nil, 0, errors.New("geoserver: DoStream not yet implemented")
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,5 @@
+module github.com/hishamkaram/geoserver/v2
+
+go 1.25
+
+toolchain go1.25.9

--- a/v2/internal/transport/auth.go
+++ b/v2/internal/transport/auth.go
@@ -1,0 +1,74 @@
+package transport
+
+import (
+	"net/http"
+)
+
+// AuthRoundTripper wraps another [http.RoundTripper] and attaches an
+// auth header to every outgoing request.
+//
+// The Apply func is called once per request. It receives the request
+// (with Header already lazily-allocated if needed) and sets whatever
+// header(s) the auth scheme requires. Designed to be wrapped further by
+// users who want to layer additional behavior (OpenTelemetry spans,
+// Vault-rotated creds, retry libs).
+type AuthRoundTripper struct {
+	Apply func(*http.Request)
+	Base  http.RoundTripper
+}
+
+// RoundTrip implements [http.RoundTripper].
+//
+// To stay friendly to higher-layer wrappers (e.g., [http.Client] retries
+// or future request rewinds), the request is cloned before mutation —
+// the caller's copy stays untouched.
+func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.Apply == nil {
+		base := rt.Base
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		return base.RoundTrip(req)
+	}
+	clone := req.Clone(req.Context())
+	rt.Apply(clone)
+	base := rt.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}
+
+// HeaderRoundTripper wraps another [http.RoundTripper] and attaches a
+// fixed set of headers to every outgoing request. Used for User-Agent
+// and any headers configured via WithHeader.
+type HeaderRoundTripper struct {
+	Headers http.Header
+	Base    http.RoundTripper
+}
+
+// RoundTrip implements [http.RoundTripper].
+func (rt *HeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(rt.Headers) == 0 {
+		base := rt.Base
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		return base.RoundTrip(req)
+	}
+	clone := req.Clone(req.Context())
+	for key, values := range rt.Headers {
+		// Don't clobber an explicit per-request override.
+		if clone.Header.Get(key) != "" {
+			continue
+		}
+		for _, v := range values {
+			clone.Header.Add(key, v)
+		}
+	}
+	base := rt.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}

--- a/v2/internal/transport/transport.go
+++ b/v2/internal/transport/transport.go
@@ -1,0 +1,158 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// Doer is the subset of [*http.Client] the transport layer needs.
+// Allows tests to substitute a fake.
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Request is the per-call shape: method, fully-built URL, optional JSON
+// body, optional query params, optional Accept override.
+//
+// The transport does NOT own URL composition — callers (resource
+// sub-clients) build the URL via [BuildURL] and pass it here.
+type Request struct {
+	Method string
+	URL    string
+	// Body, if non-nil, is JSON-encoded with the body cap respected.
+	// Use nil for GET / DELETE / HEAD with no body.
+	Body any
+	// Query is added on top of any query already present in URL.
+	Query map[string]string
+	// Accept overrides the default "application/json".
+	Accept string
+}
+
+// JSON is a JSON-shaped target for [DoJSON]. nil disables decoding.
+type JSON any
+
+// DoJSON sends a JSON-shaped request, decodes a JSON-shaped response,
+// and translates non-2xx responses into a *transport-layer-Error.
+//
+// On success: status code is reported in the returned status; out (if
+// non-nil) is filled from the response body. Error is nil.
+//
+// On non-2xx: returns a structured Error wrapping the response body
+// (capped) so the calling resource sub-client can rewrap as a
+// public *APIError with the correct Op string. status is the actual
+// status code; out is unchanged.
+//
+// On transport error: status is 0; err is the wrapped transport error.
+func DoJSON(ctx context.Context, doer Doer, logger *slog.Logger, op string, req Request, out JSON) (status int, err error) {
+	httpReq, err := buildHTTPRequest(ctx, req)
+	if err != nil {
+		return 0, fmt.Errorf("%s: build request: %w", op, err)
+	}
+
+	resp, err := doer.Do(httpReq)
+	if err != nil {
+		logDebug(logger, "request failed", "op", op, "method", req.Method, "url", req.URL, "err", err)
+		return 0, fmt.Errorf("%s: %w", op, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, bodyReadCap))
+	if readErr != nil {
+		logDebug(logger, "body read failed", "op", op, "method", req.Method, "url", req.URL, "status", resp.StatusCode, "err", readErr)
+		return resp.StatusCode, fmt.Errorf("%s: read body: %w", op, readErr)
+	}
+
+	logDebug(logger, "request done", "op", op, "method", req.Method, "url", req.URL, "status", resp.StatusCode, "body_bytes", len(body))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, &Error{
+			Op:         op,
+			Method:     req.Method,
+			URL:        req.URL,
+			StatusCode: resp.StatusCode,
+			Body:       body,
+		}
+	}
+
+	if out == nil || len(body) == 0 {
+		return resp.StatusCode, nil
+	}
+	if jsonErr := json.Unmarshal(body, out); jsonErr != nil {
+		return resp.StatusCode, fmt.Errorf("%s: decode response: %w", op, jsonErr)
+	}
+	return resp.StatusCode, nil
+}
+
+// Error is the transport-layer non-2xx error. The public *APIError type
+// in the root v2 package wraps this with the same fields and the
+// status-to-sentinel mapping.
+type Error struct {
+	Op         string
+	Method     string
+	URL        string
+	StatusCode int
+	Body       []byte
+}
+
+func (e *Error) Error() string {
+	preview := string(e.Body)
+	if len(preview) > 120 {
+		preview = preview[:120] + "…"
+	}
+	return fmt.Sprintf("%s %s %s: %d %s: %s",
+		e.Op, e.Method, e.URL, e.StatusCode, http.StatusText(e.StatusCode), preview)
+}
+
+// Read body cap matches the public *APIError.Body cap so the wrapper
+// doesn't have to re-truncate.
+const bodyReadCap = 8 << 10 // 8 KiB
+
+// buildHTTPRequest constructs the http.Request with body / query /
+// Accept set. Auth and User-Agent are applied by the transport
+// RoundTripper, not here.
+func buildHTTPRequest(ctx context.Context, req Request) (*http.Request, error) {
+	var body io.Reader = http.NoBody
+	if req.Body != nil {
+		buf, err := json.Marshal(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("encode body: %w", err)
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	accept := req.Accept
+	if accept == "" {
+		accept = "application/json"
+	}
+	httpReq.Header.Set("Accept", accept)
+	if req.Body != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	if len(req.Query) > 0 {
+		q := httpReq.URL.Query()
+		for k, v := range req.Query {
+			q.Add(k, v)
+		}
+		httpReq.URL.RawQuery = q.Encode()
+	}
+
+	return httpReq, nil
+}
+
+func logDebug(logger *slog.Logger, msg string, args ...any) {
+	if logger == nil {
+		return
+	}
+	logger.Debug(msg, args...)
+}

--- a/v2/internal/transport/url.go
+++ b/v2/internal/transport/url.go
@@ -1,0 +1,49 @@
+// Package transport contains the HTTP transport algorithms for the v2
+// GeoServer client. External code must not import this package.
+package transport
+
+import (
+	"errors"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// ErrInvalidBaseURL is returned by [BuildURL] when the supplied base URL
+// fails to parse.
+var ErrInvalidBaseURL = errors.New("transport: invalid base URL")
+
+// BuildURL joins parts onto base with each user-provided segment
+// PathEscape'd individually. Empty segments are dropped.
+//
+// The encoded path is preserved through [url.URL.String] by setting
+// [url.URL.RawPath] alongside [url.URL.Path]. Without RawPath, a segment
+// PathEscape'd to a sequence containing "%" (e.g., "*" → "%2A") would be
+// re-encoded by String() to "%252A", which GeoServer's StrictHttpFirewall
+// rejects as a potentially malicious URL.
+func BuildURL(base string, parts []string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", ErrInvalidBaseURL
+	}
+
+	basePath := strings.TrimRight(u.Path, "/")
+	escaped := make([]string, 0, len(parts)+1)
+	if basePath != "" {
+		escaped = append(escaped, basePath)
+	}
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		escaped = append(escaped, url.PathEscape(p))
+	}
+	rawPath := path.Join(escaped...)
+	decoded, decodeErr := url.PathUnescape(rawPath)
+	if decodeErr != nil {
+		return "", decodeErr
+	}
+	u.Path = decoded
+	u.RawPath = rawPath
+	return u.String(), nil
+}

--- a/v2/internal/transport/url_test.go
+++ b/v2/internal/transport/url_test.go
@@ -1,0 +1,58 @@
+package transport_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/transport"
+)
+
+func TestBuildURL_Plain(t *testing.T) {
+	got, err := transport.BuildURL("http://localhost:8080/geoserver/", []string{"rest", "workspaces"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "http://localhost:8080/geoserver/rest/workspaces" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBuildURL_NoDoubleEncoding(t *testing.T) {
+	cases := []struct{ name, seg, must, mustNot string }{
+		{"asterisk", "*", "%2A", "%252A"},
+		{"space", "my workspace", "my%20workspace", "%2520"},
+		{"non-ASCII", "café", "%C3%A9", "%25"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := transport.BuildURL("http://localhost:8080/geoserver/", []string{"rest", tc.seg})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, tc.must) {
+				t.Fatalf("URL %q must contain %q", got, tc.must)
+			}
+			if strings.Contains(got, tc.mustNot) {
+				t.Fatalf("URL %q must NOT contain %q (regression)", got, tc.mustNot)
+			}
+		})
+	}
+}
+
+func TestBuildURL_DropsEmptySegments(t *testing.T) {
+	got, err := transport.BuildURL("http://localhost:8080/geoserver/", []string{"rest", "", "workspaces"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "http://localhost:8080/geoserver/rest/workspaces" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBuildURL_InvalidBaseURL(t *testing.T) {
+	_, err := transport.BuildURL("://nope", []string{"rest"})
+	if !errors.Is(err, transport.ErrInvalidBaseURL) {
+		t.Fatalf("expected ErrInvalidBaseURL, got %v", err)
+	}
+}

--- a/v2/options.go
+++ b/v2/options.go
@@ -1,0 +1,143 @@
+package geoserver
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Option configures a [*Client] at construction. Options are applied in
+// order; later options override earlier ones for the same field.
+type Option func(*clientConfig) error
+
+// clientConfig is the internal accumulator of options. Resolved into a
+// *Client by [New].
+type clientConfig struct {
+	httpClient    *http.Client
+	timeout       time.Duration
+	transport     http.RoundTripper
+	logger        *slog.Logger
+	userAgent     string
+	auth          authCredentials
+	defaultHeader http.Header
+}
+
+// authCredentials holds the resolved auth strategy. Mutually exclusive:
+// at most one of basic / bearer is set. Empty == no auth header attached.
+type authCredentials struct {
+	kind     authKind
+	username string
+	password string
+	bearer   string
+}
+
+type authKind int
+
+const (
+	authNone authKind = iota
+	authBasic
+	authBearer
+)
+
+// WithHTTPClient supplies a custom *http.Client. The client's Transport
+// (if any) is wrapped — auth and user-agent layers are applied on top.
+// Mutually exclusive with [WithTransport]; later option wins.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cfg *clientConfig) error {
+		if c == nil {
+			return errors.New("geoserver: WithHTTPClient: client is nil")
+		}
+		cfg.httpClient = c
+		return nil
+	}
+}
+
+// WithTransport supplies the base [http.RoundTripper] for the client's
+// HTTP transport. Auth and user-agent layers wrap this. Mutually
+// exclusive with [WithHTTPClient]; later option wins.
+func WithTransport(rt http.RoundTripper) Option {
+	return func(cfg *clientConfig) error {
+		if rt == nil {
+			return errors.New("geoserver: WithTransport: transport is nil")
+		}
+		cfg.transport = rt
+		return nil
+	}
+}
+
+// WithTimeout sets the *http.Client's Timeout. Zero means no timeout
+// (rely on context deadlines instead). Default: 30 seconds.
+func WithTimeout(d time.Duration) Option {
+	return func(cfg *clientConfig) error {
+		if d < 0 {
+			return errors.New("geoserver: WithTimeout: negative duration")
+		}
+		cfg.timeout = d
+		return nil
+	}
+}
+
+// WithLogger sets the *slog.Logger the client uses for HTTP-level
+// logging. Default: a discard handler (silent).
+func WithLogger(l *slog.Logger) Option {
+	return func(cfg *clientConfig) error {
+		if l == nil {
+			return errors.New("geoserver: WithLogger: logger is nil; pass slog.New(slog.DiscardHandler) to silence")
+		}
+		cfg.logger = l
+		return nil
+	}
+}
+
+// WithUserAgent sets the User-Agent header sent on every request.
+// Default: "geoserver-go/v2".
+func WithUserAgent(ua string) Option {
+	return func(cfg *clientConfig) error {
+		if ua == "" {
+			return errors.New("geoserver: WithUserAgent: empty user-agent")
+		}
+		cfg.userAgent = ua
+		return nil
+	}
+}
+
+// WithBasicAuth attaches HTTP basic-auth headers to every request.
+// Mutually exclusive with [WithBearerToken]; later option wins.
+func WithBasicAuth(username, password string) Option {
+	return func(cfg *clientConfig) error {
+		if username == "" {
+			return errors.New("geoserver: WithBasicAuth: empty username")
+		}
+		cfg.auth = authCredentials{kind: authBasic, username: username, password: password}
+		return nil
+	}
+}
+
+// WithBearerToken attaches a bearer token to every request.
+// Mutually exclusive with [WithBasicAuth]; later option wins.
+func WithBearerToken(token string) Option {
+	return func(cfg *clientConfig) error {
+		if token == "" {
+			return errors.New("geoserver: WithBearerToken: empty token")
+		}
+		cfg.auth = authCredentials{kind: authBearer, bearer: token}
+		return nil
+	}
+}
+
+// WithHeader adds a default header sent on every request. Multiple calls
+// accumulate. Authoritative for headers set before request-level
+// overrides apply.
+func WithHeader(key, value string) Option {
+	return func(cfg *clientConfig) error {
+		if key == "" {
+			return errors.New("geoserver: WithHeader: empty key")
+		}
+		if cfg.defaultHeader == nil {
+			cfg.defaultHeader = http.Header{}
+		}
+		cfg.defaultHeader.Add(key, value)
+		return nil
+	}
+}

--- a/v2/rest/workspaces/types.go
+++ b/v2/rest/workspaces/types.go
@@ -1,0 +1,49 @@
+// Package workspaces is the v2 sub-client for the GeoServer
+// /rest/workspaces resource. The exported surface is intentionally
+// shaped like every other v2 resource sub-client so callers learn the
+// pattern once.
+package workspaces
+
+// Workspace is the GeoServer workspace document. Fields are the subset
+// callers and the GeoServer JSON wire format both use.
+type Workspace struct {
+	Name     string `json:"name"`
+	Isolated bool   `json:"isolated,omitempty"`
+}
+
+// WorkspacePatch is a partial-update payload. Pointer fields let callers
+// distinguish "field absent" from "field set to false / empty string"
+// when issuing an Update — GeoServer treats PUT as a merge-patch.
+type WorkspacePatch struct {
+	Isolated *bool `json:"isolated,omitempty"`
+}
+
+// ListOptions controls listing behavior. Currently empty; GeoServer's
+// /rest/workspaces does not paginate. Reserved for future fields and
+// kept on the public API so a future paginating release is non-breaking.
+type ListOptions struct{}
+
+// DeleteOptions controls Delete behavior.
+type DeleteOptions struct {
+	// Recurse deletes the workspace and all contained datastores,
+	// coverage stores, layer groups, etc. Default false (non-empty
+	// workspaces 403 without Recurse).
+	Recurse bool
+}
+
+// listResponse mirrors GeoServer's `{"workspaces":{"workspace":[…]}}`.
+type listResponse struct {
+	Workspaces struct {
+		Workspace []Workspace `json:"workspace"`
+	} `json:"workspaces"`
+}
+
+// detailResponse mirrors GeoServer's `{"workspace":{…}}`.
+type detailResponse struct {
+	Workspace Workspace `json:"workspace"`
+}
+
+// createRequest mirrors GeoServer's create body shape.
+type createRequest struct {
+	Workspace Workspace `json:"workspace"`
+}

--- a/v2/rest/workspaces/workspaces.go
+++ b/v2/rest/workspaces/workspaces.go
@@ -1,0 +1,156 @@
+package workspaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+	"strconv"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+// Defined here as an interface so this subpackage doesn't import the
+// root package (which would create an import cycle since the root
+// constructs sub-clients).
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Client is the v2 workspaces sub-client. Construct via the parent
+// [*geoserver.Client] (do not call [New] directly outside the root
+// package's wiring).
+type Client struct {
+	core Core
+}
+
+// New constructs the sub-client. Used by the root [*geoserver.Client]
+// wiring; library users access the same instance via
+// `c.Workspaces`.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// List returns every workspace currently configured on the server.
+func (c *Client) List(ctx context.Context, _ ListOptions) ([]Workspace, error) {
+	const op = "Workspaces.List"
+	u, err := c.core.URL("rest", "workspaces")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp listResponse
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Workspaces.Workspace, nil
+}
+
+// Iter returns a [iter.Seq2] over the workspace list. Useful when
+// callers want range-over-func ergonomics; today the underlying
+// endpoint is a single-shot list, so the iterator yields each entry
+// from a single fetch. Future paginating endpoints in the v2 surface
+// (e.g., layers) follow the same shape.
+func (c *Client) Iter(ctx context.Context, opts ListOptions) iter.Seq2[Workspace, error] {
+	return func(yield func(Workspace, error) bool) {
+		ws, err := c.List(ctx, opts)
+		if err != nil {
+			yield(Workspace{}, err)
+			return
+		}
+		for _, w := range ws {
+			if !yield(w, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get fetches the workspace with the given name. Returns a *APIError
+// wrapping ErrNotFound if no such workspace exists.
+func (c *Client) Get(ctx context.Context, name string) (*Workspace, error) {
+	const op = "Workspaces.Get"
+	if name == "" {
+		return nil, errors.New("Workspaces.Get: empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp detailResponse
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Workspace, nil
+}
+
+// (No Exists method on the v2 surface. Idiomatic Go: call Get and match
+// the error against the package sentinel.
+//
+//	_, err := c.Workspaces.Get(ctx, name)
+//	if errors.Is(err, geoserver.ErrNotFound) {
+//	    // doesn't exist
+//	}
+//
+// This is the same pattern used by encoding/json and database/sql, and
+// avoids the (bool, error) shape that requires callers to disambiguate
+// "false, nil = doesn't exist" from "false, err = real failure".)
+
+// Create registers a new workspace.
+//
+// Returns nil on success. Returns a *APIError wrapping ErrConflict if
+// the workspace already exists.
+func (c *Client) Create(ctx context.Context, ws *Workspace) error {
+	const op = "Workspaces.Create"
+	if ws == nil {
+		return errors.New("Workspaces.Create: nil workspace")
+	}
+	if ws.Name == "" {
+		return errors.New("Workspaces.Create: empty Name")
+	}
+	u, err := c.core.URL("rest", "workspaces")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := createRequest{Workspace: *ws}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Update modifies a workspace via PUT-as-merge-patch. Pointer fields on
+// patch let callers distinguish "field absent" from "field set to
+// false / empty string".
+func (c *Client) Update(ctx context.Context, name string, patch *WorkspacePatch) error {
+	const op = "Workspaces.Update"
+	if name == "" {
+		return errors.New("Workspaces.Update: empty name")
+	}
+	if patch == nil {
+		return errors.New("Workspaces.Update: nil patch")
+	}
+	u, err := c.core.URL("rest", "workspaces", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := struct {
+		Workspace WorkspacePatch `json:"workspace"`
+	}{Workspace: *patch}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// Delete removes a workspace. With opts.Recurse=true, also removes all
+// contained datastores, coverage stores, layer groups, and
+// feature/coverage definitions.
+func (c *Client) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "Workspaces.Delete"
+	if name == "" {
+		return errors.New("Workspaces.Delete: empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	query := map[string]string{"recurse": strconv.FormatBool(opts.Recurse)}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}

--- a/v2/rest/workspaces/workspaces_test.go
+++ b/v2/rest/workspaces/workspaces_test.go
@@ -1,0 +1,269 @@
+package workspaces_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+// newTestClient constructs a v2 *Client pointed at the given httptest
+// server, with basic-auth and a 5s timeout.
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// expectBasicAuth asserts the Authorization header carries the
+// admin/geoserver basic-auth value.
+func expectBasicAuth(t *testing.T, r *http.Request) {
+	t.Helper()
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:geoserver"))
+	if got := r.Header.Get("Authorization"); got != want {
+		t.Fatalf("Authorization header = %q, want %q", got, want)
+	}
+}
+
+// expectUserAgent asserts the User-Agent header is the default v2 UA.
+func expectUserAgent(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got := r.Header.Get("User-Agent"); got != "geoserver-go/v2" {
+		t.Fatalf("User-Agent = %q, want %q", got, "geoserver-go/v2")
+	}
+}
+
+func TestList_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectBasicAuth(t, r)
+		expectUserAgent(t, r)
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/workspaces" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"workspaces":{"workspace":[{"name":"topp"},{"name":"sf","isolated":true}]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Workspaces.List(context.Background(), workspaces.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d workspaces, want 2", len(got))
+	}
+	if got[0].Name != "topp" || got[1].Name != "sf" || !got[1].Isolated {
+		t.Fatalf("unexpected workspaces: %+v", got)
+	}
+}
+
+func TestList_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad creds")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Workspaces.List(context.Background(), workspaces.ListOptions{})
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+	var apiErr *geoserver.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *geoserver.APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("APIError.StatusCode = %d", apiErr.StatusCode)
+	}
+	if apiErr.Op != "Workspaces.List" {
+		t.Fatalf("APIError.Op = %q, want Workspaces.List", apiErr.Op)
+	}
+}
+
+func TestIter_RangeOverFunc(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"workspaces":{"workspace":[{"name":"a"},{"name":"b"},{"name":"c"}]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	var names []string
+	for ws, err := range c.Workspaces.Iter(context.Background(), workspaces.ListOptions{}) {
+		if err != nil {
+			t.Fatalf("iter error: %v", err)
+		}
+		names = append(names, ws.Name)
+	}
+	if len(names) != 3 || names[0] != "a" || names[2] != "c" {
+		t.Fatalf("iterator yielded %v", names)
+	}
+}
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"workspace":{"name":"topp","isolated":false}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	ws, err := c.Workspaces.Get(context.Background(), "topp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ws.Name != "topp" {
+		t.Fatalf("Name = %q", ws.Name)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "no such workspace")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Workspaces.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreate_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/workspaces" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != `{"workspace":{"name":"new_ws"}}` {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Workspaces.Create(context.Background(), &workspaces.Workspace{Name: "new_ws"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreate_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, "exists")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Workspaces.Create(context.Background(), &workspaces.Workspace{Name: "topp"})
+	if !errors.Is(err, geoserver.ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestUpdate_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/workspaces/topp" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != `{"workspace":{"isolated":true}}` {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	isolated := true
+	if err := c.Workspaces.Update(context.Background(), "topp", &workspaces.WorkspacePatch{Isolated: &isolated}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDelete_RecurseQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/workspaces/topp" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("recurse") != "true" {
+			t.Errorf("recurse = %q, want true", r.URL.Query().Get("recurse"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Workspaces.Delete(context.Background(), "topp", workspaces.DeleteOptions{Recurse: true}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDelete_500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Workspaces.Delete(context.Background(), "topp", workspaces.DeleteOptions{})
+	if !errors.Is(err, geoserver.ErrServerError) {
+		t.Fatalf("expected ErrServerError, got %v", err)
+	}
+}
+
+// URL-escaping regression: workspace names with characters that
+// PathEscape encodes to a sequence containing "%" must produce a
+// single-encoded URL on the wire (not double-encoded "%25..").
+func TestGet_URLEscaping_Asterisk(t *testing.T) {
+	var capturedRequestURI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"workspace":{"name":"weird"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Workspaces.Get(context.Background(), "weird*name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(capturedRequestURI, "weird%2Aname") {
+		t.Fatalf("expected %%2A in request URI, got %q", capturedRequestURI)
+	}
+	if contains(capturedRequestURI, "%252A") {
+		t.Fatalf("URL is double-encoded: %q", capturedRequestURI)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Lands the v2 redesign at module path \`github.com/hishamkaram/geoserver/v2\` (its own \`go.mod\`, independent \`v2.x.y\` tags). One reference resource — **Workspaces** — is implemented end-to-end as the pattern other resources will follow. v1 is unchanged.

This is Workstream C from the post-v1.1.0 follow-up plan (\`~/.claude/plans/tranquil-hatching-rabin.md\`).

## Design tenets (locked in via the revival plan)

- **Immutable \`*Client\`.** All fields private; configured via functional options at construction; concurrent use safe.
- **Mandatory \`context.Context\`** as first arg on every public method.
- **Sub-client pattern.** \`c.Workspaces\` returns a \`*workspaces.Client\` value with \`List\` / \`Iter\` / \`Get\` / \`Create\` / \`Update\` / \`Delete\`.
- **Single error type** \`*APIError\` with package sentinels (\`ErrNotFound\`, \`ErrConflict\`, \`ErrUnauthorized\`, \`ErrServerError\`, …) for \`errors.Is\` matching.
- **Auth via \`http.RoundTripper\`** (basic / bearer attach at construction; per-call paths don't re-authenticate). Custom RoundTrippers (OpenTelemetry, retry libs, Vault) layer naturally.
- **Pagination via \`iter.Seq2\`.** The \`Workspaces.Iter\` method demonstrates the shape; non-paginating endpoints fall back to single-page Seq2.
- **Zero runtime third-party deps.** v2 imports only stdlib \`net/http\`, \`encoding/json\`, \`log/slog\`, \`context\`, \`iter\`. **Tests too — no testify.** Fully realizes the design tenet.

## What's in this PR

### v2 module skeleton

- \`v2/go.mod\` (Go 1.25, toolchain go1.25.9, **zero \`require\` blocks**)
- \`v2/doc.go\`, \`README.md\`, \`CHANGELOG.md\`
- \`v2/geoserver.go\` — \`*Client\`, \`New()\`, \`buildHTTPClient\` + \`applyAuth\` + the \`coreAdapter\` that bridges the parent \`Client\` to sub-clients via the \`workspaces.Core\` interface (so sub-clients don't import the root package, avoiding import cycles)
- \`v2/errors.go\` — \`*APIError\` type, status-to-sentinel mapping, \`errors.Is\` via \`Unwrap()\`/\`Is()\`
- \`v2/options.go\` — \`WithHTTPClient\`, \`WithTransport\`, \`WithBasicAuth\`, \`WithBearerToken\`, \`WithLogger\`, \`WithUserAgent\`, \`WithTimeout\`, \`WithHeader\`

### Transport layer (\`v2/internal/transport/\`)

- \`url.go\` — \`BuildURL\` with the v1.1 RawPath fix (PathEscape per segment + RawPath preservation, baked in from day one)
- \`auth.go\` — \`AuthRoundTripper\`, \`HeaderRoundTripper\`
- \`transport.go\` — \`DoJSON\`: single chokepoint for REST calls, body cap, structured logging, status-code-to-sentinel via the public-package wrapper
- \`url_test.go\` — unit tests for \`BuildURL\` including the asterisk / space / non-ASCII regression cases

### Workspaces reference sub-client (\`v2/rest/workspaces/\`)

- \`types.go\` — \`Workspace\`, \`WorkspacePatch\` (pointer fields for merge-patch semantics), \`ListOptions\`, \`DeleteOptions\`
- \`workspaces.go\` — \`Client\` + \`List\` / \`Iter\` (\`iter.Seq2\`) / \`Get\` / \`Create\` / \`Update\` / \`Delete\`. **Note: no \`Exists\` method.** Idiomatic Go is to call \`Get\` and match \`errors.Is(err, ErrNotFound)\` (same pattern as \`encoding/json\`, \`database/sql\`).
- \`workspaces_test.go\` — 11 httptest unit tests covering 2xx happy paths and 401/404/409/500 sentinel mapping plus a URL-escaping regression guard

### CI / Makefile / docs

- \`.github/workflows/ci.yml\` — adds \`unit-v2\` job. Runs \`go vet\` + \`go test -race\` in \`./v2\`. **NOT in the required-checks list yet** (it's advisory until v2 stabilizes; add to branch protection as a follow-up).
- \`Makefile\` — \`make test-v2-unit\` and \`make build-v2\` targets.
- Root \`CLAUDE.md\` updated to reflect v2's status.

## Local verification

\`\`\`
$ make build-v2     # cd v2 && go build ./... && go vet ./...  — clean
$ make test-v2-unit # cd v2 && go test -race -short -timeout=60s ./...  — all 11 workspaces tests + url tests pass
\`\`\`

v1 module is untouched; its full local gates (vet, lint, test-unit, examples, vuln) all still pass green from the master baseline.

## Test plan

Required v1 gates (must pass — v1 is the recommended dep):

- [ ] \`Lint\`
- [ ] \`Unit tests (Go 1.25)\`
- [ ] \`govulncheck\`
- [ ] \`Analyze (Go)\` (CodeQL)
- [ ] \`GeoServer 2.27.4\` (integration)
- [ ] \`GeoServer 2.28.0\` (integration)

Advisory new gate (not required for merge yet — promotes to required once v2 stabilizes):

- [ ] \`Unit tests v2 (Go 1.25)\`

## Out of scope this PR

- **Other v2 resources** (datastores, styles, layers, layergroups, coverages, feature types, namespaces, settings, security, ACL, about, capabilities). Each ports in its own follow-up PR using the workspaces pattern.
- **OWS subpackages** (\`ows/wms/\`, \`ows/wfs/\`, \`ows/wcs/\`). Defer to v2.x point release.
- **v2 integration tests** against a real GeoServer. Defer until enough resources port to model an end-to-end flow.
- **\`v2.0.0-alpha.1\` tag**. Tagging is the user's call.