### PR TITLE
chore: prep v1.1.1 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] — Unreleased
+
+Patch release. Bug fix plus the internal restructure that landed in `master` after v1.1.0. No public API change. Existing v1.1.0 callers can upgrade with only a `go.mod` bump.
+
+### Fixed
+
+- **`GetDatastores` empty-collection wire form** ([#22](https://github.com/hishamkaram/geoserver/issues/22)) — GeoServer 2.28+ returns `{"dataStores":""}` (a bare string) for an empty datastore collection rather than `{"dataStores":{"dataStore":[]}}`, which broke unmarshal on the fixed struct shape with `json: cannot unmarshal string into Go struct field …`. `GetDatastoresContext` now accepts both shapes; the empty form returns a `nil` slice. Same envelope pattern v1.1 already had for coverages and styles. Reported by @sotex.
+
 ### Changed — internal restructure (no API change)
 
 The implementation behind a few public methods on `*GeoServer` has moved into a new `internal/transport` package. The exported symbols, signatures, and observable behavior are byte-identical to v1.1.0 — verified by full unit + integration suites on GeoServer 2.27.4 and 2.28.0 plus the `breaking-change-checker` agent's exported-API diff.


### PR DESCRIPTION
## Summary

Stages the v1.1.1 CHANGELOG stanza so a tag push (`git tag v1.1.1 && git push origin v1.1.1`) triggers the release.yml workflow's `awk`-extracted release notes cleanly. No code changes.

Covers:

- **Fixed**: `GetDatastores` empty-collection wire form (issue #22, reported by @sotex). The bug fix already landed in #55.
- **Changed**: the internal/transport restructure that was already in `[Unreleased]` from PR #41. Moved under the v1.1.1 stanza so it ships with the tag.

Tagging is held until the user runs:

```bash
git tag v1.1.1
git push origin v1.1.1
```

— then GitHub Releases auto-generates a release with just the v1.1.1 stanza as the body (release.yml handles the extraction).

## Test plan

- [x] CHANGELOG entry follows the existing Keep-a-Changelog format
- [x] release.yml's awk extractor matches `## [1.1.1]` (verified the awk pattern `^## \[1\.1\.1\]` against the new heading)
- [ ] Docs-only change; CI gates pass