### PR TITLE
docs(v2): godoc Example_* for remaining 10 sub-clients

### DIFF
--- a/v2/rest/about/example_test.go
+++ b/v2/rest/about/example_test.go
@@ -1,0 +1,48 @@
+package about_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// Example_ping issues a cheap liveness probe. Useful at boot time
+// to fail fast if GeoServer isn't reachable, before any resource
+// calls.
+func Example_ping() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(2*time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := c.About.Ping(ctx); err != nil {
+		switch {
+		case errors.Is(err, geoserver.ErrUnauthorized):
+			fmt.Println("up but credentials rejected")
+		default:
+			fmt.Println("not reachable")
+		}
+	}
+}
+
+// Example_version reads the full component version document. Useful
+// for diagnostics and for gating feature paths on a minimum GeoServer
+// version.
+func Example_version() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	info, err := c.About.Version(context.Background())
+	if err != nil {
+		return
+	}
+	for _, r := range info.Resource {
+		fmt.Printf("%s = %s\n", r.Name, r.Version)
+	}
+}

--- a/v2/rest/acl/example_test.go
+++ b/v2/rest/acl/example_test.go
@@ -1,0 +1,49 @@
+package acl_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/acl"
+)
+
+// ExampleClient_Layers returns the layer-ACL sub-client. Future
+// service-level and catalog-level ACL endpoints will live alongside
+// (e.g., c.ACL.Services(), c.ACL.Catalog()).
+func ExampleClient_Layers() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.ACL.Layers()
+}
+
+// ExampleLayersClient_Add grants the EDITOR role write access to
+// every layer in the topp workspace. Empty Layer defaults to "*"
+// (any layer); empty Roles encodes as "*" (any role) — be deliberate.
+func ExampleLayersClient_Add() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.ACL.Layers().Add(context.Background(), acl.Rule{
+		Workspace: "topp",
+		Layer:     "*",
+		Operation: acl.OpWrite,
+		Roles:     []string{"EDITOR"},
+	})
+}
+
+// ExampleLayersClient_List dumps every layer ACL rule on the server.
+func ExampleLayersClient_List() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	rules, err := c.ACL.Layers().List(context.Background(), acl.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, r := range rules {
+		key, roles := r.Encode()
+		fmt.Printf("%s -> %s\n", key, roles)
+	}
+}

--- a/v2/rest/coverages/example_test.go
+++ b/v2/rest/coverages/example_test.go
@@ -1,0 +1,54 @@
+package coverages_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/coverages"
+)
+
+// ExampleClient_InWorkspace shows the 2-level scoping. Coverages live
+// under workspace + coverage store; chain through both before reaching
+// CRUD methods.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	cs := c.Coverages.InWorkspace("nurc").InCoverageStore("world_dem")
+	_ = cs // cs.Get / cs.List / cs.Create / cs.Update / cs.Delete / cs.Discover
+}
+
+// ExampleCoverageStoreClient_Discover lists native coverages in the
+// store. Default mode (DiscoverAll) returns configured + available
+// — most coverage stores expose a single coverage that's already
+// configured, so DiscoverAll is the typical default.
+func ExampleCoverageStoreClient_Discover() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	cs := c.Coverages.InWorkspace("nurc").InCoverageStore("world_dem")
+	names, err := cs.Discover(context.Background(), coverages.DiscoverOptions{})
+	if err != nil {
+		return
+	}
+	for _, n := range names {
+		fmt.Println(n)
+	}
+}
+
+// ExampleCoverageStoreClient_Create publishes a native coverage from
+// the store. NativeCoverageName must match a name returned by
+// [CoverageStoreClient.Discover].
+func ExampleCoverageStoreClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Coverages.InWorkspace("nurc").InCoverageStore("world_dem").Create(context.Background(),
+		&coverages.Coverage{
+			Name:               "world_dem",
+			NativeCoverageName: "world_dem",
+			Title:              "World DEM",
+			SRS:                "EPSG:4326",
+		})
+}

