### PR TITLE
feat(v2): port WMS GetCapabilities + system reload/reset (v1 parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The library was dormant for ~3 years (Feb 2023 → May 2026) before being revive
 ## Roadmap
 
 - **v1.1.x** — security fixes, integration test maintenance, additive Dependabot updates.
-- **v2** — `v2.0.0-alpha.1` published at `github.com/hishamkaram/geoserver/v2` (`go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1`). The full catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, and about are ported and exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Only WMS GetCapabilities remains pending (deferred to a v2.x point release after the `ows/wms/` XML subpackage lands). Public API may still refine before `v2.0.0` — no production guarantees yet.
+- **v2** — `v2.0.0-alpha.1` published at `github.com/hishamkaram/geoserver/v2` (`go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1`). Full v1 parity at `master`: catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, about, system (reload + cache reset), and WMS GetCapabilities (`v2/ows/wms`). Exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Public API may still refine before `v2.0.0` — no production guarantees yet.
 
   Design themes (now realized in code):
   - Resource sub-clients (`c.Workspaces.Get(ctx, name)`, `c.Datastores.InWorkspace(ws).Get(...)`, `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Get(...)`).

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **`v2/ows/wms/` package** — port of v1's `wms/` package. Same XML type tree (Capabilities, Service, Capability, Layer, Style, BoundingBox, …) so callers move with no shape changes. New free function `wms.ParseCapabilities(io.Reader)` (v2 idiom — `io.Reader` instead of `[]byte`; the deprecated v1 `ParseCapabilities` no-`E` variant that swallowed errors is gone). New sub-client `c.WMS` with `GetCapabilities(ctx, opts)` — global by default, `c.WMS.InWorkspace(ws)` for a workspace-scoped capabilities view. `GetCapabilitiesOptions` carries Version (default "1.1.1") and an optional UpdateSequence cache token.
+- **`v2/rest/system/` package** — port of v1's `configuration.go`. New sub-client `c.System` with `Reload(ctx)` (`POST /rest/reload`) and `ResetCache(ctx)` (`POST /rest/reset`). The v1 typo'd method names (`ReloadConfigration` / `RestConfigrationCache`) are dropped; v2 uses the corrected spelling.
+- **`internal/transport.DoXML`** — XML-decoding equivalent of `DoJSON` with a 32 MiB body cap (`DoJSON`'s 8 KiB cap is too small for real WMS capabilities documents). The error path still uses the 8 KiB cap so an oversized error body can't blow up.
+
+### Added (tests)
+
+- `v2/ows/wms/wms_test.go` — fixture-based parse tests, httptest tests for global + workspace scope, version + updatesequence query handling, and 404 / 500 → sentinel mapping.
+- `v2/ows/wms/wms_integration_test.go` — real GeoServer assertions (capabilities document is non-empty for the global scope and a fresh empty workspace).
+- `v2/rest/system/system_test.go` — httptest tests for Reload + ResetCache happy path, plus 401 / 403 / 500 → sentinel mapping.
+- `v2/rest/system/system_integration_test.go` — real GeoServer Reload + ResetCache (idempotent, safe to repeat).
+- Godoc `Example_*` for both new packages.
+
 ### Added (godoc)
 
 - Godoc `Example_*` functions for the remaining 10 sub-clients (layers, layergroups, featuretypes, coverages, coveragestores, namespaces, settings, security, acl, about) so every public sub-client renders an inline usage demo on `pkg.go.dev`. Examples without `// Output:` comments compile-check via `go test` but don't execute, so they stay green without a live GeoServer (PR #62, post-`v2.0.0-alpha.1`).

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,6 +1,6 @@
 # geoserver/v2
 
-> 🧪 **`v2.0.0-alpha.1` is published.** v2 has feature parity with v1 today (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL); only WMS GetCapabilities is deferred to a v2.x point release once the `ows/wms/` XML subpackage lands. Public API may still change before `v2.0.0` based on early-adopter feedback — no production guarantees yet. **For stable production use, stay on the v1 line:**
+> 🧪 **`v2.0.0-alpha.1` is published.** v2 now has full v1 parity at `master`: workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL, system (reload + cache reset), and WMS GetCapabilities (`v2/ows/wms`). Public API may still change before `v2.0.0` based on early-adopter feedback — no production guarantees yet. **For stable production use, stay on the v1 line:**
 >
 > ```go
 > import "github.com/hishamkaram/geoserver"          // v1.1.x — stable, full surface

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -24,7 +24,10 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/security"
 	"github.com/hishamkaram/geoserver/v2/rest/settings"
 	"github.com/hishamkaram/geoserver/v2/rest/styles"
+	"github.com/hishamkaram/geoserver/v2/rest/system"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+
+	"github.com/hishamkaram/geoserver/v2/ows/wms"
 )
 
 const (
@@ -113,6 +116,17 @@ type Client struct {
 	// [acl.Client.Layers]; service-level and catalog-level ACL
 	// endpoints can be added in follow-up PRs.
 	ACL *acl.Client
+
+	// System is the entry point for server-management operations —
+	// Reload (catalog + configuration from disk) and ResetCache
+	// (store / raster / schema caches). Both require admin auth.
+	System *system.Client
+
+	// WMS is the entry point for WMS service operations — currently
+	// GetCapabilities (XML, decoded into [wms.Capabilities]). Use
+	// [wms.Client.InWorkspace] for a workspace-scoped capabilities
+	// document. WFS / WCS land alongside under v2/ows/ in follow-ups.
+	WMS *wms.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -182,6 +196,8 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.About = about.New(adapter)
 	c.Security = security.New(adapter)
 	c.ACL = acl.New(adapter)
+	c.System = system.New(adapter)
+	c.WMS = wms.New(adapter)
 	return c, nil
 }
 
@@ -299,6 +315,27 @@ func (a coreAdapter) Do(ctx context.Context, op string, method, requestURL strin
 func (a coreAdapter) DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error) {
 	// Placeholder; expand when the first streaming resource ports.
 	return nil, 0, errors.New("geoserver: DoStream not yet implemented")
+}
+
+// DoXML issues a GET-style request and decodes the response as XML.
+// Used by the OWS sub-clients (WMS / WFS / WCS) for GetCapabilities
+// and similar XML endpoints. Response body cap is 32 MiB to handle
+// large capabilities documents; the JSON 8 KiB cap on [Do] would
+// truncate them.
+func (a coreAdapter) DoXML(ctx context.Context, op, method, requestURL string, query map[string]string, out any) error {
+	_, err := transport.DoXML(ctx, a.core.httpClient, a.core.logger, op, transport.Request{
+		Method: method,
+		URL:    requestURL,
+		Query:  query,
+	}, out)
+	if err == nil {
+		return nil
+	}
+	var tErr *transport.Error
+	if errors.As(err, &tErr) {
+		return newAPIError(tErr.Op, tErr.Method, tErr.URL, tErr.StatusCode, tErr.Body)
+	}
+	return err
 }
 
 // DoRaw issues a request with an arbitrary-Reader body and explicit

--- a/v2/internal/transport/transport.go
+++ b/v2/internal/transport/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"log/slog"
@@ -62,6 +63,63 @@ type JSON any
 // On transport error: status is 0; err is the wrapped transport error.
 func DoJSON(ctx context.Context, doer Doer, logger *slog.Logger, op string, req Request, out JSON) (status int, err error) {
 	return doRequest(ctx, doer, logger, op, req, out)
+}
+
+// DoXML sends a request and decodes the response body as XML. Use
+// this for the OWS endpoints (WMS / WFS / WCS GetCapabilities) where
+// the response is XML rather than JSON. Request body, if any, is sent
+// as RawBody — typical OWS calls are GET with no body.
+//
+// On success: out (if non-nil) is xml.Unmarshal'd from the response
+// body; the body cap is [xmlBodyReadCap] (32 MiB) since capabilities
+// documents are often well above the [bodyReadCap] used by [DoJSON].
+//
+// On non-2xx: returns a structured Error wrapping the response body
+// (truncated to [bodyReadCap]) so the caller can inspect what came back.
+//
+// On transport error: status is 0; err is the wrapped transport error.
+func DoXML(ctx context.Context, doer Doer, logger *slog.Logger, op string, req Request, out any) (status int, err error) {
+	if req.Accept == "" {
+		req.Accept = "application/xml"
+	}
+	httpReq, err := buildHTTPRequest(ctx, req)
+	if err != nil {
+		return 0, fmt.Errorf("%s: build request: %w", op, err)
+	}
+
+	resp, err := doer.Do(httpReq)
+	if err != nil {
+		logDebug(logger, "request failed", "op", op, "method", req.Method, "url", req.URL, "err", err)
+		return 0, fmt.Errorf("%s: %w", op, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, bodyReadCap))
+		logDebug(logger, "request done", "op", op, "method", req.Method, "url", req.URL, "status", resp.StatusCode, "body_bytes", len(body))
+		return resp.StatusCode, &Error{
+			Op:         op,
+			Method:     req.Method,
+			URL:        req.URL,
+			StatusCode: resp.StatusCode,
+			Body:       body,
+		}
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, xmlBodyReadCap))
+	if readErr != nil {
+		logDebug(logger, "body read failed", "op", op, "method", req.Method, "url", req.URL, "status", resp.StatusCode, "err", readErr)
+		return resp.StatusCode, fmt.Errorf("%s: read body: %w", op, readErr)
+	}
+	logDebug(logger, "request done", "op", op, "method", req.Method, "url", req.URL, "status", resp.StatusCode, "body_bytes", len(body))
+
+	if out == nil || len(body) == 0 {
+		return resp.StatusCode, nil
+	}
+	if xmlErr := xml.Unmarshal(body, out); xmlErr != nil {
+		return resp.StatusCode, fmt.Errorf("%s: decode response: %w", op, xmlErr)
+	}
+	return resp.StatusCode, nil
 }
 
 // DoRaw sends a request with an arbitrary-Reader body and explicit
@@ -150,6 +208,13 @@ func (e *Error) Error() string {
 // Read body cap matches the public *APIError.Body cap so the wrapper
 // doesn't have to re-truncate.
 const bodyReadCap = 8 << 10 // 8 KiB
+
+// xmlBodyReadCap is the larger cap used by [DoXML] on the success path.
+// WMS / WFS / WCS GetCapabilities documents are commonly tens to
+// hundreds of KiB on real installations; the JSON 8 KiB cap is too
+// small. The error path still uses [bodyReadCap] so an oversized error
+// body doesn't blow up.
+const xmlBodyReadCap = 32 << 20 // 32 MiB
 
 // buildHTTPRequest constructs the http.Request with body / query /
 // Accept set. Auth and User-Agent are applied by the transport

--- a/v2/ows/wms/example_test.go
+++ b/v2/ows/wms/example_test.go
@@ -1,0 +1,54 @@
+package wms_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wms"
+)
+
+// ExampleClient_GetCapabilities fetches the global WMS capabilities
+// document and prints every advertised top-level layer.
+func ExampleClient_GetCapabilities() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	caps, err := c.WMS.GetCapabilities(context.Background(), wms.GetCapabilitiesOptions{})
+	if err != nil {
+		return
+	}
+	fmt.Printf("WMS %s — %s\n", caps.Version, caps.Service.Title)
+	for _, layer := range caps.Capability.Layer.Layer {
+		fmt.Printf("  - %s\n", layer.Title)
+	}
+}
+
+// ExampleClient_InWorkspace returns a workspace-scoped capabilities
+// view — only layers under that workspace appear in the response.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_, _ = c.WMS.InWorkspace("topp").GetCapabilities(context.Background(),
+		wms.GetCapabilitiesOptions{Version: "1.3.0"})
+}
+
+// ExampleParseCapabilities decodes a capabilities document fetched
+// out-of-band — useful for parsing a saved fixture or a body from a
+// custom transport.
+func ExampleParseCapabilities() {
+	body := strings.NewReader(`<?xml version="1.0"?>
+<WMT_MS_Capabilities version="1.1.1">
+  <Service><Title>Demo</Title></Service>
+  <Capability/>
+</WMT_MS_Capabilities>`)
+
+	caps, err := wms.ParseCapabilities(body)
+	if err != nil {
+		return
+	}
+	fmt.Println(caps.Service.Title)
+	// Output: Demo
+}

--- a/v2/ows/wms/types.go
+++ b/v2/ows/wms/types.go
@@ -1,0 +1,225 @@
+// Package wms is the v2 sub-client for the GeoServer WMS service. It
+// covers the GetCapabilities endpoint — fetching the XML capabilities
+// document and parsing it into Go types. The exported XML types mirror
+// v1's wms package one-for-one so callers can move with no shape
+// changes; the parser accepts io.Reader (v2 idiom) instead of []byte.
+//
+// WMS request endpoints (GetMap, GetFeatureInfo, GetLegendGraphic) are
+// HTTP-content endpoints rather than catalog operations and stay on
+// the application layer. WFS / WCS GetCapabilities can land alongside
+// in this package's siblings (ows/wfs, ows/wcs) using the same shape.
+package wms
+
+import "encoding/xml"
+
+// OnlineResource is the xlink:href + xlink:type pair returned for any
+// linkable element (request DCP endpoints, MetadataURL, LegendURL, …).
+type OnlineResource struct {
+	XMLName xml.Name `xml:"OnlineResource"`
+	Type    string   `xml:"http://www.w3.org/1999/xlink type,attr,omitempty"`
+	Href    string   `xml:"http://www.w3.org/1999/xlink href,attr,omitempty"`
+}
+
+// KeywordList is the keyword list attached to a Service or Layer.
+type KeywordList struct {
+	XMLName xml.Name  `xml:"KeywordList,omitempty"`
+	Keyword []*string `xml:"Keyword,omitempty"`
+}
+
+// Get is the GET DCP-type endpoint descriptor.
+type Get struct {
+	XMLName        xml.Name       `xml:"Get"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// Post is the POST DCP-type endpoint descriptor.
+type Post struct {
+	XMLName        xml.Name       `xml:"Post"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// HTTP wraps the GET / POST DCP-type endpoints.
+type HTTP struct {
+	XMLName xml.Name `xml:"HTTP"`
+	Get     *Get     `xml:"Get,omitempty"`
+	Post    *Post    `xml:"Post,omitempty"`
+}
+
+// DCPType wraps the HTTP transport descriptor for a request.
+type DCPType struct {
+	XMLName xml.Name `xml:"DCPType,omitempty"`
+	HTTP    HTTP     `xml:"HTTP,omitempty"`
+}
+
+// RequestEntry describes a single request — its supported Format list
+// and DCPType endpoints. Used inside [Request].
+type RequestEntry struct {
+	XMLName xml.Name
+	Format  []*string `xml:"Format,omitempty"`
+	DCPType DCPType   `xml:"DCPType,omitempty"`
+}
+
+// Request enumerates the WMS operations the server supports along
+// with each operation's DCP endpoints and supported formats.
+type Request struct {
+	XMLName          xml.Name     `xml:"Request"`
+	GetCapabilities  RequestEntry `xml:"GetCapabilities"`
+	GetMap           RequestEntry `xml:"GetMap"`
+	GetFeatureInfo   RequestEntry `xml:"GetFeatureInfo"`
+	DescribeLayer    RequestEntry `xml:"DescribeLayer"`
+	GetLegendGraphic RequestEntry `xml:"GetLegendGraphic"`
+	GetStyles        RequestEntry `xml:"GetStyles"`
+}
+
+// UserDefinedSymbolization is the SLD UserDefinedSymbolization element
+// telling clients whether SLD/UserStyle/UserLayer/RemoteWFS are
+// supported.
+type UserDefinedSymbolization struct {
+	XMLName    xml.Name `xml:"UserDefinedSymbolization"`
+	SupportSLD string   `xml:"SupportSLD,attr"`
+	UserLayer  string   `xml:"UserLayer,attr"`
+	UserStyle  string   `xml:"UserStyle,attr"`
+	RemoteWFS  string   `xml:"RemoteWFS,attr"`
+}
+
+// Exception lists the supported exception report formats.
+type Exception struct {
+	XMLName xml.Name  `xml:"Exception"`
+	Format  []*string `xml:"Format"`
+}
+
+// AuthorityURL points at the authority that issued an [Identifier]
+// (CRS code, layer ID, …). Carries an OnlineResource for the
+// authority's URL.
+type AuthorityURL struct {
+	XMLName        xml.Name       `xml:"AuthorityURL"`
+	Name           string         `xml:"name,attr"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// LatLonBoundingBox is the lat/lon extent of a Layer.
+type LatLonBoundingBox struct {
+	XMLName xml.Name `xml:"LatLonBoundingBox"`
+	MinX    float64  `xml:"minx,attr"`
+	MinY    float64  `xml:"miny,attr"`
+	MaxX    float64  `xml:"maxx,attr"`
+	MaxY    float64  `xml:"maxy,attr"`
+}
+
+// BoundingBox is a layer's CRS-specific extent.
+type BoundingBox struct {
+	XMLName xml.Name `xml:"BoundingBox"`
+	MinX    float64  `xml:"minx,attr"`
+	MinY    float64  `xml:"miny,attr"`
+	MaxX    float64  `xml:"maxx,attr"`
+	MaxY    float64  `xml:"maxy,attr"`
+	SRS     string   `xml:"SRS,attr,omitempty"`
+}
+
+// LegendURL is a renderable legend for a Style.
+type LegendURL struct {
+	XMLName        xml.Name       `xml:"LegendURL"`
+	Height         float64        `xml:"height,attr"`
+	Width          float64        `xml:"width,attr"`
+	Format         string         `xml:"Format"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// Style describes one rendering style for a Layer.
+type Style struct {
+	XMLName   xml.Name  `xml:"Style"`
+	Name      string    `xml:"Name"`
+	Title     string    `xml:"Title"`
+	LegendURL LegendURL `xml:"LegendURL"`
+}
+
+// MetadataURL is a layer-level pointer to an external metadata document.
+type MetadataURL struct {
+	XMLName        xml.Name       `xml:"MetadataURL"`
+	Type           string         `xml:"type,attr"`
+	Format         string         `xml:"Format"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// LogoURL is the logo image for a Service or Attribution.
+type LogoURL struct {
+	XMLName        xml.Name       `xml:"LogoURL"`
+	Width          float32        `xml:"width,attr"`
+	Height         float32        `xml:"height,attr"`
+	Format         string         `xml:"Format"`
+	OnlineResource OnlineResource `xml:"OnlineResource"`
+}
+
+// Dimension declares a non-spatial dimension axis on a Layer
+// (typically time, elevation, custom).
+type Dimension struct {
+	XMLName xml.Name `xml:"Dimension"`
+	Name    string   `xml:"name,attr,omitempty"`
+	Units   string   `xml:"units,attr,omitempty"`
+}
+
+// Extent declares the active value range on a [Dimension].
+type Extent struct {
+	XMLName xml.Name `xml:"Extent"`
+	Name    string   `xml:"name,attr,omitempty"`
+	Default string   `xml:"default,attr,omitempty"`
+}
+
+// Attribution is the per-Layer attribution block (title, online
+// resource, logo).
+type Attribution struct {
+	XMLName        xml.Name       `xml:"Attribution"`
+	Title          string         `xml:"Title,omitempty"`
+	OnlineResource OnlineResource `xml:"OnlineResource,omitempty"`
+	LogoURL        LogoURL        `xml:"LogoURL,omitempty"`
+}
+
+// Layer is one published WMS layer. Layers nest — `Layer.Layer` is
+// the child list when this is a layer group / category.
+type Layer struct {
+	XMLName           xml.Name          `xml:"Layer"`
+	Title             string            `xml:"Title"`
+	Abstract          string            `xml:"Abstract"`
+	Queryable         int8              `xml:"queryable,attr,omitempty"`
+	SRS               []*string         `xml:"SRS,omitempty"`
+	LatLonBoundingBox LatLonBoundingBox `xml:"LatLonBoundingBox,omitempty"`
+	BoundingBox       []*BoundingBox    `xml:"BoundingBox,omitempty"`
+	AuthorityURL      AuthorityURL      `xml:"AuthorityURL,omitempty"`
+	Style             []*Style          `xml:"Style,omitempty"`
+	Layer             []*Layer          `xml:"Layer,omitempty"`
+	MetadataURL       []*MetadataURL    `xml:"MetadataURL,omitempty"`
+	Dimension         Dimension         `xml:"Dimension,omitempty"`
+	Extent            Extent            `xml:"Extent,omitempty"`
+	Attribution       Attribution       `xml:"Attribution,omitempty"`
+}
+
+// Capability is the operations + advertised layer tree.
+type Capability struct {
+	XMLName                  xml.Name                 `xml:"Capability"`
+	Request                  Request                  `xml:"Request"`
+	Exception                Exception                `xml:"Exception"`
+	UserDefinedSymbolization UserDefinedSymbolization `xml:"UserDefinedSymbolization"`
+	Layer                    Layer                    `xml:"Layer"`
+}
+
+// Service is the service-level metadata block (title, keywords, fees,
+// access constraints).
+type Service struct {
+	XMLName           xml.Name       `xml:"Service"`
+	Name              string         `xml:"Name"`
+	Title             string         `xml:"Title"`
+	KeywordList       KeywordList    `xml:"KeywordList"`
+	OnlineResource    OnlineResource `xml:"OnlineResource"`
+	Fees              string         `xml:"Fees"`
+	AccessConstraints string         `xml:"AccessConstraints"`
+}
+
+// Capabilities is the root of the WMS GetCapabilities document
+// (`<WMT_MS_Capabilities>` for WMS 1.1.1).
+type Capabilities struct {
+	XMLName        xml.Name   `xml:"WMT_MS_Capabilities"`
+	Version        string     `xml:"version,attr,omitempty"`
+	UpdateSequence string     `xml:"updateSequence,attr,omitempty"`
+	Service        Service    `xml:"Service"`
+	Capability     Capability `xml:"Capability"`
+}

--- a/v2/ows/wms/wms.go
+++ b/v2/ows/wms/wms.go
@@ -1,0 +1,123 @@
+package wms
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+// Defined as an interface so this subpackage doesn't import the root
+// (which would create an import cycle since the root constructs sub-
+// clients).
+type Core interface {
+	URL(parts ...string) (string, error)
+	DoXML(ctx context.Context, op, method, requestURL string, query map[string]string, out any) error
+}
+
+// Client is the v2 WMS sub-client. The current surface covers
+// [Client.GetCapabilities]; [Client.InWorkspace] returns a
+// workspace-scoped view that issues `/ {workspace}/wms` rather than
+// the global `/wms`.
+//
+//	caps, err := c.WMS.GetCapabilities(ctx, wms.GetCapabilitiesOptions{})
+//	caps, err := c.WMS.InWorkspace("topp").GetCapabilities(ctx, wms.GetCapabilitiesOptions{})
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core Core
+	// workspace is "" for the global scope.
+	workspace string
+}
+
+// New constructs the global-scope WMS sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace returns a fresh WMS client scoped to the given
+// workspace. Use this when you want only the workspace's layer tree
+// in the capabilities document. The original (global-scope) client
+// is unaffected.
+func (c *Client) InWorkspace(workspace string) *Client {
+	return &Client{core: c.core, workspace: workspace}
+}
+
+// Workspace returns the workspace name this client is scoped to,
+// or "" for the global scope.
+func (c *Client) Workspace() string { return c.workspace }
+
+// IsGlobal reports whether this client operates against the global
+// `/wms` endpoint (true) or a workspace-scoped one (false).
+func (c *Client) IsGlobal() bool { return c.workspace == "" }
+
+// GetCapabilitiesOptions controls a [Client.GetCapabilities] call.
+// All fields are optional.
+type GetCapabilitiesOptions struct {
+	// Version is the WMS protocol version requested. Default
+	// "1.1.1" — matches v1's GetCapabilities and is the version
+	// this package's [Capabilities] type tree decodes.
+	Version string
+
+	// UpdateSequence is an optional cache-coordination token.
+	// GeoServer returns 304 / a fresh document depending on the
+	// sequence relative to the server's current state. Leave empty
+	// to always get the current document.
+	UpdateSequence string
+}
+
+// GetCapabilities fetches the WMS GetCapabilities XML document and
+// parses it into a [*Capabilities]. On a 4xx/5xx response, returns a
+// *APIError wrapping the appropriate sentinel.
+func (c *Client) GetCapabilities(ctx context.Context, opts GetCapabilitiesOptions) (*Capabilities, error) {
+	const op = "WMS.GetCapabilities"
+
+	parts := []string{}
+	if c.workspace != "" {
+		parts = append(parts, c.workspace)
+	}
+	parts = append(parts, "wms")
+	u, err := c.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	version := opts.Version
+	if version == "" {
+		version = "1.1.1"
+	}
+	query := map[string]string{
+		"service": "wms",
+		"version": version,
+		"request": "GetCapabilities",
+	}
+	if opts.UpdateSequence != "" {
+		query["updatesequence"] = opts.UpdateSequence
+	}
+
+	var caps Capabilities
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, query, &caps); err != nil {
+		return nil, err
+	}
+	return &caps, nil
+}
+
+// ParseCapabilities reads a WMS GetCapabilities XML document from r
+// and decodes it into a [*Capabilities]. Useful for parsing a
+// capabilities document fetched out-of-band — e.g., a saved fixture,
+// or a body fetched through a custom transport. Returns a typed parse
+// error on malformed input.
+func ParseCapabilities(r io.Reader) (*Capabilities, error) {
+	if r == nil {
+		return nil, errors.New("wms: ParseCapabilities: nil reader")
+	}
+	var caps Capabilities
+	if err := xml.NewDecoder(r).Decode(&caps); err != nil {
+		return nil, fmt.Errorf("wms: parse capabilities: %w", err)
+	}
+	return &caps, nil
+}

--- a/v2/ows/wms/wms_integration_test.go
+++ b/v2/ows/wms/wms_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package wms_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/ows/wms"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func TestWMS_GetCapabilities_Global_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	caps, err := c.WMS.GetCapabilities(ctx, wms.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (global): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty: %+v", caps)
+	}
+	if caps.Service.Name == "" {
+		t.Errorf("Service.Name is empty: %+v", caps.Service)
+	}
+}
+
+func TestWMS_GetCapabilities_Workspace_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	// A fresh workspace with no layers still has a valid (empty)
+	// capabilities document.
+	caps, err := c.WMS.InWorkspace(wsName).GetCapabilities(ctx, wms.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (workspace): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty for workspace-scoped caps")
+	}
+}
+
+func TestWMS_GetCapabilities_NonExistentWorkspace_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// GeoServer's wire behavior on a missing workspace: some versions
+	// return 404, others return a service exception with HTTP 200 and
+	// an XML error body that fails to parse as Capabilities. Either
+	// surfaces as an error; we accept both.
+	_, err := c.WMS.InWorkspace("definitely-not-a-real-workspace-zz").
+		GetCapabilities(ctx, wms.GetCapabilitiesOptions{})
+	if err == nil {
+		t.Fatalf("expected error for missing workspace")
+	}
+	// If it's a typed APIError, the sentinel chain works. If it's a
+	// parse error from a service-exception body returned with 200,
+	// it'll be a wrapped xml-decode error — that's still a non-nil
+	// error and meets the assertion.
+	if errors.Is(err, geoserver.ErrNotFound) {
+		// strict path
+		return
+	}
+	// Otherwise just ensure we got a usable error message.
+	if err.Error() == "" {
+		t.Fatalf("error has empty message: %v", err)
+	}
+}

