### PR TITLE
docs: add runnable v2 examples (workspaces, publish-postgis, style-upload, error-handling)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ compose-test-down: ## tear down integration-test compose
 examples: ## compile-check every example under examples/
 	$(GO) build -o /dev/null ./examples/...
 
+.PHONY: examples-v2
+examples-v2: ## compile-check every example under v2/examples/
+	cd v2 && $(GO) build -o /dev/null ./examples/...
+
 .PHONY: test-v2-unit
 test-v2-unit: ## v2 module unit tests (no Docker)
 	cd v2 && $(GO) test -race -short -timeout=60s ./...

--- a/v2/README.md
+++ b/v2/README.md
@@ -118,6 +118,17 @@ _ = cov.Create(ctx, &coverages.Coverage{
 })
 ```
 
+## Runnable examples
+
+The [`examples/`](examples/) directory contains self-contained `main` packages demonstrating each idiom:
+
+- [`workspaces/`](examples/workspaces/) — flat sub-client CRUD; `errors.Is` matching.
+- [`publish-postgis/`](examples/publish-postgis/) — end-to-end workspace → datastore → feature type → layer flow with the hierarchical sub-clients.
+- [`style-upload/`](examples/style-upload/) — two-step style publish via `Create` + `UploadSLD`.
+- [`error-handling/`](examples/error-handling/) — full sentinel set + `*APIError` inspection via `errors.As`.
+
+Run any with `go run ./v2/examples/<name>` against a `make compose-up` stack, or compile-check all with `make examples-v2`.
+
 ## Resource status
 
 | Resource | v1 | v2 |

--- a/v2/examples/README.md
+++ b/v2/examples/README.md
@@ -1,0 +1,37 @@
+# Runnable v2 examples
+
+Each subdirectory is a self-contained `main` package demonstrating one v2 idiom. Run any of them with:
+
+```bash
+go run ./v2/examples/<name>
+```
+
+(Or `cd v2 && go run ./examples/<name>`.)
+
+All examples expect a GeoServer + PostGIS stack reachable at the URL configured in code (default: `http://localhost:8080/geoserver/`, admin / geoserver). Boot the stack via `make compose-up` from the repo root.
+
+| Example | Demonstrates |
+|---|---|
+| [`workspaces/`](workspaces/) | The functional-options constructor (`New(url, opts...) (*Client, error)`); flat sub-client (`c.Workspaces`); list / create / get / delete; `errors.Is` for sentinel matching. |
+| [`publish-postgis/`](publish-postgis/) | End-to-end flow: workspace → PostGIS datastore → feature type → fetch the published layer. Exercises the hierarchical sub-clients (`InWorkspace`, `InDatastore`). |
+| [`style-upload/`](style-upload/) | Two-step style publish: register metadata via `Create`, then `UploadSLD` with a raw-XML body. |
+| [`error-handling/`](error-handling/) | Match GeoServer errors via `errors.Is(err, geoserver.ErrNotFound)` and inspect the typed `*geoserver.APIError` via `errors.As`. |
+
+These are reference flows, not test fixtures. The unit suite (`make test-v2-unit`) and the v2 integration ramp-up cover the same surface more rigorously.
+
+## Running against a different GeoServer
+
+Each example reads the server URL and credentials from environment variables when set:
+
+```bash
+export GEOSERVER_URL="https://geoserver.example.com/geoserver/"
+export GEOSERVER_USER="admin"
+export GEOSERVER_PASS="hunter2"
+go run ./v2/examples/workspaces
+```
+
+Defaults match `make compose-up`: `http://localhost:8080/geoserver/`, `admin`, `geoserver`.
+
+## v1 examples
+
+The parent [`examples/`](../../examples/) directory contains the v1 reference flows. Compare them side-by-side with the v2 versions here to see the API surface differences laid out in [`docs/migration-v1-to-v2.md`](../../docs/migration-v1-to-v2.md).