--- a/v2/rest/coveragestores/example_test.go
+++ b/v2/rest/coveragestores/example_test.go
@@ -1,0 +1,48 @@
+package coveragestores_test
+
+import (
+	"context"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/coveragestores"
+)
+
+// ExampleClient_InWorkspace returns a workspace-scoped coverage-stores
+// client. Coverage stores are the raster-side analogue of datastores —
+// each one points at a raster source (GeoTIFF, ImageMosaic, ArcSDE,
+// etc.) and holds zero or more coverages.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.CoverageStores.InWorkspace("nurc")
+}
+
+// ExampleWorkspaceClient_Create publishes a GeoTIFF as a coverage
+// store. URL points at a file inside the GeoServer data directory
+// (or any URL the JVM can resolve).
+func ExampleWorkspaceClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.CoverageStores.InWorkspace("nurc").Create(context.Background(),
+		&coveragestores.CoverageStore{
+			Name:    "world_dem",
+			URL:     "file:data/coverages/world_dem.tif",
+			Type:    "GeoTIFF",
+			Enabled: true,
+		})
+}
+
+// ExampleWorkspaceClient_Update flips the Enabled flag without
+// touching the URL or type. The pointer fields on
+// [coveragestores.Patch] distinguish "leave alone" (nil) from
+// "set to zero value" (&value).
+func ExampleWorkspaceClient_Update() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	enabled := false
+	_ = c.CoverageStores.InWorkspace("nurc").Update(context.Background(), "world_dem",
+		&coveragestores.Patch{Enabled: &enabled})
+}

--- a/v2/rest/featuretypes/example_test.go
+++ b/v2/rest/featuretypes/example_test.go
@@ -1,0 +1,55 @@
+package featuretypes_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
+)
+
+// ExampleClient_InWorkspace shows the 2-level scoping. Feature types
+// live under workspace + datastore, so callers fluently chain through
+// both levels before reaching CRUD methods.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ds := c.FeatureTypes.InWorkspace("topp").InDatastore("states_pg")
+	_ = ds // ds.Get / ds.List / ds.Create / ds.Update / ds.Delete / ds.Discover
+}
+
+// ExampleDatastoreClient_Discover lists tables in the underlying
+// datastore that haven't yet been published as feature types — the
+// typical input to a publish workflow.
+func ExampleDatastoreClient_Discover() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ds := c.FeatureTypes.InWorkspace("topp").InDatastore("states_pg")
+	tables, err := ds.Discover(context.Background(), featuretypes.DiscoverOptions{
+		Kind: featuretypes.DiscoverAvailableWithGeometry,
+	})
+	if err != nil {
+		return
+	}
+	for _, t := range tables {
+		fmt.Println(t)
+	}
+}
+
+// ExampleDatastoreClient_Create publishes a PostGIS table as a feature
+// type. NativeName must match the underlying table; SRS is required
+// for WMS rendering.
+func ExampleDatastoreClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.FeatureTypes.InWorkspace("topp").InDatastore("states_pg").Create(context.Background(),
+		&featuretypes.FeatureType{
+			Name:       "states",
+			NativeName: "states",
+			Title:      "USA States",
+			SRS:        "EPSG:4326",
+		})
+}

--- a/v2/rest/layergroups/example_test.go
+++ b/v2/rest/layergroups/example_test.go
@@ -1,0 +1,50 @@
+package layergroups_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
+)
+
+// ExampleClient_InWorkspace returns a workspace-scoped layer-groups
+// client.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.LayerGroups.InWorkspace("topp")
+}
+
+// ExampleWorkspaceClient_Iter ranges over every layer group in a
+// workspace.
+func ExampleWorkspaceClient_Iter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	for g, err := range c.LayerGroups.InWorkspace("topp").Iter(context.Background(), layergroups.ListOptions{}) {
+		if err != nil {
+			return
+		}
+		fmt.Printf("%s — %d members\n", g.Name, len(g.Publishables.Published))
+	}
+}
+
+// ExampleWorkspaceClient_Create bundles two layers into a SINGLE-mode
+// layer group. The mixed string/object Styles wire form is handled
+// automatically — pass an empty [layergroups.Styles] to default each
+// member's style.
+func ExampleWorkspaceClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.LayerGroups.InWorkspace("topp").Create(context.Background(), &layergroups.LayerGroup{
+		Name: "boundaries",
+		Mode: "SINGLE",
+		Publishables: layergroups.Publishables{Published: layergroups.Published{
+			{Type: "layer", Name: "topp:states"},
+			{Type: "layer", Name: "topp:counties"},
+		}},
+	})
+}

