### PR TITLE
chore: date release stanzas for v1.1.1 and v2.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.1] — Unreleased
+## [1.1.1] — 2026-05-03
 
 Patch release. Bug fix plus the internal restructure that landed in `master` after v1.1.0. No public API change. Existing v1.1.0 callers can upgrade with only a `go.mod` bump.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.0.0-alpha.1] — 2026-05-03
+
+First public preview of v2. Surface is wide (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL) and exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Public API may still change before `v2.0.0` based on early-adopter feedback. No production guarantees.
+
 ### Added
 
 - Initial scaffold. `*Client` immutable constructor (`New`) with functional options (`WithHTTPClient`, `WithTransport`, `WithBasicAuth`, `WithBearerToken`, `WithLogger`, `WithUserAgent`, `WithTimeout`, `WithHeader`).
@@ -43,4 +47,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - New CI step `Run v2 integration tests` runs the suite alongside the v1 integration tests against both `GeoServer 2.27.4` and `GeoServer 2.28.0` matrix legs; both legs must pass for PR merge.
 - New Makefile target `make test-v2-integration` for local runs against `make compose-up`.
 
-No release tag yet; the module's first published tag will be `v2.0.0-alpha.1` when the surface is wide enough to warrant a soak.
+### Added (godoc)
+
+- `v2/example_test.go`, `v2/rest/workspaces/example_test.go`, `v2/rest/datastores/example_test.go`, `v2/rest/styles/example_test.go` — godoc `Example_*` functions that render under each public symbol on `pkg.go.dev`. Examples without `// Output:` comments compile-check via `go test` but don't execute, so they stay green without a live GeoServer.


### PR DESCRIPTION
## Summary

Date the v1.1.1 and v2.0.0-alpha.1 release stanzas ahead of tagging both releases.

- `CHANGELOG.md`: `[1.1.1] — Unreleased` → `[1.1.1] — 2026-05-03`
- `v2/CHANGELOG.md`: graduate `[Unreleased]` → `[2.0.0-alpha.1] — 2026-05-03` (with a one-paragraph release summary), keep an empty `[Unreleased]` section above for future work, and fold in the godoc `Example_*` work from PR #59 under "Added (godoc)".

Verified release.yml's awk extraction returns the right body for both `v1.1.1` and `v2.0.0-alpha.1` tags.

## Test plan

- [x] `awk` dry-run against both files extracts the expected stanza
- [x] No code changes; tests are unchanged
