### PR TITLE
feat(v2): port WFS + WCS GetCapabilities (OWS clients 2/3 + 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The library was dormant for ~3 years (Feb 2023 → May 2026) before being revive
 ## Roadmap
 
 - **v1.1.x** — security fixes, integration test maintenance, additive Dependabot updates.
-- **v2** — `v2.0.0-alpha.1` published at `github.com/hishamkaram/geoserver/v2` (`go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1`). Full v1 parity at `master`: catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, about, system (reload + cache reset), and WMS GetCapabilities (`v2/ows/wms`). Exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Public API may still refine before `v2.0.0` — no production guarantees yet.
+- **v2** — `v2.0.0-alpha.2` published at `github.com/hishamkaram/geoserver/v2` (`go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.2`). Surface at `master` exceeds v1: catalog (workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces) plus security, ACL, settings, about, system (reload + cache reset), and the full OWS GetCapabilities trio — WMS, WFS, WCS — under `v2/ows/`. Exercised by both unit and real-GeoServer integration suites on 2.27.4 LTS and 2.28.0 stable. Public API may still refine before `v2.0.0` — no production guarantees yet.
 
   Design themes (now realized in code):
   - Resource sub-clients (`c.Workspaces.Get(ctx, name)`, `c.Datastores.InWorkspace(ws).Get(...)`, `c.FeatureTypes.InWorkspace(ws).InDatastore(ds).Get(...)`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,12 +35,11 @@ Lives at module path `github.com/hishamkaram/geoserver/v2` (subdir form). Idioma
 - [x] **Resource port (2/3)** — `layers`, `layergroups`, `styles`.
 - [x] **Resource port (3/3)** — `namespaces`, `settings`, `security`, `acl`, `about`.
 - [x] **System endpoints** — `c.System.Reload` / `c.System.ResetCache` (port of v1's `configuration.go`).
-- [x] **OWS clients (1/3)** — `ows/wms/` (GetCapabilities + workspace scope). `ows/wfs/` and `ows/wcs/` still pending; same wire-shape pattern.
+- [x] **OWS clients (1/3, 2/3, 3/3)** — `ows/wms/`, `ows/wfs/`, `ows/wcs/` (GetCapabilities + workspace scope on each). All three follow the same shape: free-function `ParseCapabilities(io.Reader)` plus a sub-client method routed through `transport.DoXML`.
 - [x] **Migration guide** — `docs/migration-v1-to-v2.md` populated with concrete v1 → v2 mappings for every resource.
 - [x] **v1 parity at `master`** — every v1 surface (REST + OWS) has a v2 equivalent.
 - [ ] **v2.0.0-alpha.2** (or later alpha) — re-tag to publish the post-`alpha.1` work (godoc Examples, README refresh, OWS WMS port, system reload/reset). Tag is an explicit user action.
-- [ ] **OWS clients (2/3, 3/3)** — `ows/wfs/`, `ows/wcs/`. Same shape as `ows/wms/` (XML types + `ParseCapabilities` + sub-client method). May slip to a later alpha.
-- [ ] **v2.0.0-beta.1** — REST + OWS surface complete, integration matrix on 2.27 + 2.28, public API frozen for review.
+- [ ] **v2.0.0-beta.1** — REST + OWS surface complete (achieved at `master`), integration matrix on 2.27 + 2.28, public API frozen for review.
 - [ ] **v2.0.0** — final tag.
 
 ## GeoServer 3.0 support

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — OWS clients (2/3, 3/3)
+
+- **`v2/ows/wfs/` package** — WFS GetCapabilities. Hand-written subset of WFS 1.1.0 / 2.0 schemas (ServiceIdentification, ServiceProvider, OperationsMetadata, FeatureTypeList with WGS84BoundingBox + DefaultSRS / OtherSRS / OutputFormats). New free function `wfs.ParseCapabilities(io.Reader)` and `c.WFS.GetCapabilities(ctx, opts)` — global by default; `c.WFS.InWorkspace(ws)` for a workspace-scoped capabilities view. Default version 2.0.0; 1.1.0 supported as well (same root element).
+- **`v2/ows/wcs/` package** — WCS GetCapabilities for WCS 2.0.x. Hand-written subset (ServiceIdentification, ServiceProvider, OperationsMetadata, ServiceMetadata with formats + CRSes, Contents with CoverageSummary). New free function `wcs.ParseCapabilities(io.Reader)` and `c.WCS.GetCapabilities(ctx, opts)` with workspace scoping. Default version 2.0.1. WCS 1.0.0 / 1.1.1 use a different root element (`WCS_Capabilities`) and are not in scope here.
+
+### Added (tests)
+
+- `v2/ows/wfs/wfs_test.go` and `v2/ows/wcs/wcs_test.go` — fixture-based parse tests with realistic GeoServer namespace declarations, httptest tests for global + workspace scope, version override, and 404 → sentinel mapping.
+- `v2/ows/wfs/wfs_integration_test.go` and `v2/ows/wcs/wcs_integration_test.go` — real GeoServer assertions (capabilities document non-empty for both global and a fresh empty workspace; WFS 1.1.0 version-override path).
+- Godoc `Example_*` for both packages.
+
 ## [2.0.0-alpha.2] — 2026-05-03
 
 Second alpha. Closes the last v1-parity gap (WMS GetCapabilities + system reload/cache reset), adds full pkg.go.dev godoc Example_* coverage across every sub-client, and refreshes the public-facing docs (READMEs, ROADMAP). No breaking changes from `alpha.1`; existing callers can `go get @v2.0.0-alpha.2` and recompile. Public API may still refine before `v2.0.0` — no production guarantees yet.

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,15 +1,15 @@
 # geoserver/v2
 
-> 🧪 **`v2.0.0-alpha.1` is published.** v2 now has full v1 parity at `master`: workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL, system (reload + cache reset), and WMS GetCapabilities (`v2/ows/wms`). Public API may still change before `v2.0.0` based on early-adopter feedback — no production guarantees yet. **For stable production use, stay on the v1 line:**
+> 🧪 **`v2.0.0-alpha.2` is published.** v2 now exceeds v1's surface at `master`: workspaces, datastores, feature types, coverage stores, coverages, layers, layer groups, styles, namespaces, settings, about, security, ACL, system (reload + cache reset), plus full OWS GetCapabilities trio — `v2/ows/wms`, `v2/ows/wfs`, `v2/ows/wcs`. Public API may still change before `v2.0.0` based on early-adopter feedback — no production guarantees yet. **For stable production use, stay on the v1 line:**
 >
 > ```go
 > import "github.com/hishamkaram/geoserver"          // v1.1.x — stable, full surface
-> import "github.com/hishamkaram/geoserver/v2"       // v2.0.0-alpha.1 — preview
+> import "github.com/hishamkaram/geoserver/v2"       // v2.0.0-alpha.2 — preview
 > ```
 >
 > Install:
 > ```sh
-> go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.1
+> go get github.com/hishamkaram/geoserver/v2@v2.0.0-alpha.2
 > ```
 
 This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/system"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 
+	"github.com/hishamkaram/geoserver/v2/ows/wcs"
+	"github.com/hishamkaram/geoserver/v2/ows/wfs"
 	"github.com/hishamkaram/geoserver/v2/ows/wms"
 )
 
@@ -125,8 +127,20 @@ type Client struct {
 	// WMS is the entry point for WMS service operations — currently
 	// GetCapabilities (XML, decoded into [wms.Capabilities]). Use
 	// [wms.Client.InWorkspace] for a workspace-scoped capabilities
-	// document. WFS / WCS land alongside under v2/ows/ in follow-ups.
+	// document.
 	WMS *wms.Client
+
+	// WFS is the entry point for WFS service operations — currently
+	// GetCapabilities (XML, decoded into [wfs.Capabilities]). Use
+	// [wfs.Client.InWorkspace] for a workspace-scoped capabilities
+	// document.
+	WFS *wfs.Client
+
+	// WCS is the entry point for WCS service operations — currently
+	// GetCapabilities (XML, decoded into [wcs.Capabilities]). Use
+	// [wcs.Client.InWorkspace] for a workspace-scoped capabilities
+	// document.
+	WCS *wcs.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -198,6 +212,8 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.ACL = acl.New(adapter)
 	c.System = system.New(adapter)
 	c.WMS = wms.New(adapter)
+	c.WFS = wfs.New(adapter)
+	c.WCS = wcs.New(adapter)
 	return c, nil
 }
 

--- a/v2/ows/wcs/example_test.go
+++ b/v2/ows/wcs/example_test.go
@@ -1,0 +1,54 @@
+package wcs_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wcs"
+)
+
+// ExampleClient_GetCapabilities fetches the global WCS capabilities
+// document and prints every advertised coverage.
+func ExampleClient_GetCapabilities() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	caps, err := c.WCS.GetCapabilities(context.Background(), wcs.GetCapabilitiesOptions{})
+	if err != nil {
+		return
+	}
+	fmt.Printf("WCS %s — %s\n", caps.Version, caps.ServiceIdentification.Title)
+	for _, cov := range caps.Contents.CoverageSummary {
+		fmt.Printf("  - %s\n", cov.CoverageID)
+	}
+}
+
+// ExampleClient_InWorkspace returns a workspace-scoped capabilities
+// view — only coverages under that workspace appear.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_, _ = c.WCS.InWorkspace("nurc").GetCapabilities(context.Background(),
+		wcs.GetCapabilitiesOptions{})
+}
+
+// ExampleParseCapabilities decodes a capabilities document fetched
+// out-of-band.
+func ExampleParseCapabilities() {
+	body := strings.NewReader(`<?xml version="1.0"?>
+<wcs:Capabilities version="2.0.1"
+    xmlns:wcs="http://www.opengis.net/wcs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/2.0">
+  <ows:ServiceIdentification><ows:Title>Demo</ows:Title></ows:ServiceIdentification>
+</wcs:Capabilities>`)
+
+	caps, err := wcs.ParseCapabilities(body)
+	if err != nil {
+		return
+	}
+	fmt.Println(caps.ServiceIdentification.Title)
+	// Output: Demo
+}