--- a/v2/rest/layers/example_test.go
+++ b/v2/rest/layers/example_test.go
@@ -1,0 +1,54 @@
+package layers_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/layers"
+)
+
+// ExampleClient_InWorkspace returns a workspace-scoped layers client.
+// Layer operations are always workspace-scoped — the root client is
+// just an entry point.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ws := c.Layers.InWorkspace("topp")
+	_ = ws // ws.Get / ws.List / ws.Update / ws.Delete (no Create)
+}
+
+// ExampleWorkspaceClient_Iter ranges over every layer in a workspace.
+// There is no Create method — layers are created as a side-effect of
+// publishing a feature type (via [featuretypes]) or a coverage (via
+// [coverages]); manage them via this client after publish.
+func ExampleWorkspaceClient_Iter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	for l, err := range c.Layers.InWorkspace("topp").Iter(context.Background(), layers.ListOptions{}) {
+		if err != nil {
+			return
+		}
+		fmt.Println(l.Name)
+	}
+}
+
+// ExampleWorkspaceClient_Update reassigns a layer's default style.
+// Useful after [styles.Client.Create]+UploadSLD to make the new SLD
+// the default rendering for a layer.
+func ExampleWorkspaceClient_Update() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ws := c.Layers.InWorkspace("topp")
+	layer, err := ws.Get(context.Background(), "states")
+	if errors.Is(err, geoserver.ErrNotFound) {
+		return
+	}
+
+	layer.DefaultStyle = &layers.Ref{Name: "my-polygon"}
+	_ = ws.Update(context.Background(), "states", layer)
+}

--- a/v2/rest/namespaces/example_test.go
+++ b/v2/rest/namespaces/example_test.go
@@ -1,0 +1,51 @@
+package namespaces_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
+)
+
+// ExampleClient_Get fetches a namespace by prefix. Each workspace gets
+// an auto-created namespace with the same prefix; explicit Create is
+// only needed for namespaces that don't follow that pattern.
+func ExampleClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	ns, err := c.Namespaces.Get(context.Background(), "topp")
+	if errors.Is(err, geoserver.ErrNotFound) {
+		return
+	}
+	if err == nil {
+		fmt.Printf("%s -> %s\n", ns.Prefix, ns.URI)
+	}
+}
+
+// ExampleClient_Iter ranges over every namespace.
+func ExampleClient_Iter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	for ns, err := range c.Namespaces.Iter(context.Background(), namespaces.ListOptions{}) {
+		if err != nil {
+			return
+		}
+		fmt.Println(ns.Prefix)
+	}
+}
+
+// ExampleClient_Create registers a namespace with a non-standard URI
+// (e.g., for an external schema or OGC service binding).
+func ExampleClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Namespaces.Create(context.Background(), &namespaces.Namespace{
+		Prefix: "acme",
+		URI:    "https://schemas.acme.example/v1",
+	})
+}

