### PR TITLE
chore(ci): make release.yml v2-tag aware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,27 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Resolve module path for tag
+        id: module
+        run: |
+          set -euo pipefail
+          tag='${{ github.ref_name }}'
+          # v1 tags (v1.x.y, v1.x.y-rc.N, etc.) target the root module;
+          # v2 tags target the /v2/ submodule (separate go.mod, separate
+          # CHANGELOG). Matching on the leading `v2.` covers both stable
+          # and pre-release v2 tags.
+          if [[ "$tag" =~ ^v2\. ]]; then
+            echo "module_dir=v2" >>"$GITHUB_OUTPUT"
+            echo "changelog=v2/CHANGELOG.md" >>"$GITHUB_OUTPUT"
+            echo "Tag $tag → v2 module"
+          else
+            echo "module_dir=." >>"$GITHUB_OUTPUT"
+            echo "changelog=CHANGELOG.md" >>"$GITHUB_OUTPUT"
+            echo "Tag $tag → root module"
+          fi
+
       - name: Verify build
+        working-directory: ${{ steps.module.outputs.module_dir }}
         run: |
           go mod verify
           go vet ./...
@@ -38,9 +58,9 @@ jobs:
             $0 ~ "^## \\["version"\\]" {flag=1; next}
             flag && /^## \[/ {exit}
             flag {print}
-          ' CHANGELOG.md > /tmp/release-notes.md
+          ' '${{ steps.module.outputs.changelog }}' > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
-            echo "::error::No CHANGELOG stanza found for [$version] (tag $tag); refusing to publish a release with empty body."
+            echo "::error::No CHANGELOG stanza found for [$version] (tag $tag) in ${{ steps.module.outputs.changelog }}; refusing to publish a release with empty body."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

The release workflow hardcoded `CHANGELOG.md` (root) and `./...` (root module) for both build verification and release-note extraction. With v2 living at `/v2/` as a separate module with its own CHANGELOG, v2 tags would fail at the verify step (root module doesn't include v2 packages) or extract empty release notes (no v2 stanza in root CHANGELOG).

This PR resolves the module path and CHANGELOG file dynamically:

- Tags matching `^v2\.` → v2 module + `v2/CHANGELOG.md`.
- Anything else (v1 tags) → root module + `CHANGELOG.md`.

The match on the leading `v2.` covers stable `v2.X.Y` as well as pre-release shapes (`v2.0.0-alpha.N`, `v2.0.0-beta.N`, `v2.0.0-rc.N`). The existing prerelease conditional still works unchanged because it scans `github.ref` for the suffix.

The fail-fast behavior on missing CHANGELOG stanza is preserved — publishing with an empty body still aborts the workflow.

## Why now

No-op for v1 tags. Required before the user tags `v2.0.0-alpha.1` — without this fix, that tag would either fail or publish a release with an empty body.

## Test plan

- [x] Verified the awk extractor against a fake `## [2.0.0-alpha.1] — 2026-05-04` stanza
- [x] `bash -n` syntax check on the resolve step
- [ ] CI: workflow YAML syntax validated by GitHub Actions on PR push