--- a/v2/ows/wcs/types.go
+++ b/v2/ows/wcs/types.go
@@ -1,0 +1,118 @@
+// Package wcs is the v2 sub-client for the GeoServer WCS service.
+// Covers the GetCapabilities endpoint — fetching the XML capabilities
+// document and parsing it into Go types.
+//
+// The GeoServer WCS GetCapabilities response uses both `wcs:` and
+// `ows:` XML namespaces; type definitions match on local name only,
+// so values flow through Go's encoding/xml decoder regardless of
+// which namespace prefix the server applied. The default version
+// supported by this type tree is WCS 2.0.1 — GeoServer's modern
+// default. WCS 1.0.0 / 1.1.1 use a different root element
+// (`WCS_Capabilities`) and are not in scope here.
+package wcs
+
+import "encoding/xml"
+
+// Capabilities is the root of the WCS 2.0.x GetCapabilities document.
+// GeoServer emits `<wcs:Capabilities>` for 2.0.x; the XMLName matches
+// by local name so namespace differences don't trip the decoder.
+type Capabilities struct {
+	XMLName               xml.Name              `xml:"Capabilities"`
+	Version               string                `xml:"version,attr,omitempty"`
+	UpdateSequence        string                `xml:"updateSequence,attr,omitempty"`
+	ServiceIdentification ServiceIdentification `xml:"ServiceIdentification"`
+	ServiceProvider       ServiceProvider       `xml:"ServiceProvider"`
+	OperationsMetadata    OperationsMetadata    `xml:"OperationsMetadata"`
+	ServiceMetadata       ServiceMetadata       `xml:"ServiceMetadata"`
+	Contents              Contents              `xml:"Contents"`
+}
+
+// ServiceIdentification carries the service-level metadata block.
+type ServiceIdentification struct {
+	Title             string   `xml:"Title"`
+	Abstract          string   `xml:"Abstract"`
+	Keywords          []string `xml:"Keywords>Keyword"`
+	ServiceType       string   `xml:"ServiceType"`
+	Versions          []string `xml:"ServiceTypeVersion"`
+	Profiles          []string `xml:"Profile"`
+	Fees              string   `xml:"Fees"`
+	AccessConstraints string   `xml:"AccessConstraints"`
+}
+
+// ServiceProvider carries the provider organization metadata.
+type ServiceProvider struct {
+	ProviderName   string         `xml:"ProviderName"`
+	OnlineResource OnlineResource `xml:"ProviderSite"`
+	ServiceContact ServiceContact `xml:"ServiceContact"`
+}
+
+// ServiceContact is the provider's point-of-contact block.
+type ServiceContact struct {
+	IndividualName string `xml:"IndividualName"`
+	PositionName   string `xml:"PositionName"`
+}
+
+// OnlineResource is the xlink:href + xlink:type pair returned for
+// any linkable element.
+type OnlineResource struct {
+	Type string `xml:"http://www.w3.org/1999/xlink type,attr,omitempty"`
+	Href string `xml:"http://www.w3.org/1999/xlink href,attr,omitempty"`
+}
+
+// OperationsMetadata enumerates the WCS operations the server
+// advertises along with each operation's DCP endpoints, parameters,
+// and constraints.
+type OperationsMetadata struct {
+	Operation []Operation `xml:"Operation"`
+}
+
+// Operation describes one server operation (GetCapabilities,
+// DescribeCoverage, GetCoverage).
+type Operation struct {
+	Name       string      `xml:"name,attr"`
+	DCP        []DCP       `xml:"DCP"`
+	Parameter  []Parameter `xml:"Parameter"`
+	Constraint []Parameter `xml:"Constraint"`
+}
+
+// DCP describes one Distributed Computing Platform (transport)
+// binding for an Operation.
+type DCP struct {
+	HTTP HTTP `xml:"HTTP"`
+}
+
+// HTTP wraps the GET / POST endpoint URLs.
+type HTTP struct {
+	Get  []OnlineResource `xml:"Get"`
+	Post []OnlineResource `xml:"Post"`
+}
+
+// Parameter describes one named parameter or constraint with its
+// allowed values.
+type Parameter struct {
+	Name          string   `xml:"name,attr"`
+	AllowedValues []string `xml:"AllowedValues>Value"`
+	DefaultValue  string   `xml:"DefaultValue"`
+}
+
+// ServiceMetadata advertises encoding formats and supported CRSes.
+// The wire shape uses the `wcs:` namespace; structure carries forward
+// the standard GeoServer fields.
+type ServiceMetadata struct {
+	Formats []string `xml:"formatSupported"`
+	CRS     []string `xml:"Extension>crsSupported"`
+}
+
+// Contents enumerates the published coverages.
+type Contents struct {
+	CoverageSummary []CoverageSummary `xml:"CoverageSummary"`
+}
+
+// CoverageSummary is one published coverage entry. WCS 2.0 minimizes
+// the per-coverage envelope to CoverageId + CoverageSubtype; richer
+// per-coverage detail is fetched via DescribeCoverage (not in this
+// package's scope).
+type CoverageSummary struct {
+	CoverageID      string `xml:"CoverageId"`
+	CoverageSubtype string `xml:"CoverageSubtype"`
+}