--- a/v2/ows/wms/wms_test.go
+++ b/v2/ows/wms/wms_test.go
@@ -1,0 +1,244 @@
+package wms_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wms"
+)
+
+const minimalCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
+<WMT_MS_Capabilities version="1.1.1" updateSequence="42">
+  <Service>
+    <Name>OGC:WMS</Name>
+    <Title>Test GeoServer Web Map Service</Title>
+    <KeywordList>
+      <Keyword>WMS</Keyword>
+      <Keyword>GeoServer</Keyword>
+    </KeywordList>
+    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                    xlink:type="simple" xlink:href="http://example.com/geoserver/wms"/>
+    <Fees>NONE</Fees>
+    <AccessConstraints>NONE</AccessConstraints>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>application/vnd.ogc.wms_xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:type="simple" xlink:href="http://example.com/geoserver/wms?"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+    </Request>
+    <Exception>
+      <Format>application/vnd.ogc.se_xml</Format>
+    </Exception>
+    <Layer>
+      <Title>Root layer</Title>
+      <Layer queryable="1">
+        <Title>states</Title>
+        <Abstract>USA states</Abstract>
+        <SRS>EPSG:4326</SRS>
+        <LatLonBoundingBox minx="-130" miny="20" maxx="-65" maxy="50"/>
+        <BoundingBox SRS="EPSG:4326" minx="-130" miny="20" maxx="-65" maxy="50"/>
+        <Style>
+          <Name>polygon</Name>
+          <Title>Default polygon style</Title>
+          <LegendURL height="20" width="20">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xlink:type="simple" xlink:href="http://example.com/legend.png"/>
+          </LegendURL>
+        </Style>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMT_MS_Capabilities>`
+
+func TestParseCapabilities_OK(t *testing.T) {
+	caps, err := wms.ParseCapabilities(strings.NewReader(minimalCapsXML))
+	if err != nil {
+		t.Fatalf("ParseCapabilities: %v", err)
+	}
+	if caps.Version != "1.1.1" {
+		t.Errorf("Version = %q, want 1.1.1", caps.Version)
+	}
+	if caps.UpdateSequence != "42" {
+		t.Errorf("UpdateSequence = %q, want 42", caps.UpdateSequence)
+	}
+	if caps.Service.Title != "Test GeoServer Web Map Service" {
+		t.Errorf("Service.Title = %q", caps.Service.Title)
+	}
+	if got := len(caps.Service.KeywordList.Keyword); got != 2 {
+		t.Errorf("KeywordList: got %d keywords, want 2", got)
+	}
+
+	// Layer tree: root has one child layer named "states".
+	root := caps.Capability.Layer
+	if got := len(root.Layer); got != 1 {
+		t.Fatalf("root has %d child layers, want 1", got)
+	}
+	states := root.Layer[0]
+	if states.Title != "states" {
+		t.Errorf("child Title = %q", states.Title)
+	}
+	if states.Queryable != 1 {
+		t.Errorf("Queryable = %d, want 1", states.Queryable)
+	}
+	if got := len(states.SRS); got != 1 || states.SRS[0] == nil || *states.SRS[0] != "EPSG:4326" {
+		t.Errorf("SRS = %+v", states.SRS)
+	}
+	if states.LatLonBoundingBox.MinX != -130 || states.LatLonBoundingBox.MaxY != 50 {
+		t.Errorf("LatLonBoundingBox = %+v", states.LatLonBoundingBox)
+	}
+	if got := len(states.Style); got != 1 || states.Style[0].Name != "polygon" {
+		t.Errorf("Style = %+v", states.Style)
+	}
+}
+
+func TestParseCapabilities_NilReader(t *testing.T) {
+	_, err := wms.ParseCapabilities(nil)
+	if err == nil {
+		t.Fatalf("expected error on nil reader")
+	}
+}
+
+func TestParseCapabilities_Malformed(t *testing.T) {
+	_, err := wms.ParseCapabilities(strings.NewReader("<not-wms/>"))
+	if err == nil {
+		t.Fatalf("expected error on non-WMS XML")
+	}
+	// xml.Unmarshal returns "expected element type <WMT_MS_Capabilities> but
+	// have <not-wms>". We just check the error is wrapped under our prefix.
+	if !strings.Contains(err.Error(), "wms: parse capabilities") {
+		t.Errorf("error not wrapped: %v", err)
+	}
+}
+
+func TestGetCapabilities_GlobalScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wms" {
+			t.Errorf("path = %q, want /wms", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("service") != "wms" || q.Get("request") != "GetCapabilities" {
+			t.Errorf("query = %+v", q)
+		}
+		if q.Get("version") != "1.1.1" {
+			t.Errorf("version = %q, want 1.1.1 (default)", q.Get("version"))
+		}
+		w.Header().Set("Content-Type", "application/vnd.ogc.wms_xml")
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, err := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	caps, err := c.WMS.GetCapabilities(context.Background(), wms.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if caps.Version != "1.1.1" {
+		t.Errorf("Version = %q", caps.Version)
+	}
+}
+
+func TestGetCapabilities_WorkspaceScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/topp/wms" {
+			t.Errorf("path = %q, want /topp/wms", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.ogc.wms_xml")
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	if _, err := c.WMS.InWorkspace("topp").GetCapabilities(context.Background(),
+		wms.GetCapabilitiesOptions{}); err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+}
+
+func TestGetCapabilities_VersionAndUpdateSequence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("version") != "1.3.0" {
+			t.Errorf("version = %q, want 1.3.0", q.Get("version"))
+		}
+		if q.Get("updatesequence") != "42" {
+			t.Errorf("updatesequence = %q, want 42", q.Get("updatesequence"))
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, _ = c.WMS.GetCapabilities(context.Background(), wms.GetCapabilitiesOptions{
+		Version:        "1.3.0",
+		UpdateSequence: "42",
+	})
+}
+
+func TestGetCapabilities_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such workspace", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	_, err := c.WMS.InWorkspace("missing").GetCapabilities(context.Background(),
+		wms.GetCapabilitiesOptions{})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetCapabilities_InternalServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "kaboom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	_, err := c.WMS.GetCapabilities(context.Background(), wms.GetCapabilitiesOptions{})
+	if !errors.Is(err, geoserver.ErrServerError) {
+		t.Fatalf("err = %v, want ErrServerError", err)
+	}
+}
+
+func TestClient_IsGlobal(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	if !c.WMS.IsGlobal() {
+		t.Errorf("freshly constructed WMS client should be global")
+	}
+	scoped := c.WMS.InWorkspace("topp")
+	if scoped.IsGlobal() {
+		t.Errorf("workspace-scoped client reports IsGlobal=true")
+	}
+	if scoped.Workspace() != "topp" {
+		t.Errorf("Workspace() = %q", scoped.Workspace())
+	}
+	// Original is unaffected.
+	if !c.WMS.IsGlobal() {
+		t.Errorf("InWorkspace mutated original")
+	}
+}

--- a/v2/rest/system/example_test.go
+++ b/v2/rest/system/example_test.go
@@ -1,0 +1,36 @@
+package system_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// Example_reload reloads GeoServer's catalog and configuration from
+// disk. Use after an out-of-band edit to the data directory or after
+// rolling out new plugins.
+func Example_reload() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	if err := c.System.Reload(context.Background()); err != nil {
+		switch {
+		case errors.Is(err, geoserver.ErrUnauthorized):
+			fmt.Println("auth required")
+		case errors.Is(err, geoserver.ErrForbidden):
+			fmt.Println("admin role required")
+		}
+	}
+}
+
+// Example_resetCache invalidates store / raster / schema caches
+// without a full Reload — useful after an upstream schema migration
+// when configuration on disk hasn't changed.
+func Example_resetCache() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.System.ResetCache(context.Background())
+}

--- a/v2/rest/system/system.go
+++ b/v2/rest/system/system.go
@@ -1,0 +1,66 @@
+// Package system is the v2 sub-client for GeoServer's server-management
+// endpoints under /rest — currently `POST /rest/reload` and
+// `POST /rest/reset`. These are operational primitives, not catalog
+// resources, so they live in their own sub-client rather than under
+// [about] (which is read-only).
+package system
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Client is the v2 system sub-client.
+//
+//	if err := c.System.Reload(ctx); err != nil { /* … */ }
+//	if err := c.System.ResetCache(ctx); err != nil { /* … */ }
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core Core
+}
+
+// New constructs the sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// Reload reloads the GeoServer catalog and configuration from disk.
+// Use this after an out-of-band edit to the data directory or after
+// rolling out new GeoServer plugins. Drops in-memory caches and
+// reconnects every datastore.
+//
+// Mapped to `POST /rest/reload`. Requires admin auth.
+func (c *Client) Reload(ctx context.Context) error {
+	const op = "System.Reload"
+	u, err := c.core.URL("rest", "reload")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, nil, nil, nil)
+}
+
+// ResetCache resets all store, raster, and schema caches. Use this
+// when the underlying data has changed (e.g., a PostGIS schema
+// migration) and stale GeoServer caches need to be invalidated
+// without a full [Client.Reload].
+//
+// Mapped to `POST /rest/reset`. Requires admin auth.
+func (c *Client) ResetCache(ctx context.Context) error {
+	const op = "System.ResetCache"
+	u, err := c.core.URL("rest", "reset")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, nil, nil, nil)
+}

--- a/v2/rest/system/system_integration_test.go
+++ b/v2/rest/system/system_integration_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package system_test
+
+import (
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+)
+
+func TestSystem_ResetCache_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Reset is fast and idempotent — safe to run repeatedly.
+	if err := c.System.ResetCache(ctx); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+}
+
+func TestSystem_Reload_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Reload is heavier but should complete within the test timeout
+	// against the lightly-loaded compose stack. It's idempotent.
+	if err := c.System.Reload(ctx); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+}

--- a/v2/rest/system/system_test.go
+++ b/v2/rest/system/system_test.go
@@ -1,0 +1,94 @@
+package system_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+func TestReload_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/rest/reload" {
+			t.Errorf("Path = %q, want /rest/reload", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := c.System.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+}
+
+func TestReload_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "auth required", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("bad", "creds"))
+
+	err := c.System.Reload(context.Background())
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestReload_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "non-admin user", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	err := c.System.Reload(context.Background())
+	if !errors.Is(err, geoserver.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestResetCache_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/rest/reset" {
+			t.Errorf("Path = %q, want /rest/reset", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	if err := c.System.ResetCache(context.Background()); err != nil {
+		t.Fatalf("ResetCache: %v", err)
+	}
+}
+
+func TestResetCache_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "kaboom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	err := c.System.ResetCache(context.Background())
+	if !errors.Is(err, geoserver.ErrServerError) {
+		t.Fatalf("err = %v, want ErrServerError", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last two unported v1 surfaces. After this PR, v2 has full v1 feature parity.

### \`v2/ows/wms\` — port of v1's \`wms\` package

- Same XML type tree (Capabilities, Service, Capability, Layer, Style, BoundingBox, …) so callers move with no shape changes.
- \`wms.ParseCapabilities(io.Reader)\` — v2 idiom (\`io.Reader\` instead of \`[]byte\`). The deprecated v1 no-\`E\` variant that swallowed errors is gone.
- \`c.WMS.GetCapabilities(ctx, opts)\` — global by default; \`c.WMS.InWorkspace(ws)\` for a workspace-scoped capabilities view.
- \`GetCapabilitiesOptions\` carries Version (default \`1.1.1\`) and UpdateSequence (cache token).

### \`v2/rest/system\` — port of v1's \`configuration.go\`

- \`c.System.Reload(ctx)\` → \`POST /rest/reload\`
- \`c.System.ResetCache(ctx)\` → \`POST /rest/reset\`
- Drops v1's typo'd method names (\`ReloadConfigration\` / \`RestConfigrationCache\`); v2 uses the corrected spelling.

### \`internal/transport.DoXML\`

XML-decoding equivalent of \`DoJSON\` with a **32 MiB** body cap. \`DoJSON\`'s 8 KiB cap is too small for real WMS capabilities documents (often 100 KiB+ on a populated server). The error path still uses 8 KiB so an oversized error body can't blow up.

## Tests

- httptest unit tests for both new packages — happy path, \`ErrNotFound\`, \`ErrUnauthorized\`, \`ErrForbidden\`, \`ErrServerError\`, malformed-XML parse error, \`IsGlobal\`/\`InWorkspace\` behavior, version + updatesequence query handling.
- Integration tests (\`//go:build integration\`) for both packages against the compose stack.
- Godoc \`Example_*\` for both packages.

## Test plan

- [x] \`cd v2 && go vet ./...\` clean
- [x] \`cd v2 && go test -count=1 ./...\` green (all 16 packages)
- [x] \`cd v2 && golangci-lint run ./...\` 0 issues
- [x] \`cd v2 && go vet -tags=integration ./...\` clean
- [ ] CI: 7 required checks + CodeQL pass on this branch
- [ ] Real-server integration legs (2.27.4 LTS + 2.28.0 stable) cover the new \`wms\` + \`system\` integration tests

## Docs

- \`v2/CHANGELOG.md\` \`[Unreleased]\` updated.
- \`v2/README.md\` banner: full v1 parity, WMS "deferred" disclaimer removed.
- Root \`README.md\` Roadmap mirrors that.