### PR TITLE
docs(v2): add godoc Example_* functions for pkg.go.dev rendering

### DIFF
--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -1,0 +1,83 @@
+package geoserver_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// ExampleNew constructs a Client against a local GeoServer instance.
+// All other configuration (auth, timeout, logging) is layered via
+// [geoserver.Option] values.
+func ExampleNew() {
+	c, err := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(10*time.Second),
+	)
+	if err != nil {
+		// In real code: handle the error. New only fails on
+		// invalid serverURL or option misconfiguration.
+		panic(err)
+	}
+	_ = c
+}
+
+// ExampleNew_basicAuth shows the typical credential setup for an
+// on-premise GeoServer instance.
+func ExampleNew_basicAuth() {
+	_, _ = geoserver.New(
+		"https://geoserver.example.com/geoserver",
+		geoserver.WithBasicAuth("admin", os.Getenv("GEOSERVER_PASSWORD")),
+	)
+}
+
+// ExampleNew_bearerToken shows how to authenticate against a
+// GeoServer fronted by an OAuth2 / JWT proxy.
+func ExampleNew_bearerToken() {
+	_, _ = geoserver.New(
+		"https://geoserver.example.com/geoserver",
+		geoserver.WithBearerToken(os.Getenv("GEOSERVER_TOKEN")),
+	)
+}
+
+// ExampleNew_logging wires the client's slog handler to text output
+// on stderr at debug level — every HTTP request is logged.
+func ExampleNew_logging() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	_, _ = geoserver.New(
+		"http://localhost:8080/geoserver",
+		geoserver.WithLogger(logger),
+	)
+}
+
+// Example_errorHandling shows the two idiomatic ways to inspect a
+// returned error: [errors.Is] against the package sentinels for
+// status-code matching, and [errors.As] to a [*geoserver.APIError]
+// for the full request context.
+func Example_errorHandling() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_, err := c.Workspaces.Get(context.Background(), "no-such-workspace")
+	switch {
+	case err == nil:
+		// found
+	case errors.Is(err, geoserver.ErrNotFound):
+		fmt.Println("not found — create it instead")
+	case errors.Is(err, geoserver.ErrUnauthorized):
+		fmt.Println("credentials rejected")
+	default:
+		// Inspect the typed error for diagnostics.
+		var apiErr *geoserver.APIError
+		if errors.As(err, &apiErr) {
+			fmt.Printf("%s %s -> %d\n", apiErr.Method, apiErr.URL, apiErr.StatusCode)
+		}
+	}
+}

--- a/v2/rest/datastores/example_test.go
+++ b/v2/rest/datastores/example_test.go
@@ -1,0 +1,75 @@
+package datastores_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/datastores"
+)
+
+// ExampleClient_InWorkspace returns a workspace-scoped datastore
+// client. All datastore operations are workspace-scoped — the root
+// [*Client] is just an entry point.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ws := c.Datastores.InWorkspace("topp")
+	_ = ws // ws.Get / ws.Create / ws.List / ws.Update / ws.Delete
+}
+
+// ExampleWorkspaceClient_Create_postGIS publishes a PostGIS connection
+// using the convenience [datastores.PostGIS] connector. For other
+// drivers, supply a [datastores.Datastore] directly via
+// [datastores.Raw].
+func ExampleWorkspaceClient_Create_postGIS() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	err := c.Datastores.InWorkspace("topp").Create(context.Background(), datastores.PostGIS{
+		Name:     "states_pg",
+		Host:     "postgis.example.com",
+		Port:     5432,
+		Database: "gis",
+		Schema:   "public",
+		User:     "gis_ro",
+		Password: "secret",
+	})
+	if errors.Is(err, geoserver.ErrConflict) {
+		fmt.Println("already exists")
+	}
+}
+
+// ExampleWorkspaceClient_Create_raw publishes a shapefile via the
+// [datastores.Raw] adapter — useful for drivers that don't have a
+// dedicated convenience type yet.
+func ExampleWorkspaceClient_Create_raw() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Datastores.InWorkspace("topp").Create(context.Background(),
+		datastores.Raw(datastores.Datastore{
+			Name: "states_shp",
+			ConnectionParameters: datastores.ConnectionParameters{
+				Entry: []datastores.ConnectionEntry{
+					{Key: "url", Value: "file:data/shapefiles/states.shp"},
+				},
+			},
+		}))
+}
+
+// ExampleWorkspaceClient_Iter ranges over every datastore in a
+// workspace.
+func ExampleWorkspaceClient_Iter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	for ds, err := range c.Datastores.InWorkspace("topp").Iter(context.Background(), datastores.ListOptions{}) {
+		if err != nil {
+			return
+		}
+		fmt.Printf("%s (%s)\n", ds.Name, ds.Type)
+	}
+}