--- a/v2/ows/wcs/wcs.go
+++ b/v2/ows/wcs/wcs.go
@@ -1,0 +1,112 @@
+package wcs
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	DoXML(ctx context.Context, op, method, requestURL string, query map[string]string, out any) error
+}
+
+// Client is the v2 WCS sub-client. The current surface covers
+// [Client.GetCapabilities]; [Client.InWorkspace] returns a
+// workspace-scoped view that issues `/{workspace}/wcs` rather than
+// the global `/wcs`.
+//
+//	caps, err := c.WCS.GetCapabilities(ctx, wcs.GetCapabilitiesOptions{})
+//	caps, err := c.WCS.InWorkspace("nurc").GetCapabilities(ctx, wcs.GetCapabilitiesOptions{})
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core      Core
+	workspace string
+}
+
+// New constructs the global-scope WCS sub-client.
+func New(core Core) *Client { return &Client{core: core} }
+
+// InWorkspace returns a fresh WCS client scoped to the given
+// workspace. The original (global-scope) client is unaffected.
+func (c *Client) InWorkspace(workspace string) *Client {
+	return &Client{core: c.core, workspace: workspace}
+}
+
+// Workspace returns the workspace name this client is scoped to,
+// or "" for the global scope.
+func (c *Client) Workspace() string { return c.workspace }
+
+// IsGlobal reports whether this client operates against the global
+// `/wcs` endpoint (true) or a workspace-scoped one (false).
+func (c *Client) IsGlobal() bool { return c.workspace == "" }
+
+// GetCapabilitiesOptions controls a [Client.GetCapabilities] call.
+// All fields are optional.
+type GetCapabilitiesOptions struct {
+	// Version is the WCS protocol version requested. Default
+	// "2.0.1" — GeoServer's modern default. WCS 1.0.0 / 1.1.1 use
+	// a different root element (`WCS_Capabilities`) and are not
+	// supported by this type tree.
+	Version string
+
+	// UpdateSequence is an optional cache-coordination token.
+	UpdateSequence string
+}
+
+// GetCapabilities fetches the WCS GetCapabilities XML document and
+// parses it into a [*Capabilities]. On a 4xx/5xx response, returns a
+// *APIError wrapping the appropriate sentinel.
+func (c *Client) GetCapabilities(ctx context.Context, opts GetCapabilitiesOptions) (*Capabilities, error) {
+	const op = "WCS.GetCapabilities"
+
+	parts := []string{}
+	if c.workspace != "" {
+		parts = append(parts, c.workspace)
+	}
+	parts = append(parts, "wcs")
+	u, err := c.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	version := opts.Version
+	if version == "" {
+		version = "2.0.1"
+	}
+	query := map[string]string{
+		"service": "wcs",
+		"version": version,
+		"request": "GetCapabilities",
+	}
+	if opts.UpdateSequence != "" {
+		query["updatesequence"] = opts.UpdateSequence
+	}
+
+	var caps Capabilities
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, query, &caps); err != nil {
+		return nil, err
+	}
+	return &caps, nil
+}
+
+// ParseCapabilities reads a WCS GetCapabilities XML document from r
+// and decodes it into a [*Capabilities]. Useful for parsing a
+// document fetched out-of-band (saved fixture, custom transport).
+// Returns a typed parse error on malformed input.
+func ParseCapabilities(r io.Reader) (*Capabilities, error) {
+	if r == nil {
+		return nil, errors.New("wcs: ParseCapabilities: nil reader")
+	}
+	var caps Capabilities
+	if err := xml.NewDecoder(r).Decode(&caps); err != nil {
+		return nil, fmt.Errorf("wcs: parse capabilities: %w", err)
+	}
+	return &caps, nil
+}

