### PR TITLE
docs: refresh READMEs for v2.0.0-alpha.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The library was dormant for ~3 years (Feb 2023 → May 2026) before being revive
 ## Roadmap
 
 - **v1.1.x** — security fixes, integration test maintenance, additive Dependabot updates.
-- **v2** — pre-alpha at `github.com/hishamkaram/geoserver/v2`. The full catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, and about have been ported and unit-tested; only WMS GetCapabilities remains pending (deferred to a v2.x point release after the `ows/wms/` XML subpackage lands).
+- **v2** — `v2.0.0-alpha.1` published at `github.com/hishamkaram/geoserver/v2` (`go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1`). The full catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, and about are ported and exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Only WMS GetCapabilities remains pending (deferred to a v2.x point release after the `ows/wms/` XML subpackage lands). Public API may still refine before `v2.0.0` — no production guarantees yet.
 
   Design themes (now realized in code):
   - Resource sub-clients (`c.Workspaces.Get(ctx, name)`, `c.Datastores.InWorkspace(ws).Get(...)`, `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Get(...)`).

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,10 +1,15 @@
 # geoserver/v2
 
-> ⚠️ **In development.** v2 has feature parity with v1 today (catalog, security, ACL, settings, about, namespaces) — only WMS GetCapabilities is deferred to a v2.x point release once the `ows/wms/` XML subpackage lands. The public API is not yet stable; expect refinement before `v2.0.0-beta.1`. **For production use today, use the v1 line:**
+> 🧪 **`v2.0.0-alpha.1` is published.** v2 has feature parity with v1 today (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL); only WMS GetCapabilities is deferred to a v2.x point release once the `ows/wms/` XML subpackage lands. Public API may still change before `v2.0.0` based on early-adopter feedback — no production guarantees yet. **For stable production use, stay on the v1 line:**
 >
 > ```go
-> import "github.com/hishamkaram/geoserver"          // v1 — stable, full surface
-> import "github.com/hishamkaram/geoserver/v2"       // v2 — in development
+> import "github.com/hishamkaram/geoserver"          // v1.1.x — stable, full surface
+> import "github.com/hishamkaram/geoserver/v2"       // v2.0.0-alpha.1 — preview
+> ```
+>
+> Install:
+> ```sh
+> go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1
 > ```
 
 This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).


### PR DESCRIPTION
## Summary

Update both READMEs now that `v2.0.0-alpha.1` is published.

- `v2/README.md` banner: "In development" → "v2.0.0-alpha.1 published" with install one-liner and prerelease disclaimer
- `README.md` Roadmap: "v2 — pre-alpha" → published install + integration-test status

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] Install command (`go get …@v2.0.0-alpha.1`) matches the actual tag