--- a/v2/rest/security/example_test.go
+++ b/v2/rest/security/example_test.go
@@ -1,0 +1,71 @@
+package security_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/security"
+)
+
+// ExampleClient_Users returns the users sub-client for the default
+// user/group service. Use [Client.UsersInService] for a custom
+// service.
+func ExampleClient_Users() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	users := c.Security.Users()
+	for _, u := range mustList(users.List(context.Background(), security.ListOptions{})) {
+		fmt.Printf("%s enabled=%v\n", u.Name, u.Enabled)
+	}
+}
+
+// ExampleUsersClient_Create registers a new user in the default
+// user/group service. The Password field is write-only — GeoServer
+// won't return the hash on subsequent reads.
+func ExampleUsersClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Security.Users().Create(context.Background(), &security.User{
+		Name:     "alice",
+		Password: "s3cret",
+		Enabled:  true,
+	})
+}
+
+// ExampleRolesClient_AssignToUser grants a role to a user. The role
+// must already exist (create with [RolesClient.Create]).
+func ExampleRolesClient_AssignToUser() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Security.Roles.Create(context.Background(), "EDITOR")
+	_ = c.Security.Roles.AssignToUser(context.Background(), "EDITOR", "alice")
+}
+
+// ExampleRolesClient_ForUser returns every role assigned to a user.
+// Useful for an authz audit pass.
+func ExampleRolesClient_ForUser() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	roles, err := c.Security.Roles.ForUser(context.Background(), "alice")
+	if err != nil {
+		return
+	}
+	for _, r := range roles {
+		fmt.Println(r)
+	}
+}
+
+// mustList is an example helper: panics on List errors so the example
+// stays focused on the successful path. Real code should match
+// [errors.Is] against the package sentinels and recover gracefully.
+func mustList[T any](xs []T, err error) []T {
+	if err != nil {
+		panic(err)
+	}
+	return xs
+}

--- a/v2/rest/settings/example_test.go
+++ b/v2/rest/settings/example_test.go
@@ -1,0 +1,38 @@
+package settings_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// ExampleClient_Get fetches the singleton global-settings document.
+func ExampleClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	s, err := c.Settings.Get(context.Background())
+	if err != nil {
+		return
+	}
+	fmt.Printf("charset=%s decimals=%d\n",
+		s.Global.Settings.Charset, s.Global.Settings.NumDecimals)
+}
+
+// ExampleClient_Update changes the verbose-exceptions flag and the
+// feature-type cache size. Settings is a merge-patch endpoint —
+// fetch, mutate, and put back.
+func ExampleClient_Update() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	s, err := c.Settings.Get(context.Background())
+	if err != nil {
+		return
+	}
+	s.Global.Settings.VerboseExceptions = true
+	s.Global.FeatureTypeCacheSize = 1000
+
+	_ = c.Settings.Update(context.Background(), s)
+}


### PR DESCRIPTION
## Summary

Completes pkg.go.dev godoc-example coverage across v2. Builds on PR #59 (workspaces / datastores / styles) with the remaining 10 sub-clients: layers, layergroups, featuretypes, coverages, coveragestores, namespaces, settings, security, acl, about.

Examples without \`// Output:\` comments compile-check via \`go test\` but don't execute, so they stay green in CI without needing a live GeoServer.

## Highlights

| Sub-client | Examples |
|---|---|
| layers | InWorkspace, Iter, Update (style reassignment) |
| layergroups | InWorkspace, Iter, Create with multi-member Publishables |
| featuretypes | InWorkspace 2-level, Discover, Create |
| coverages | InWorkspace 2-level under coverage stores, Discover, Create |
| coveragestores | Create GeoTIFF, Update with Patch pointers |
| namespaces | Get, Iter, Create |
| settings | Get, Update fetch-mutate-put |
| security | Users, Roles.AssignToUser, Roles.ForUser |
| acl | Layers.Add, Layers.List (Operation enum) |
| about | Ping with deadline, Version |

The \`about\` package uses package-level \`Example_ping\` / \`Example_version\` naming because go vet's example checker plus staticcheck \`QF1011\` collide on type-asserting \`c.About\` through the parent client; the package-level form sidesteps that without losing pkg.go.dev rendering.

## Test plan

- [x] \`cd v2 && go vet ./...\` clean
- [x] \`cd v2 && go test -count=1 ./...\` green (all 10 packages compile-check)
- [x] \`cd v2 && golangci-lint run ./...\` 0 issues