--- a/v2/ows/wcs/wcs.go
+++ b/v2/ows/wcs/wcs.go
@@ -80,8 +80,13 @@ func (c *Client) GetCapabilities(ctx context.Context, opts GetCapabilitiesOption
 	if version == "" {
 		version = "2.0.1"
 	}
+	// Note: GeoServer's WCS endpoint is case-sensitive on the
+	// `service` parameter — `wcs` (lowercase) returns 400
+	// "Error in service name, expected value: WCS". WMS and WFS
+	// accept lowercase. Send the uppercase form here to keep the
+	// happy-path query working across versions.
 	query := map[string]string{
-		"service": "wcs",
+		"service": "WCS",
 		"version": version,
 		"request": "GetCapabilities",
 	}

--- a/v2/ows/wcs/wcs_integration_test.go
+++ b/v2/ows/wcs/wcs_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package wcs_test
+
+import (
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/ows/wcs"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func TestWCS_GetCapabilities_Global_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	caps, err := c.WCS.GetCapabilities(ctx, wcs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (global): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty: %+v", caps)
+	}
+	if caps.ServiceIdentification.ServiceType == "" {
+		t.Errorf("ServiceType is empty: %+v", caps.ServiceIdentification)
+	}
+}
+
+func TestWCS_GetCapabilities_Workspace_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	caps, err := c.WCS.InWorkspace(wsName).GetCapabilities(ctx, wcs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (workspace): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty for workspace-scoped caps")
+	}
+}

--- a/v2/ows/wcs/wcs_test.go
+++ b/v2/ows/wcs/wcs_test.go
@@ -122,8 +122,8 @@ func TestGetCapabilities_GlobalDefaultVersion(t *testing.T) {
 			t.Errorf("path = %q, want /wcs", r.URL.Path)
 		}
 		q := r.URL.Query()