--- a/v2/examples/error-handling/main.go
+++ b/v2/examples/error-handling/main.go
@@ -1,0 +1,130 @@
+// error-handling is a runnable v2 example: demonstrate how to match
+// GeoServer errors with `errors.Is` against package sentinels and
+// inspect the typed *geoserver.APIError via `errors.As`.
+//
+//	go run ./v2/examples/error-handling
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func main() {
+	url := envOr("GEOSERVER_URL", "http://localhost:8080/geoserver/")
+	user := envOr("GEOSERVER_USER", "admin")
+	pass := envOr("GEOSERVER_PASS", "geoserver")
+
+	c, err := geoserver.New(url,
+		geoserver.WithBasicAuth(user, pass),
+		geoserver.WithTimeout(10*time.Second),
+		geoserver.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))),
+	)
+	if err != nil {
+		fatal("construct client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 1. ErrNotFound on a missing workspace.
+	_, err = c.Workspaces.Get(ctx, "definitely_not_a_real_workspace_v2")
+	switch {
+	case errors.Is(err, geoserver.ErrNotFound):
+		fmt.Println("✓ ErrNotFound matched via errors.Is")
+	case err == nil:
+		fmt.Println("unexpected: workspace exists?")
+	default:
+		fmt.Printf("unexpected error: %v\n", err)
+	}
+
+	// 2. Inspect the underlying *APIError for the same call to read
+	// status code, op, and the (capped) response body.
+	_, err = c.Workspaces.Get(ctx, "still_not_real")
+	var apiErr *geoserver.APIError
+	if errors.As(err, &apiErr) {
+		fmt.Printf("✓ *APIError: Op=%q Method=%q Status=%d BodyLen=%d\n",
+			apiErr.Op, apiErr.Method, apiErr.StatusCode, len(apiErr.Body))
+	}
+
+	// 3. ErrConflict on a duplicate create.
+	const dupName = "v2_examples_error_handling_dup"
+	// best-effort cleanup
+	_ = c.Workspaces.Delete(ctx, dupName, workspaces.DeleteOptions{Recurse: true})
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: dupName}); err != nil {
+		fatal("first create: %v", err)
+	}
+	defer func() {
+		_ = c.Workspaces.Delete(ctx, dupName, workspaces.DeleteOptions{Recurse: true})
+	}()
+
+	err = c.Workspaces.Create(ctx, &workspaces.Workspace{Name: dupName})
+	switch {
+	case errors.Is(err, geoserver.ErrConflict):
+		fmt.Println("✓ ErrConflict matched on duplicate create")
+	case err == nil:
+		fmt.Println("unexpected: duplicate Create succeeded")
+	default:
+		fmt.Printf("unexpected error on duplicate create: %v\n", err)
+	}
+
+	// 4. ErrUnauthorized — point a fresh client at a deliberately wrong
+	// password and probe a protected endpoint. Note no logger to keep
+	// output clean.
+	bad, err := geoserver.New(url,
+		geoserver.WithBasicAuth(user, "absolutely-wrong-password"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		fatal("construct bad-auth client: %v", err)
+	}
+	_, err = bad.Workspaces.List(ctx, workspaces.ListOptions{})
+	switch {
+	case errors.Is(err, geoserver.ErrUnauthorized):
+		fmt.Println("✓ ErrUnauthorized matched on bad credentials")
+	case err == nil:
+		fmt.Println("unexpected: list succeeded with bad creds")
+	default:
+		fmt.Printf("unexpected auth error: %v\n", err)
+	}
+
+	// 5. The full sentinel set, for reference.
+	fmt.Println()
+	fmt.Println("Full sentinel set you can match with errors.Is:")
+	for _, s := range []error{
+		geoserver.ErrBadRequest,
+		geoserver.ErrUnauthorized,
+		geoserver.ErrForbidden,
+		geoserver.ErrNotFound,
+		geoserver.ErrMethodNotAllowed,
+		geoserver.ErrConflict,
+		geoserver.ErrUnsupportedMediaType,
+		geoserver.ErrRateLimited,
+		geoserver.ErrServerError,
+		geoserver.ErrBadGateway,
+		geoserver.ErrServiceUnavailable,
+		geoserver.ErrGatewayTimeout,
+	} {
+		fmt.Printf("  - %v\n", s)
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/v2/examples/publish-postgis/main.go
+++ b/v2/examples/publish-postgis/main.go
@@ -1,0 +1,159 @@
+// publish-postgis is a runnable v2 example: end-to-end flow that creates
+// a workspace, registers a PostGIS datastore, publishes a feature type,
+// and reads the resulting layer back. Demonstrates the hierarchical
+// sub-clients (InWorkspace, InDatastore).
+//
+// Requires the make-compose-up PostGIS stack with the lbldyt table
+// pre-loaded (docker/postgis/init/01-lbldyt.sql).
+//
+//	go run ./v2/examples/publish-postgis
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/datastores"
+	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
+	"github.com/hishamkaram/geoserver/v2/rest/layers"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func main() {
+	url := envOr("GEOSERVER_URL", "http://localhost:8080/geoserver/")
+	user := envOr("GEOSERVER_USER", "admin")
+	pass := envOr("GEOSERVER_PASS", "geoserver")
+
+	c, err := geoserver.New(url,
+		geoserver.WithBasicAuth(user, pass),
+		geoserver.WithTimeout(30*time.Second),
+		geoserver.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))),
+	)
+	if err != nil {
+		fatal("construct client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		workspace = "v2_examples_postgis"
+		datastore = "lbldyt_pg"
+		// Native table name — must exist in the PostGIS DB.
+		nativeTable  = "lbldyt"
+		featureType  = "lbldyt"
+		dbHost       = "postgis"
+		dbName       = "geoserver"
+		dbUser       = "postgres"
+		dbPass       = "postgres"
+		dbPort       = 5432
+		expectedAttr = "wkb_geometry"
+	)
+
+	// Best-effort cleanup from a previous run, in workspace-recurse order.
+	_ = c.Workspaces.Delete(ctx, workspace, workspaces.DeleteOptions{Recurse: true})
+
+	// 1. Workspace.
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: workspace}); err != nil {
+		fatal("create workspace: %v", err)
+	}
+	fmt.Printf("created workspace %q\n", workspace)
+
+	// 2. PostGIS datastore.
+	if err := c.Datastores.InWorkspace(workspace).Create(ctx, datastores.PostGIS{
+		Name:     datastore,
+		Host:     dbHost,
+		Port:     dbPort,
+		Database: dbName,
+		User:     dbUser,
+		Password: dbPass,
+	}); err != nil {
+		fatal("create datastore: %v", err)
+	}
+	fmt.Printf("created PostGIS datastore %q in %q\n", datastore, workspace)
+
+	// 3. Discover available tables (should include nativeTable).
+	available, err := c.FeatureTypes.InWorkspace(workspace).InDatastore(datastore).
+		Discover(ctx, featuretypes.DiscoverOptions{Kind: featuretypes.DiscoverAvailableWithGeometry})
+	if err != nil {
+		fatal("discover tables: %v", err)
+	}
+	fmt.Printf("discovered %d available tables: %v\n", len(available), available)
+
+	// 4. Publish the feature type. NativeName must match the DB table.
+	if err := c.FeatureTypes.InWorkspace(workspace).InDatastore(datastore).
+		Create(ctx, &featuretypes.FeatureType{
+			Name:       featureType,
+			NativeName: nativeTable,
+			SRS:        "EPSG:4326",
+			Enabled:    true,
+		}); err != nil {
+		fatal("publish feature type: %v", err)
+	}
+	fmt.Printf("published feature type %q (native %q)\n", featureType, nativeTable)
+
+	// 5. Fetch the auto-created layer back.
+	layer, err := c.Layers.InWorkspace(workspace).Get(ctx, featureType)
+	if err != nil {
+		fatal("fetch layer: %v", err)
+	}
+	fmt.Printf("layer: name=%q type=%q resource=%q queryable=%t\n",
+		layer.Name, layer.Type,
+		safeName(layer.Resource),
+		layer.Queryable)
+
+	// 6. Inspect the feature type document — verify the geometry column was discovered.
+	ft, err := c.FeatureTypes.InWorkspace(workspace).InDatastore(datastore).
+		Get(ctx, featureType)
+	if err != nil {
+		fatal("fetch feature type: %v", err)
+	}
+	hasGeom := false
+	if ft.Attributes != nil {
+		for _, a := range ft.Attributes.Attribute {
+			if a.Name == expectedAttr {
+				hasGeom = true
+				break
+			}
+		}
+	}
+	fmt.Printf("feature type has %s column: %t\n", expectedAttr, hasGeom)
+
+	// 7. Cleanup. Recurse=true through the workspace cleans the whole tree.
+	if err := c.Workspaces.Delete(ctx, workspace, workspaces.DeleteOptions{Recurse: true}); err != nil {
+		// Don't error out — the example has already done its job.
+		fmt.Fprintf(os.Stderr, "warn: cleanup failed: %v\n", err)
+	} else {
+		fmt.Printf("cleaned up workspace %q\n", workspace)
+	}
+
+	// Demonstrate that the datastore is gone.
+	_, err = c.Datastores.InWorkspace(workspace).Get(ctx, datastore)
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("verified datastore was removed by recursive workspace delete")
+	}
+}
+
+func safeName(r *layers.Ref) string {
+	if r == nil {
+		return ""
+	}
+	return r.Name
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/v2/examples/style-upload/main.go
+++ b/v2/examples/style-upload/main.go
@@ -1,0 +1,129 @@
+// style-upload is a runnable v2 example: register a style's metadata,
+// then upload an SLD body via UploadSLD. Demonstrates the two-step
+// publish flow and the workspace-scoped Accept-quirk handling.
+//
+//	go run ./v2/examples/style-upload
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/styles"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+// inlineSLD is a tiny SLD that paints polygons solid red. Embedded so the
+// example doesn't need an external file; in real code you'd typically
+// open a file or fetch from S3 / a config bucket.
+const inlineSLD = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>red_polygon</Name>
+    <UserStyle>
+      <Title>Red polygon</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#FF0000</CssParameter>
+            </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`
+
+func main() {
+	url := envOr("GEOSERVER_URL", "http://localhost:8080/geoserver/")
+	user := envOr("GEOSERVER_USER", "admin")
+	pass := envOr("GEOSERVER_PASS", "geoserver")
+
+	c, err := geoserver.New(url,
+		geoserver.WithBasicAuth(user, pass),
+		geoserver.WithTimeout(30*time.Second),
+		geoserver.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))),
+	)
+	if err != nil {
+		fatal("construct client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const (
+		workspace = "v2_examples_styles"
+		styleName = "red_polygon"
+	)
+
+	// Best-effort cleanup from a prior run.
+	_ = c.Workspaces.Delete(ctx, workspace, workspaces.DeleteOptions{Recurse: true})
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: workspace}); err != nil {
+		fatal("create workspace: %v", err)
+	}
+	fmt.Printf("created workspace %q\n", workspace)
+
+	ws := c.Styles.InWorkspace(workspace)
+
+	// Step 1: register the style metadata. Workspace-scoped POST
+	// automatically uses Accept: */* under the hood (the Accept-quirk
+	// workaround is internal to v2).
+	if err := ws.Create(ctx, &styles.Style{Name: styleName}); err != nil {
+		fatal("create style metadata: %v", err)
+	}
+	fmt.Printf("registered style metadata %q\n", styleName)
+
+	// Step 2: upload the SLD body. Default Content-Type is
+	// application/vnd.ogc.sld+xml; override via UploadOptions.Format
+	// for SE 1.1 / GeoCSS / etc.
+	if err := ws.UploadSLD(ctx, styleName, bytes.NewReader([]byte(inlineSLD)), styles.UploadOptions{}); err != nil {
+		fatal("upload SLD: %v", err)
+	}
+	fmt.Printf("uploaded SLD body for %q (%d bytes)\n", styleName, len(inlineSLD))
+
+	// Read back the metadata.
+	got, err := ws.Get(ctx, styleName)
+	if err != nil {
+		fatal("fetch style: %v", err)
+	}
+	fmt.Printf("style: name=%q format=%q filename=%q\n", got.Name, got.Format, got.Filename)
+
+	// Cleanup.
+	if err := ws.Delete(ctx, styleName, styles.DeleteOptions{Purge: true}); err != nil {
+		fmt.Fprintf(os.Stderr, "warn: delete style: %v\n", err)
+	}
+	if err := c.Workspaces.Delete(ctx, workspace, workspaces.DeleteOptions{Recurse: true}); err != nil {
+		fmt.Fprintf(os.Stderr, "warn: cleanup workspace: %v\n", err)
+	}
+
+	// Verify the style is gone.
+	_, err = ws.Get(ctx, styleName)
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("verified style and workspace cleaned up")
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/v2/examples/workspaces/main.go
+++ b/v2/examples/workspaces/main.go
@@ -1,0 +1,101 @@
+// workspaces is a runnable v2 example: list, create, get, and delete a
+// GeoServer workspace using the v2 functional-options constructor and
+// flat *Client.Workspaces sub-client.
+//
+// Run with a compose stack at http://localhost:8080/geoserver/ (defaults
+// from `make compose-up`):
+//
+//	go run ./v2/examples/workspaces
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func main() {
+	url := envOr("GEOSERVER_URL", "http://localhost:8080/geoserver/")
+	user := envOr("GEOSERVER_USER", "admin")
+	pass := envOr("GEOSERVER_PASS", "geoserver")
+
+	c, err := geoserver.New(url,
+		geoserver.WithBasicAuth(user, pass),
+		geoserver.WithTimeout(10*time.Second),
+		geoserver.WithUserAgent("geoserver-v2-examples-workspaces/1.0"),
+		geoserver.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))),
+	)
+	if err != nil {
+		fatal("construct client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// List existing workspaces.
+	existing, err := c.Workspaces.List(ctx, workspaces.ListOptions{})
+	if err != nil {
+		fatal("list workspaces: %v", err)
+	}
+	fmt.Printf("found %d existing workspaces\n", len(existing))
+
+	// Create a fresh workspace; clean up at the end.
+	const name = "v2_examples_workspaces_demo"
+
+	// Best-effort cleanup in case a previous run left it behind.
+	_ = c.Workspaces.Delete(ctx, name, workspaces.DeleteOptions{Recurse: true})
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: name}); err != nil {
+		fatal("create workspace %q: %v", name, err)
+	}
+	fmt.Printf("created workspace %q\n", name)
+
+	// Fetch the workspace we just created — sanity check.
+	ws, err := c.Workspaces.Get(ctx, name)
+	if err != nil {
+		fatal("fetch workspace %q: %v", name, err)
+	}
+	fmt.Printf("fetched workspace: name=%q isolated=%t\n", ws.Name, ws.Isolated)
+
+	// 404 on a non-existent workspace returns ErrNotFound via errors.Is.
+	_, err = c.Workspaces.Get(ctx, "definitely_not_a_real_workspace_v2")
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("expected ErrNotFound for a missing workspace — verified")
+	}
+
+	// Iterate (range-over-func) — useful when you want to streaming-process
+	// the list without materializing the full slice.
+	count := 0
+	for ws, iterErr := range c.Workspaces.Iter(ctx, workspaces.ListOptions{}) {
+		if iterErr != nil {
+			fatal("iter workspaces: %v", iterErr)
+		}
+		count++
+		_ = ws
+	}
+	fmt.Printf("iterator yielded %d workspaces\n", count)
+
+	// Clean up.
+	if err := c.Workspaces.Delete(ctx, name, workspaces.DeleteOptions{Recurse: true}); err != nil {
+		fatal("delete workspace %q: %v", name, err)
+	}
+	fmt.Printf("deleted workspace %q\n", name)
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Mirrors the v1 `examples/` layout under `v2/examples/`, now that v2 has feature parity. Four self-contained `main` packages exercising the major v2 idioms:

| Example | Demonstrates |
|---|---|
| [`workspaces/`](v2/examples/workspaces/) | Functional-options constructor with `WithBasicAuth`/`WithLogger`/`WithUserAgent`; flat sub-client (`c.Workspaces`); list / create / get / delete; `errors.Is` for sentinel matching; `Iter` range-over-func. |
| [`publish-postgis/`](v2/examples/publish-postgis/) | End-to-end flow: workspace → PostGIS datastore → feature type → fetch the auto-created layer back. Exercises hierarchical scoping (`InWorkspace`, `InDatastore`) and `Discover` for available tables. |
| [`style-upload/`](v2/examples/style-upload/) | Two-step style publish: register metadata via `Create`, then `UploadSLD` with a raw-XML body. Exercises the workspace-scoped Accept-quirk that's automatic in v2. |
| [`error-handling/`](v2/examples/error-handling/) | Full sentinel-set walkthrough — `ErrNotFound`, `ErrConflict` (on duplicate Create), `ErrUnauthorized` (with deliberately bad credentials), and `*APIError` inspection via `errors.As`. |

Each example reads `GEOSERVER_URL` / `GEOSERVER_USER` / `GEOSERVER_PASS` from env with sensible defaults matching `make compose-up`.

## Build infrastructure

- New Makefile target `make examples-v2` runs `go build -o /dev/null ./examples/...` from the v2 module — compile-check parity with the existing v1 `make examples`.
- `v2/examples/README.md` indexes the examples and documents env-var overrides.
- `v2/README.md` gets a "Runnable examples" section linking the new tree.

## Test plan

- [x] `make examples-v2` clean (all four examples compile)
- [x] `go vet ./v2/examples/...` clean
- [x] `golangci-lint run ./v2/examples/...` clean
- [ ] CI: docs / examples-only change; existing v1 + v2 unit suites unaffected
- [ ] CI: `Lint`, `govulncheck`, `Analyze (Go)` green
- [ ] CI: `GeoServer 2.27.4`, `GeoServer 2.28.0` integration green