--- a/v2/rest/styles/example_test.go
+++ b/v2/rest/styles/example_test.go
@@ -1,0 +1,55 @@
+package styles_test
+
+import (
+	"context"
+	"os"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/styles"
+)
+
+// ExampleClient_InWorkspace returns a workspace-scoped styles client.
+// Without InWorkspace the client operates against the global
+// /rest/styles endpoint.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	global := c.Styles                     // operates on /rest/styles
+	scoped := c.Styles.InWorkspace("topp") // operates on /rest/workspaces/topp/styles
+
+	_, _ = global, scoped
+}
+
+// ExampleClient_Create registers a workspace-scoped style metadata
+// document. Follow with [Client.UploadSLD] to attach the SLD body.
+//
+// The workspace-scoped POST endpoint requires Accept: */* (a GeoServer
+// REST quirk) — v2 applies this automatically; the global path uses
+// the default Accept.
+func ExampleClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Styles.InWorkspace("topp").Create(context.Background(), &styles.Style{
+		Name: "my-polygon",
+	})
+}
+
+// ExampleClient_UploadSLD uploads or replaces the SLD body for an
+// existing style. Default Content-Type is "application/vnd.ogc.sld+xml"
+// (SLD 1.0); override via [styles.UploadOptions.Format] for SE 1.1 or
+// GeoCSS.
+func ExampleClient_UploadSLD() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	f, err := os.Open("polygon.sld")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_ = c.Styles.InWorkspace("topp").UploadSLD(context.Background(),
+		"my-polygon", f, styles.UploadOptions{})
+}

--- a/v2/rest/workspaces/example_test.go
+++ b/v2/rest/workspaces/example_test.go
@@ -1,0 +1,84 @@
+package workspaces_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+// ExampleClient_Get fetches a single workspace by name. Match
+// [geoserver.ErrNotFound] via [errors.Is] to detect "doesn't exist"
+// rather than checking for nil first — there is no Exists method on
+// the v2 surface (see encoding/json and database/sql for the same
+// idiom).
+func ExampleClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ws, err := c.Workspaces.Get(context.Background(), "topp")
+	switch {
+	case errors.Is(err, geoserver.ErrNotFound):
+		fmt.Println("not found")
+	case err != nil:
+		// real failure
+	default:
+		fmt.Printf("%s isolated=%v\n", ws.Name, ws.Isolated)
+	}
+}
+
+// ExampleClient_Iter ranges over every workspace using Go 1.23+
+// range-over-func. The yielded error is non-nil only on the first
+// iteration if the underlying List call fails.
+func ExampleClient_Iter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	for ws, err := range c.Workspaces.Iter(context.Background(), workspaces.ListOptions{}) {
+		if err != nil {
+			// fetch failed — bail out
+			return
+		}
+		fmt.Println(ws.Name)
+	}
+}
+
+// ExampleClient_Create registers a fresh workspace. A duplicate name
+// surfaces as an [*geoserver.APIError] wrapping
+// [geoserver.ErrConflict].
+func ExampleClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	err := c.Workspaces.Create(context.Background(), &workspaces.Workspace{
+		Name:     "my-workspace",
+		Isolated: false,
+	})
+	if errors.Is(err, geoserver.ErrConflict) {
+		fmt.Println("already exists")
+	}
+}
+
+// ExampleClient_Update flips the workspace's Isolated flag. The
+// pointer field on [workspaces.WorkspacePatch] lets callers
+// distinguish "leave field alone" (nil) from "set to false" (&false).
+func ExampleClient_Update() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	isolated := true
+	_ = c.Workspaces.Update(context.Background(), "my-workspace",
+		&workspaces.WorkspacePatch{Isolated: &isolated})
+}
+
+// ExampleClient_Delete removes a workspace and (with Recurse=true)
+// every datastore, layer, and style it contains.
+func ExampleClient_Delete() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Workspaces.Delete(context.Background(), "my-workspace",
+		workspaces.DeleteOptions{Recurse: true})
+}


### PR DESCRIPTION
## Summary

Add godoc `Example_*` functions to v2 so `pkg.go.dev` renders inline usage demos under each public symbol. Examples without `// Output:` comments are compile-checked by `go test` but not executed — they stay green in CI without needing a live GeoServer instance, while still failing fast if the public surface drifts.

## Coverage

| File | Examples |
|---|---|
| `v2/example_test.go` | `ExampleNew`, `ExampleNew_basicAuth`, `ExampleNew_bearerToken`, `ExampleNew_logging`, `Example_errorHandling` |
| `v2/rest/workspaces/example_test.go` | `ExampleClient_Get`, `ExampleClient_Iter`, `ExampleClient_Create`, `ExampleClient_Update`, `ExampleClient_Delete` |
| `v2/rest/datastores/example_test.go` | `ExampleClient_InWorkspace`, `ExampleWorkspaceClient_Create_postGIS`, `ExampleWorkspaceClient_Create_raw`, `ExampleWorkspaceClient_Iter` |
| `v2/rest/styles/example_test.go` | `ExampleClient_InWorkspace`, `ExampleClient_Create`, `ExampleClient_UploadSLD` |

The set covers the three resources users hit first (workspaces, datastores, styles) plus the package-level patterns (constructor with options, `errors.Is(err, ErrNotFound)`, `errors.As(&apiErr)`). Other resources can pick up the same pattern in follow-up PRs.

## Test plan

- [x] `cd v2 && go vet ./...` clean
- [x] `cd v2 && go test -count=1 ./...` green (all examples compile)
- [x] `cd v2 && golangci-lint run ./...` 0 issues