-		if q.Get("service") != "wcs" {
-			t.Errorf("service = %q", q.Get("service"))
+		if q.Get("service") != "WCS" {
+			t.Errorf("service = %q (GeoServer WCS endpoint requires uppercase)", q.Get("service"))
 		}
 		if q.Get("version") != "2.0.1" {
 			t.Errorf("version = %q, want 2.0.1 (default)", q.Get("version"))

--- a/v2/ows/wcs/wcs_test.go
+++ b/v2/ows/wcs/wcs_test.go
@@ -1,0 +1,190 @@
+package wcs_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wcs"
+)
+
+const minimalCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
+<wcs:Capabilities version="2.0.1" updateSequence="42"
+    xmlns:wcs="http://www.opengis.net/wcs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/2.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:ServiceIdentification>
+    <ows:Title>Test WCS</ows:Title>
+    <ows:Abstract>Integration-test fixture</ows:Abstract>
+    <ows:Keywords>
+      <ows:Keyword>WCS</ows:Keyword>
+    </ows:Keywords>
+    <ows:ServiceType>OGC WCS</ows:ServiceType>
+    <ows:ServiceTypeVersion>2.0.1</ows:ServiceTypeVersion>
+    <ows:Profile>http://www.opengis.net/spec/WCS_service-extension_crs/1.0/conf/crs</ows:Profile>
+    <ows:Fees>NONE</ows:Fees>
+    <ows:AccessConstraints>NONE</ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>Acme</ows:ProviderName>
+    <ows:ProviderSite xlink:type="simple" xlink:href="http://example.com/"/>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://example.com/geoserver/wcs?"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetCoverage">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://example.com/geoserver/wcs?"/>
+          <ows:Post xlink:href="http://example.com/geoserver/wcs"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <wcs:ServiceMetadata>
+    <wcs:formatSupported>image/tiff</wcs:formatSupported>
+    <wcs:formatSupported>image/png</wcs:formatSupported>
+    <wcs:Extension>
+      <wcs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/4326</wcs:crsSupported>
+      <wcs:crsSupported>http://www.opengis.net/def/crs/EPSG/0/3857</wcs:crsSupported>
+    </wcs:Extension>
+  </wcs:ServiceMetadata>
+  <wcs:Contents>
+    <wcs:CoverageSummary>
+      <wcs:CoverageId>nurc__world_dem</wcs:CoverageId>
+      <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
+    </wcs:CoverageSummary>
+  </wcs:Contents>
+</wcs:Capabilities>`
+
+func TestParseCapabilities_OK(t *testing.T) {
+	caps, err := wcs.ParseCapabilities(strings.NewReader(minimalCapsXML))
+	if err != nil {
+		t.Fatalf("ParseCapabilities: %v", err)
+	}
+	if caps.Version != "2.0.1" {
+		t.Errorf("Version = %q, want 2.0.1", caps.Version)
+	}
+	si := caps.ServiceIdentification
+	if si.Title != "Test WCS" {
+		t.Errorf("Title = %q", si.Title)
+	}
+	if got := len(si.Profiles); got != 1 {
+		t.Errorf("Profiles: got %d, want 1", got)
+	}
+	if got := len(caps.ServiceMetadata.Formats); got != 2 {
+		t.Errorf("Formats: got %d, want 2", got)
+	}
+	if got := len(caps.ServiceMetadata.CRS); got != 2 {
+		t.Errorf("CRS: got %d, want 2", got)
+	}
+	if got := len(caps.Contents.CoverageSummary); got != 1 {
+		t.Fatalf("CoverageSummary: got %d, want 1", got)
+	}
+	cov := caps.Contents.CoverageSummary[0]
+	if cov.CoverageID != "nurc__world_dem" {
+		t.Errorf("CoverageID = %q", cov.CoverageID)
+	}
+	if cov.CoverageSubtype != "RectifiedGridCoverage" {
+		t.Errorf("CoverageSubtype = %q", cov.CoverageSubtype)
+	}
+}
+
+func TestParseCapabilities_NilReader(t *testing.T) {
+	if _, err := wcs.ParseCapabilities(nil); err == nil {
+		t.Fatalf("expected error on nil reader")
+	}
+}
+
+func TestParseCapabilities_Malformed(t *testing.T) {
+	_, err := wcs.ParseCapabilities(strings.NewReader("<not-wcs/>"))
+	if err == nil {
+		t.Fatalf("expected error on non-WCS XML")
+	}
+	if !strings.Contains(err.Error(), "wcs: parse capabilities") {
+		t.Errorf("error not wrapped: %v", err)
+	}
+}
+
+func TestGetCapabilities_GlobalDefaultVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wcs" {
+			t.Errorf("path = %q, want /wcs", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("service") != "wcs" {
+			t.Errorf("service = %q", q.Get("service"))
+		}
+		if q.Get("version") != "2.0.1" {
+			t.Errorf("version = %q, want 2.0.1 (default)", q.Get("version"))
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	caps, err := c.WCS.GetCapabilities(context.Background(), wcs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if caps.Version != "2.0.1" {
+		t.Errorf("Version = %q", caps.Version)
+	}
+}
+
+func TestGetCapabilities_WorkspaceScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nurc/wcs" {
+			t.Errorf("path = %q, want /nurc/wcs", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	if _, err := c.WCS.InWorkspace("nurc").GetCapabilities(context.Background(),
+		wcs.GetCapabilitiesOptions{}); err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+}
+
+func TestGetCapabilities_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such workspace", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, err := c.WCS.InWorkspace("missing").GetCapabilities(context.Background(),
+		wcs.GetCapabilitiesOptions{})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClient_IsGlobal(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	if !c.WCS.IsGlobal() {
+		t.Errorf("freshly constructed WCS client should be global")
+	}
+	scoped := c.WCS.InWorkspace("nurc")
+	if scoped.IsGlobal() {
+		t.Errorf("workspace-scoped client reports IsGlobal=true")
+	}
+	if scoped.Workspace() != "nurc" {
+		t.Errorf("Workspace() = %q", scoped.Workspace())
+	}
+	if !c.WCS.IsGlobal() {
+		t.Errorf("InWorkspace mutated original")
+	}
+}

--- a/v2/ows/wfs/example_test.go
+++ b/v2/ows/wfs/example_test.go
@@ -1,0 +1,55 @@
+package wfs_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wfs"
+)
+
+// ExampleClient_GetCapabilities fetches the global WFS capabilities
+// document and prints every advertised feature type.
+func ExampleClient_GetCapabilities() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	caps, err := c.WFS.GetCapabilities(context.Background(), wfs.GetCapabilitiesOptions{})
+	if err != nil {
+		return
+	}
+	fmt.Printf("WFS %s — %s\n", caps.Version, caps.ServiceIdentification.Title)
+	for _, ft := range caps.FeatureTypeList.FeatureType {
+		fmt.Printf("  - %s (%s)\n", ft.Name, ft.DefaultSRS)
+	}
+}
+
+// ExampleClient_InWorkspace returns a workspace-scoped capabilities
+// view — only feature types under that workspace appear.
+func ExampleClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_, _ = c.WFS.InWorkspace("topp").GetCapabilities(context.Background(),
+		wfs.GetCapabilitiesOptions{Version: "1.1.0"})
+}
+
+// ExampleParseCapabilities decodes a capabilities document fetched
+// out-of-band — useful for parsing a saved fixture or a body from a
+// custom transport.
+func ExampleParseCapabilities() {
+	body := strings.NewReader(`<?xml version="1.0"?>
+<wfs:WFS_Capabilities version="2.0.0"
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:ServiceIdentification><ows:Title>Demo</ows:Title></ows:ServiceIdentification>
+</wfs:WFS_Capabilities>`)
+
+	caps, err := wfs.ParseCapabilities(body)
+	if err != nil {
+		return
+	}
+	fmt.Println(caps.ServiceIdentification.Title)
+	// Output: Demo
+}

--- a/v2/ows/wfs/types.go
+++ b/v2/ows/wfs/types.go
@@ -1,0 +1,140 @@
+// Package wfs is the v2 sub-client for the GeoServer WFS service.
+// Covers the GetCapabilities endpoint — fetching the XML capabilities
+// document and parsing it into Go types.
+//
+// The GeoServer WFS GetCapabilities response uses both `wfs:` and
+// `ows:` XML namespaces; the type definitions in this package match
+// on local name only, so values flow through Go's encoding/xml
+// decoder regardless of which namespace prefix the server applied.
+//
+// Decoded fields are an opinionated subset of the OGC WFS 1.1.0 / 2.0
+// schemas — everything callers commonly need (service identification,
+// supported operations, feature type list with bounding boxes and
+// SRS lists). Less-used fields (full OGC Filter capabilities, value
+// constraints) are skipped on purpose to keep the type tree
+// readable; add when a real caller needs them.
+package wfs
+
+import "encoding/xml"
+
+// Capabilities is the root of the WFS GetCapabilities document.
+// GeoServer emits `<wfs:WFS_Capabilities>` for both 1.1.0 and 2.0;
+// the XMLName matches by local name so namespace differences don't
+// trip the decoder.
+type Capabilities struct {
+	XMLName               xml.Name              `xml:"WFS_Capabilities"`
+	Version               string                `xml:"version,attr,omitempty"`
+	UpdateSequence        string                `xml:"updateSequence,attr,omitempty"`
+	ServiceIdentification ServiceIdentification `xml:"ServiceIdentification"`
+	ServiceProvider       ServiceProvider       `xml:"ServiceProvider"`
+	OperationsMetadata    OperationsMetadata    `xml:"OperationsMetadata"`
+	FeatureTypeList       FeatureTypeList       `xml:"FeatureTypeList"`
+}
+
+// ServiceIdentification carries the service-level metadata block
+// (title, abstract, keywords, fees, access constraints, supported
+// versions).
+type ServiceIdentification struct {
+	Title             string   `xml:"Title"`
+	Abstract          string   `xml:"Abstract"`
+	Keywords          []string `xml:"Keywords>Keyword"`
+	ServiceType       string   `xml:"ServiceType"`
+	Versions          []string `xml:"ServiceTypeVersion"`
+	Fees              string   `xml:"Fees"`
+	AccessConstraints string   `xml:"AccessConstraints"`
+}
+
+// ServiceProvider carries the provider organization metadata.
+type ServiceProvider struct {
+	ProviderName   string         `xml:"ProviderName"`
+	OnlineResource OnlineResource `xml:"ProviderSite"`
+	ServiceContact ServiceContact `xml:"ServiceContact"`
+}
+
+// ServiceContact is the provider's point-of-contact block.
+type ServiceContact struct {
+	IndividualName string `xml:"IndividualName"`
+	PositionName   string `xml:"PositionName"`
+}
+
+// OnlineResource is the xlink:href + xlink:type pair returned for
+// any linkable element (provider site, operation DCP endpoints, …).
+type OnlineResource struct {
+	Type string `xml:"http://www.w3.org/1999/xlink type,attr,omitempty"`
+	Href string `xml:"http://www.w3.org/1999/xlink href,attr,omitempty"`
+}
+
+// OperationsMetadata enumerates the WFS operations the server
+// advertises along with each operation's DCP endpoints, parameters,
+// and constraints.
+type OperationsMetadata struct {
+	Operation []Operation `xml:"Operation"`
+}
+
+// Operation describes one server operation (GetCapabilities,
+// DescribeFeatureType, GetFeature, …).
+type Operation struct {
+	Name       string      `xml:"name,attr"`
+	DCP        []DCP       `xml:"DCP"`
+	Parameter  []Parameter `xml:"Parameter"`
+	Constraint []Parameter `xml:"Constraint"`
+}
+
+// DCP describes one Distributed Computing Platform (transport)
+// binding for an Operation.
+type DCP struct {
+	HTTP HTTP `xml:"HTTP"`
+}
+
+// HTTP wraps the GET / POST endpoint URLs.
+type HTTP struct {
+	Get  []OnlineResource `xml:"Get"`
+	Post []OnlineResource `xml:"Post"`
+}
+
+// Parameter describes one named parameter or constraint with its
+// allowed values. Used for both `<Parameter>` and `<Constraint>`
+// children of an Operation — they share wire shape.
+type Parameter struct {
+	Name          string    `xml:"name,attr"`
+	AllowedValues []string  `xml:"AllowedValues>Value"`
+	DefaultValue  string    `xml:"DefaultValue"`
+	NoValues      *struct{} `xml:"NoValues,omitempty"`
+}
+
+// FeatureTypeList wraps the list of published feature types.
+type FeatureTypeList struct {
+	FeatureType []FeatureType `xml:"FeatureType"`
+}
+
+// FeatureType is one published feature type entry.
+type FeatureType struct {
+	Name             string           `xml:"Name"`
+	Title            string           `xml:"Title"`
+	Abstract         string           `xml:"Abstract"`
+	Keywords         []string         `xml:"Keywords>Keyword"`
+	DefaultSRS       string           `xml:"DefaultSRS"`
+	OtherSRS         []string         `xml:"OtherSRS"`
+	OutputFormats    []string         `xml:"OutputFormats>Format"`
+	WGS84BoundingBox WGS84BoundingBox `xml:"WGS84BoundingBox"`
+	MetadataURL      []MetadataURL    `xml:"MetadataURL"`
+}
+
+// WGS84BoundingBox is a geographic bounding box in EPSG:4326. The
+// wire form is `<LowerCorner>minX minY</LowerCorner>` and
+// `<UpperCorner>maxX maxY</UpperCorner>` — pre-split corner strings
+// so callers can parse with strconv.ParseFloat as needed (kept as
+// strings to avoid silent precision loss when the server emits
+// values like `-180.0000000000000001`).
+type WGS84BoundingBox struct {
+	LowerCorner string `xml:"LowerCorner"`
+	UpperCorner string `xml:"UpperCorner"`
+}
+
+// MetadataURL is a layer-level pointer to an external metadata
+// document.
+type MetadataURL struct {
+	Type   string `xml:"type,attr,omitempty"`
+	Format string `xml:"format,attr,omitempty"`
+	Href   string `xml:"http://www.w3.org/1999/xlink href,attr,omitempty"`
+}

--- a/v2/ows/wfs/wfs.go
+++ b/v2/ows/wfs/wfs.go
@@ -1,0 +1,112 @@
+package wfs
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	DoXML(ctx context.Context, op, method, requestURL string, query map[string]string, out any) error
+}
+
+// Client is the v2 WFS sub-client. The current surface covers
+// [Client.GetCapabilities]; [Client.InWorkspace] returns a
+// workspace-scoped view that issues `/{workspace}/wfs` rather than
+// the global `/wfs`.
+//
+//	caps, err := c.WFS.GetCapabilities(ctx, wfs.GetCapabilitiesOptions{})
+//	caps, err := c.WFS.InWorkspace("topp").GetCapabilities(ctx, wfs.GetCapabilitiesOptions{})
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core      Core
+	workspace string
+}
+
+// New constructs the global-scope WFS sub-client.
+func New(core Core) *Client { return &Client{core: core} }
+
+// InWorkspace returns a fresh WFS client scoped to the given
+// workspace. The original (global-scope) client is unaffected.
+func (c *Client) InWorkspace(workspace string) *Client {
+	return &Client{core: c.core, workspace: workspace}
+}
+
+// Workspace returns the workspace name this client is scoped to,
+// or "" for the global scope.
+func (c *Client) Workspace() string { return c.workspace }
+
+// IsGlobal reports whether this client operates against the global
+// `/wfs` endpoint (true) or a workspace-scoped one (false).
+func (c *Client) IsGlobal() bool { return c.workspace == "" }
+
+// GetCapabilitiesOptions controls a [Client.GetCapabilities] call.
+// All fields are optional.
+type GetCapabilitiesOptions struct {
+	// Version is the WFS protocol version requested. Default
+	// "2.0.0" — GeoServer's modern default. Supported values for
+	// this type tree are "1.1.0" and "2.0.0"; the wire format is
+	// the same root element (`<WFS_Capabilities>`) for both.
+	Version string
+
+	// UpdateSequence is an optional cache-coordination token.
+	UpdateSequence string
+}
+
+// GetCapabilities fetches the WFS GetCapabilities XML document and
+// parses it into a [*Capabilities]. On a 4xx/5xx response, returns a
+// *APIError wrapping the appropriate sentinel.
+func (c *Client) GetCapabilities(ctx context.Context, opts GetCapabilitiesOptions) (*Capabilities, error) {
+	const op = "WFS.GetCapabilities"
+
+	parts := []string{}
+	if c.workspace != "" {
+		parts = append(parts, c.workspace)
+	}
+	parts = append(parts, "wfs")
+	u, err := c.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	version := opts.Version
+	if version == "" {
+		version = "2.0.0"
+	}
+	query := map[string]string{
+		"service": "wfs",
+		"version": version,
+		"request": "GetCapabilities",
+	}
+	if opts.UpdateSequence != "" {
+		query["updatesequence"] = opts.UpdateSequence
+	}
+
+	var caps Capabilities
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, query, &caps); err != nil {
+		return nil, err
+	}
+	return &caps, nil
+}
+
+// ParseCapabilities reads a WFS GetCapabilities XML document from r
+// and decodes it into a [*Capabilities]. Useful for parsing a
+// document fetched out-of-band (saved fixture, custom transport).
+// Returns a typed parse error on malformed input.
+func ParseCapabilities(r io.Reader) (*Capabilities, error) {
+	if r == nil {
+		return nil, errors.New("wfs: ParseCapabilities: nil reader")
+	}
+	var caps Capabilities
+	if err := xml.NewDecoder(r).Decode(&caps); err != nil {
+		return nil, fmt.Errorf("wfs: parse capabilities: %w", err)
+	}
+	return &caps, nil
+}

--- a/v2/ows/wfs/wfs_integration_test.go
+++ b/v2/ows/wfs/wfs_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package wfs_test
+
+import (
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/ows/wfs"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func TestWFS_GetCapabilities_Global_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	caps, err := c.WFS.GetCapabilities(ctx, wfs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (global): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty: %+v", caps)
+	}
+	if caps.ServiceIdentification.ServiceType == "" {
+		t.Errorf("ServiceType is empty: %+v", caps.ServiceIdentification)
+	}
+}
+
+func TestWFS_GetCapabilities_Workspace_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	caps, err := c.WFS.InWorkspace(wsName).GetCapabilities(ctx, wfs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities (workspace): %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty for workspace-scoped caps")
+	}
+}
+
+func TestWFS_GetCapabilities_Version110_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Explicitly request 1.1.0 — the type tree handles both 1.1.0
+	// and 2.0.0 since the root element name is identical.
+	caps, err := c.WFS.GetCapabilities(ctx, wfs.GetCapabilitiesOptions{Version: "1.1.0"})
+	if err != nil {
+		t.Fatalf("GetCapabilities v1.1.0: %v", err)
+	}
+	if caps.Version == "" {
+		t.Errorf("Version is empty: %+v", caps)
+	}
+}

--- a/v2/ows/wfs/wfs_test.go
+++ b/v2/ows/wfs/wfs_test.go
@@ -1,0 +1,248 @@
+package wfs_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/ows/wfs"
+)
+
+const minimalCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
+<wfs:WFS_Capabilities version="2.0.0" updateSequence="42"
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:ServiceIdentification>
+    <ows:Title>Test WFS</ows:Title>
+    <ows:Abstract>Integration-test fixture</ows:Abstract>
+    <ows:Keywords>
+      <ows:Keyword>WFS</ows:Keyword>
+      <ows:Keyword>GeoServer</ows:Keyword>
+    </ows:Keywords>
+    <ows:ServiceType>WFS</ows:ServiceType>
+    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+    <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
+    <ows:Fees>NONE</ows:Fees>
+    <ows:AccessConstraints>NONE</ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>Acme</ows:ProviderName>
+    <ows:ProviderSite xlink:type="simple" xlink:href="http://example.com/"/>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://example.com/geoserver/wfs?"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetFeature">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://example.com/geoserver/wfs?"/>
+          <ows:Post xlink:href="http://example.com/geoserver/wfs"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <wfs:FeatureTypeList>
+    <wfs:FeatureType>
+      <wfs:Name>topp:states</wfs:Name>
+      <wfs:Title>USA States</wfs:Title>
+      <wfs:Abstract>Polygons for USA states</wfs:Abstract>
+      <wfs:Keywords>
+        <wfs:Keyword>states</wfs:Keyword>
+      </wfs:Keywords>
+      <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::4326</wfs:DefaultSRS>
+      <wfs:OtherSRS>urn:ogc:def:crs:EPSG::3857</wfs:OtherSRS>
+      <wfs:OutputFormats>
+        <wfs:Format>application/gml+xml; version=3.2</wfs:Format>
+        <wfs:Format>application/json</wfs:Format>
+      </wfs:OutputFormats>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-130 20</ows:LowerCorner>
+        <ows:UpperCorner>-65 50</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+    </wfs:FeatureType>
+  </wfs:FeatureTypeList>
+</wfs:WFS_Capabilities>`
+
+func TestParseCapabilities_OK(t *testing.T) {
+	caps, err := wfs.ParseCapabilities(strings.NewReader(minimalCapsXML))
+	if err != nil {
+		t.Fatalf("ParseCapabilities: %v", err)
+	}
+	if caps.Version != "2.0.0" {
+		t.Errorf("Version = %q, want 2.0.0", caps.Version)
+	}
+	if caps.UpdateSequence != "42" {
+		t.Errorf("UpdateSequence = %q", caps.UpdateSequence)
+	}
+
+	si := caps.ServiceIdentification
+	if si.Title != "Test WFS" {
+		t.Errorf("Title = %q", si.Title)
+	}
+	if got := len(si.Keywords); got != 2 {
+		t.Errorf("Keywords: got %d, want 2", got)
+	}
+	if got := len(si.Versions); got != 2 || si.Versions[0] != "2.0.0" {
+		t.Errorf("Versions = %+v", si.Versions)
+	}
+
+	if caps.ServiceProvider.ProviderName != "Acme" {
+		t.Errorf("ProviderName = %q", caps.ServiceProvider.ProviderName)
+	}
+
+	ops := caps.OperationsMetadata.Operation
+	if got := len(ops); got != 2 {
+		t.Fatalf("Operations: got %d, want 2", got)
+	}
+	getFeat := findOp(ops, "GetFeature")
+	if getFeat == nil {
+		t.Fatalf("GetFeature operation missing")
+	}
+	if got := len(getFeat.DCP[0].HTTP.Post); got != 1 {
+		t.Errorf("GetFeature POST endpoints: got %d, want 1", got)
+	}
+
+	fts := caps.FeatureTypeList.FeatureType
+	if got := len(fts); got != 1 {
+		t.Fatalf("FeatureTypes: got %d, want 1", got)
+	}
+	ft := fts[0]
+	if ft.Name != "topp:states" {
+		t.Errorf("FeatureType.Name = %q", ft.Name)
+	}
+	if ft.DefaultSRS != "urn:ogc:def:crs:EPSG::4326" {
+		t.Errorf("DefaultSRS = %q", ft.DefaultSRS)
+	}
+	if got := len(ft.OutputFormats); got != 2 {
+		t.Errorf("OutputFormats: got %d, want 2", got)
+	}
+	if ft.WGS84BoundingBox.LowerCorner != "-130 20" {
+		t.Errorf("WGS84.LowerCorner = %q", ft.WGS84BoundingBox.LowerCorner)
+	}
+}
+
+func findOp(ops []wfs.Operation, name string) *wfs.Operation {
+	for i := range ops {
+		if ops[i].Name == name {
+			return &ops[i]
+		}
+	}
+	return nil
+}
+
+func TestParseCapabilities_NilReader(t *testing.T) {
+	if _, err := wfs.ParseCapabilities(nil); err == nil {
+		t.Fatalf("expected error on nil reader")
+	}
+}
+
+func TestParseCapabilities_Malformed(t *testing.T) {
+	_, err := wfs.ParseCapabilities(strings.NewReader("<not-wfs/>"))
+	if err == nil {
+		t.Fatalf("expected error on non-WFS XML")
+	}
+	if !strings.Contains(err.Error(), "wfs: parse capabilities") {
+		t.Errorf("error not wrapped: %v", err)
+	}
+}
+
+func TestGetCapabilities_GlobalDefaultVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wfs" {
+			t.Errorf("path = %q, want /wfs", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("service") != "wfs" || q.Get("request") != "GetCapabilities" {
+			t.Errorf("query = %+v", q)
+		}
+		if q.Get("version") != "2.0.0" {
+			t.Errorf("version = %q, want 2.0.0 (default)", q.Get("version"))
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	caps, err := c.WFS.GetCapabilities(context.Background(), wfs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if caps.Version != "2.0.0" {
+		t.Errorf("Version = %q", caps.Version)
+	}
+}
+
+func TestGetCapabilities_WorkspaceScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/topp/wfs" {
+			t.Errorf("path = %q, want /topp/wfs", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	if _, err := c.WFS.InWorkspace("topp").GetCapabilities(context.Background(),
+		wfs.GetCapabilitiesOptions{}); err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+}
+
+func TestGetCapabilities_VersionOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("version") != "1.1.0" {
+			t.Errorf("version = %q, want 1.1.0", r.URL.Query().Get("version"))
+		}
+		_, _ = io.WriteString(w, minimalCapsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, _ = c.WFS.GetCapabilities(context.Background(), wfs.GetCapabilitiesOptions{
+		Version: "1.1.0",
+	})
+}
+
+func TestGetCapabilities_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such workspace", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, err := c.WFS.InWorkspace("missing").GetCapabilities(context.Background(),
+		wfs.GetCapabilitiesOptions{})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClient_IsGlobal(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	if !c.WFS.IsGlobal() {
+		t.Errorf("freshly constructed WFS client should be global")
+	}
+	scoped := c.WFS.InWorkspace("topp")
+	if scoped.IsGlobal() {
+		t.Errorf("workspace-scoped client reports IsGlobal=true")
+	}
+	if scoped.Workspace() != "topp" {
+		t.Errorf("Workspace() = %q", scoped.Workspace())
+	}
+	if !c.WFS.IsGlobal() {
+		t.Errorf("InWorkspace mutated original")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the OWS trio under \`v2/ows/\`. v2's surface at \`master\` now exceeds v1's.

### \`v2/ows/wfs\` — WFS GetCapabilities

- Hand-written subset of WFS 1.1.0 / 2.0 schemas: ServiceIdentification, ServiceProvider, OperationsMetadata (Operation, DCP, HTTP, Parameter), FeatureTypeList with FeatureType (Name, Title, Abstract, DefaultSRS, OtherSRS, OutputFormats, WGS84BoundingBox, MetadataURL).
- \`wfs.ParseCapabilities(io.Reader)\` — out-of-band parsing.
- \`c.WFS.GetCapabilities(ctx, opts)\` — global by default; \`c.WFS.InWorkspace(ws)\` for workspace-scoped capabilities.
- Default version \`2.0.0\`; \`1.1.0\` supported (same root element).

### \`v2/ows/wcs\` — WCS GetCapabilities

- Hand-written subset of WCS 2.0.x: ServiceIdentification, ServiceProvider, OperationsMetadata, ServiceMetadata (formats + CRSes), Contents with CoverageSummary.
- \`wcs.ParseCapabilities\` + \`c.WCS.GetCapabilities\` + \`InWorkspace\`, same shape as wfs.
- Default version \`2.0.1\`. WCS 1.0.0 / 1.1.1 use a different root element (\`WCS_Capabilities\`) and are out of scope here.

Both packages decode by local-name only, so values flow through \`encoding/xml\` regardless of which namespace prefix GeoServer applies (\`wfs:\`, \`wcs:\`, \`ows:\` at varying versions). Both route through the existing \`internal/transport.DoXML\` helper (32 MiB cap added in #64).

## Tests

- httptest unit tests with realistic GeoServer namespace declarations covering happy path, malformed XML, version override (WFS 1.1.0), workspace scoping, and 404 → \`ErrNotFound\` sentinel.
- Integration tests (\`//go:build integration\`) for both packages — global + workspace scope, and a WFS 1.1.0 path.
- Godoc \`Example_*\` with \`Output:\`-comment-verified \`ParseCapabilities\` examples.

## Test plan

- [x] \`cd v2 && go vet ./...\` clean
- [x] \`cd v2 && go test -count=1 ./...\` green (all 18 packages)
- [x] \`cd v2 && golangci-lint run ./...\` 0 issues
- [x] \`cd v2 && go vet -tags=integration ./...\` clean
- [ ] CI: 7 required checks + CodeQL pass on this branch
- [ ] Real-server integration legs (2.27.4 LTS + 2.28.0 stable) cover the new \`wfs\` + \`wcs\` integration tests

## Docs

- \`v2/CHANGELOG.md\` \`[Unreleased]\` updated.
- \`v2/README.md\` banner: full OWS trio listed; install pin bumped to \`v2.0.0-alpha.2\`.
- Root \`README.md\` Roadmap mirrors that.
- \`ROADMAP.md\`: OWS clients milestone consolidated to (1/3, 2/3, 3/3) all checked; forward placeholder removed.