### PR TITLE
fix(datastores): handle empty `{"dataStores":""}` envelope (closes #22)

### DIFF
--- a/datastores.go
+++ b/datastores.go
@@ -3,6 +3,7 @@ package geoserver
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -184,6 +185,10 @@ func (g *GeoServer) GetDatastores(workspaceName string) (datastores []*Resource,
 }
 
 // GetDatastoresContext is the context-aware variant of [GeoServer.GetDatastores].
+//
+// GeoServer 2.28+ returns `{"dataStores":""}` (a bare string) for an empty
+// datastores collection, and `{"dataStores":{"dataStore":[…]}}` when populated.
+// Both shapes are accepted; the empty form returns a nil slice. (See issue #22.)
 func (g *GeoServer) GetDatastoresContext(ctx context.Context, workspaceName string) (datastores []*Resource, err error) {
 	targetURL := g.ParseURL("rest", "workspaces", workspaceName, "datastores")
 	httpRequest := HTTPRequest{
@@ -198,16 +203,23 @@ func (g *GeoServer) GetDatastoresContext(ctx context.Context, workspaceName stri
 		err = g.GetError(responseCode, response)
 		return
 	}
-	var query struct {
-		DataStores struct {
-			DataStore []*Resource
-		}
+	var envelope struct {
+		DataStores json.RawMessage `json:"dataStores,omitempty"`
 	}
-	if err = g.DeSerializeJSON(response, &query); err != nil {
-		return nil, err
+	if err = json.Unmarshal(response, &envelope); err != nil {
+		return nil, fmt.Errorf("GetDatastores: decode envelope: %w", err)
 	}
-	datastores = query.DataStores.DataStore
-	return
+	if len(envelope.DataStores) == 0 || string(envelope.DataStores) == "null" || envelope.DataStores[0] == '"' {
+		// Empty-collection wire form: GeoServer returns `{"dataStores":""}`.
+		return nil, nil
+	}
+	var inner struct {
+		DataStore []*Resource `json:"dataStore,omitempty"`
+	}
+	if err = json.Unmarshal(envelope.DataStores, &inner); err != nil {
+		return nil, fmt.Errorf("GetDatastores: decode list: %w", err)
+	}
+	return inner.DataStore, nil
 }
 
 // GetDatastoreDetails returns the full datastore document using context.Background.

--- a/datastores_unit_test.go
+++ b/datastores_unit_test.go
@@ -164,3 +164,35 @@ func TestDatastores_CreateDatastore_AppliesDBSchemaDefault(t *testing.T) {
 	assert.True(t, created)
 	assert.Contains(t, captured, `"$":"public"`)
 }
+
+// Regression for issue #22: GeoServer 2.28+ returns `{"dataStores":""}` (a
+// bare string) for an empty datastore collection, which was failing to
+// unmarshal into the `{"dataStores":{"dataStore":[…]}}` struct shape.
+func TestDatastores_GetDatastores_EmptyCollection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/rest/workspaces/empty/datastores", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dataStores":""}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	got, err := gs.GetDatastoresContext(context.Background(), "empty")
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDatastores_GetDatastores_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dataStores":{"dataStore":[{"name":"states_pg","href":"http://x/states_pg.json"},{"name":"taz_shapes"}]}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	gs := newTestCatalog(srv)
+	got, err := gs.GetDatastoresContext(context.Background(), "topp")
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+	assert.Equal(t, "states_pg", got[0].Name)
+}

--- a/v2/rest/datastores/datastores.go
+++ b/v2/rest/datastores/datastores.go
@@ -2,6 +2,7 @@ package datastores
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -68,6 +69,11 @@ func (c *WorkspaceClient) Workspace() string { return c.workspace }
 //
 // Returns a *APIError wrapping ErrNotFound if the workspace itself does
 // not exist.
+//
+// Handles GeoServer's empty-collection wire quirk: an empty datastore
+// list comes back as `{"dataStores":""}` (a bare string) rather than
+// `{"dataStores":{"dataStore":[]}}`. Both shapes are accepted; the
+// empty form returns a nil slice.
 func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Datastore, error) {
 	const op = "Datastores.List"
 	if c.workspace == "" {
@@ -77,11 +83,23 @@ func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Datastore,
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	var resp listResponse
-	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+	var envelope struct {
+		DataStores json.RawMessage `json:"dataStores"`
+	}
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &envelope); err != nil {
 		return nil, err
 	}
-	return resp.DataStores.DataStore, nil
+	if len(envelope.DataStores) == 0 || string(envelope.DataStores) == "null" || envelope.DataStores[0] == '"' {
+		// Empty-collection: GeoServer returns `{"dataStores":""}`.
+		return nil, nil
+	}
+	var inner struct {
+		DataStore []Datastore `json:"dataStore"`
+	}
+	if err := json.Unmarshal(envelope.DataStores, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode datastores list: %w", op, err)
+	}
+	return inner.DataStore, nil
 }
 
 // Iter returns a [iter.Seq2] over the datastore list. Useful when

--- a/v2/rest/datastores/datastores_test.go
+++ b/v2/rest/datastores/datastores_test.go
@@ -158,6 +158,26 @@ func TestList_OK(t *testing.T) {
 	}
 }
 
+// Regression for v1 issue #22: GeoServer 2.28+ returns `{"dataStores":""}`
+// (a bare string) for an empty datastore collection rather than the
+// expected `{"dataStores":{"dataStore":[]}}` shape. List must accept both.
+func TestList_EmptyCollection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dataStores":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Datastores.InWorkspace("empty").List(context.Background(), datastores.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for empty collection, got %+v", got)
+	}
+}
+
 func TestList_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/v2/rest/datastores/types.go
+++ b/v2/rest/datastores/types.go
@@ -160,13 +160,6 @@ type rawConnector struct{ d Datastore }
 // Datastore returns the wrapped Datastore as-is.
 func (r rawConnector) Datastore() Datastore { return r.d }
 
-// listResponse mirrors GeoServer's `{"dataStores":{"dataStore":[…]}}` shape.
-type listResponse struct {
-	DataStores struct {
-		DataStore []Datastore `json:"dataStore"`
-	} `json:"dataStores"`
-}
-
 // detailResponse mirrors GeoServer's `{"dataStore":{…}}` shape.
 type detailResponse struct {
 	DataStore Datastore `json:"dataStore"`


### PR DESCRIPTION
## Summary

Fixes the wire-format bug @sotex reported in #22 (Feb 2023): GeoServer 2.28+ returns the bare-string sentinel `{"dataStores":""}` for an empty datastores collection instead of `{"dataStores":{"dataStore":[]}}`. Both v1 `GetDatastoresContext` and v2 `Datastores.InWorkspace(ws).List` failed to unmarshal that shape:

```
json: cannot unmarshal string into Go struct field .DataStores
of type struct { DataStore []*geoserver.Resource }
```

This is the same wire quirk v1 already handled for coverages and styles (and v2 styles). Apply the same `json.RawMessage` envelope pattern: decode the outer field raw, treat `""` / `null` as the empty case, only unmarshal the inner array shape when the envelope is an object.

## Changes

- `datastores.go` (v1): `GetDatastoresContext` accepts both shapes; the empty form returns a `nil` slice.
- `v2/rest/datastores/datastores.go`: `List` accepts both shapes likewise.
- `v2/rest/datastores/types.go`: drops the now-unused `listResponse` struct.
- v1 + v2 tests cover both regressions.

## Tests

```
v1:
  TestDatastores_GetDatastores_EmptyCollection   PASS
  TestDatastores_GetDatastores_Populated         PASS

v2:
  TestList_EmptyCollection                       PASS
  TestList_OK (existing populated path)          PASS
```

`golangci-lint run ./...` clean across both modules.

Closes #22.

## Test plan

- [x] `go build ./...` clean (both modules)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` green (v1 + v2)
- [x] `golangci-lint run ./...` clean
- [ ] CI: `Lint`, `Unit tests (Go 1.25)`, `Unit tests v2 (Go 1.25)`, `govulncheck`, `Analyze (Go)` green
- [ ] CI: `GeoServer 2.27.4`, `GeoServer 2.28.0` integration green
