### PR TITLE
feat(v2/ows): add WFS DescribeFeatureType + WCS DescribeCoverage

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — OWS describe operations
+
+- **`v2/ows/wfs.Client.DescribeFeatureType(ctx, opts)`** — fetches the XSD schema describing one or more published feature types and decodes it into a `*FeatureSchema`. The schema's `Attributes(typeName)` helper walks the typical `complexType > complexContent > extension > sequence > element*` shape and surfaces a flat `[]Attribute` list. Send multiple type names in `DescribeFeatureTypeOptions.TypeNames` (comma-joined for the WFS 2.0 `typeNames` query plus the WFS 1.1.0 `typeName` alias for cross-version compatibility). Companion free function `wfs.ParseFeatureSchema(io.Reader)` for out-of-band parsing.
+- **`v2/ows/wcs.Client.DescribeCoverage(ctx, opts)`** — fetches detailed metadata for one or more coverages and decodes it into `*CoverageDescriptions` (CoverageId + BoundedBy envelope + DomainSet/RectifiedGrid + RangeType/DataRecord/Field). Useful for knowing the bands, units of measure, CRS, and pixel-space dimensions of a coverage before issuing a GetCoverage. Companion free function `wcs.ParseCoverageDescriptions(io.Reader)`.
+
+### Added (tests)
+
+- httptest unit tests for both Describe operations: parse fixtures with realistic GeoServer XML namespace declarations, query-parameter assertions (including the `typeNames` / `typeName` cross-version aliases for WFS), multi-id requests, empty-id rejection, and 404 → `ErrNotFound` sentinel.
+- Integration tests for both — WFS DescribeFeatureType against `sf:archsites` (default-install feature type), and WCS DescribeCoverage against the first coverage discovered via `c.WCS.GetCapabilities`.
+- Godoc `Example_*` for both new methods.
+
 ## [2.0.0-alpha.3] — 2026-05-03
 
 Third alpha. Closes the OWS GetCapabilities trio with WFS + WCS, taking v2's surface beyond v1's. No breaking changes from `alpha.2`; existing callers can `go get @v2.0.0-alpha.3` and recompile. Public API may still refine before `v2.0.0` — no production guarantees yet.

--- a/v2/ows/wcs/example_test.go
+++ b/v2/ows/wcs/example_test.go
@@ -35,6 +35,25 @@ func ExampleClient_InWorkspace() {
 		wcs.GetCapabilitiesOptions{})
 }
 
+// ExampleClient_DescribeCoverage fetches detailed metadata for a
+// coverage and prints each band's name + unit-of-measure.
+func ExampleClient_DescribeCoverage() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	descs, err := c.WCS.DescribeCoverage(context.Background(),
+		wcs.DescribeCoverageOptions{CoverageIDs: []string{"nurc__Arc_Sample"}})
+	if err != nil {
+		return
+	}
+	for _, d := range descs.CoverageDescription {
+		fmt.Printf("%s @ %s\n", d.CoverageID, d.BoundedBy.Envelope.SrsName)
+		for _, f := range d.RangeType.DataRecord.Field {
+			fmt.Printf("  band %s (%s)\n", f.Name, f.Quantity.Uom.Code)
+		}
+	}
+}
+
 // ExampleParseCapabilities decodes a capabilities document fetched
 // out-of-band.
 func ExampleParseCapabilities() {

--- a/v2/ows/wcs/types.go
+++ b/v2/ows/wcs/types.go
@@ -109,10 +109,116 @@ type Contents struct {
 }
 
 // CoverageSummary is one published coverage entry. WCS 2.0 minimizes
-// the per-coverage envelope to CoverageId + CoverageSubtype; richer
-// per-coverage detail is fetched via DescribeCoverage (not in this
-// package's scope).
+// the per-coverage envelope to CoverageId + CoverageSubtype; full
+// per-coverage detail is fetched via [Client.DescribeCoverage].
 type CoverageSummary struct {
 	CoverageID      string `xml:"CoverageId"`
 	CoverageSubtype string `xml:"CoverageSubtype"`
+}
+
+// CoverageDescriptions is the root of a WCS DescribeCoverage response
+// (`<wcs:CoverageDescriptions>`), holding one [CoverageDescription]
+// per requested coverage.
+type CoverageDescriptions struct {
+	XMLName             xml.Name              `xml:"CoverageDescriptions"`
+	CoverageDescription []CoverageDescription `xml:"CoverageDescription"`
+}
+
+// CoverageDescription is the per-coverage envelope returned by
+// DescribeCoverage. The native GML/SWE schemas are deep; this type
+// surfaces the common-case fields callers actually use (id, bounding
+// box, range fields). For full XML access, callers can re-parse the
+// response body with [encoding/xml] directly.
+type CoverageDescription struct {
+	CoverageID        string                `xml:"CoverageId"`
+	BoundedBy         BoundedBy             `xml:"boundedBy"`
+	DomainSet         DomainSet             `xml:"domainSet"`
+	RangeType         RangeType             `xml:"rangeType"`
+	ServiceParameters CoverageServiceParams `xml:"ServiceParameters"`
+}
+
+// BoundedBy carries the GML envelope (lower + upper corner) plus the
+// SRS (`srsName`) and dimension count (`srsDimension`) attributes.
+type BoundedBy struct {
+	Envelope Envelope `xml:"Envelope"`
+}
+
+// Envelope is the GML envelope inside [BoundedBy]. LowerCorner /
+// UpperCorner are pre-split strings (e.g., "20.0 -130.0"); kept as
+// strings to preserve the exact wire form (parse with strconv as
+// needed).
+type Envelope struct {
+	SrsName      string `xml:"srsName,attr,omitempty"`
+	AxisLabels   string `xml:"axisLabels,attr,omitempty"`
+	UomLabels    string `xml:"uomLabels,attr,omitempty"`
+	SrsDimension string `xml:"srsDimension,attr,omitempty"`
+	LowerCorner  string `xml:"lowerCorner"`
+	UpperCorner  string `xml:"upperCorner"`
+}
+
+// DomainSet describes the spatial domain of the coverage — typically
+// a [RectifiedGrid] giving the grid's CRS, dimensions, and pixel
+// origin/offset vectors.
+type DomainSet struct {
+	RectifiedGrid RectifiedGrid `xml:"RectifiedGrid"`
+}
+
+// RectifiedGrid is the gml:RectifiedGrid wrapped in DomainSet.
+type RectifiedGrid struct {
+	Dimension    string     `xml:"dimension,attr,omitempty"`
+	SrsName      string     `xml:"srsName,attr,omitempty"`
+	Limits       GridLimits `xml:"limits"`
+	AxisLabels   string     `xml:"axisLabels"`
+	Origin       string     `xml:"origin>Point>pos"`
+	OffsetVector []string   `xml:"offsetVector"`
+}
+
+// GridLimits is the integer pixel-space envelope of the grid.
+type GridLimits struct {
+	GridEnvelope GridEnvelope `xml:"GridEnvelope"`
+}
+
+// GridEnvelope is the pixel-space low/high index pair.
+type GridEnvelope struct {
+	Low  string `xml:"low"`
+	High string `xml:"high"`
+}
+
+// RangeType describes the coverage's per-pixel value structure — a
+// list of [Field] entries (one per band). Encoded as a SWE
+// DataRecord on the wire.
+type RangeType struct {
+	DataRecord DataRecord `xml:"DataRecord"`
+}
+
+// DataRecord is the SWE DataRecord wrapping the range fields.
+type DataRecord struct {
+	Field []Field `xml:"field"`
+}
+
+// Field is one band/component in the coverage's range type.
+// Quantity carries the unit-of-measure (Uom) attribute.
+type Field struct {
+	Name     string   `xml:"name,attr,omitempty"`
+	Quantity Quantity `xml:"Quantity"`
+}
+
+// Quantity is the SWE Quantity inside a [Field].
+type Quantity struct {
+	Description string `xml:"description"`
+	Uom         Uom    `xml:"uom"`
+	Constraint  string `xml:"constraint>AllowedValues>interval"`
+}
+
+// Uom is the unit-of-measure descriptor on a [Quantity].
+type Uom struct {
+	Code string `xml:"code,attr,omitempty"`
+}
+
+// CoverageServiceParams is the WCS service-parameters block per
+// coverage — currently exposes the native CoverageSubtype and
+// supported format(s).
+type CoverageServiceParams struct {
+	CoverageSubtype string `xml:"CoverageSubtype"`
+	NativeFormat    string `xml:"nativeFormat"`
 }

--- a/v2/ows/wcs/wcs.go
+++ b/v2/ows/wcs/wcs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Core is the plumbing the sub-client needs from the parent [*Client].
@@ -114,4 +115,72 @@ func ParseCapabilities(r io.Reader) (*Capabilities, error) {
 		return nil, fmt.Errorf("wcs: parse capabilities: %w", err)
 	}
 	return &caps, nil
+}
+
+// DescribeCoverageOptions controls a [Client.DescribeCoverage] call.
+// CoverageIDs is required (the coverage identifiers to describe).
+type DescribeCoverageOptions struct {
+	// CoverageIDs is the list of coverage identifiers to describe
+	// (e.g., []string{"nurc__Arc_Sample"}). Required — WCS rejects
+	// an empty list.
+	CoverageIDs []string
+
+	// Version is the WCS protocol version requested. Default
+	// "2.0.1".
+	Version string
+}
+
+// DescribeCoverage fetches detailed metadata for one or more
+// coverages and parses it into a [*CoverageDescriptions].
+//
+// Returns a *APIError wrapping the appropriate sentinel on a 4xx/5xx
+// response.
+func (c *Client) DescribeCoverage(ctx context.Context, opts DescribeCoverageOptions) (*CoverageDescriptions, error) {
+	const op = "WCS.DescribeCoverage"
+	if len(opts.CoverageIDs) == 0 {
+		return nil, errors.New(op + ": empty CoverageIDs (WCS DescribeCoverage requires at least one)")
+	}
+
+	parts := []string{}
+	if c.workspace != "" {
+		parts = append(parts, c.workspace)
+	}
+	parts = append(parts, "wcs")
+	u, err := c.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	version := opts.Version
+	if version == "" {
+		version = "2.0.1"
+	}
+	// GeoServer's WCS endpoint is case-sensitive on `service` —
+	// see the comment in [Client.GetCapabilities].
+	query := map[string]string{
+		"service":    "WCS",
+		"version":    version,
+		"request":    "DescribeCoverage",
+		"coverageId": strings.Join(opts.CoverageIDs, ","),
+	}
+
+	var descs CoverageDescriptions
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, query, &descs); err != nil {
+		return nil, err
+	}
+	return &descs, nil
+}
+
+// ParseCoverageDescriptions reads a WCS DescribeCoverage XML document
+// from r and decodes it into a [*CoverageDescriptions]. Useful for
+// parsing a document fetched out-of-band.
+func ParseCoverageDescriptions(r io.Reader) (*CoverageDescriptions, error) {
+	if r == nil {
+		return nil, errors.New("wcs: ParseCoverageDescriptions: nil reader")
+	}
+	var descs CoverageDescriptions
+	if err := xml.NewDecoder(r).Decode(&descs); err != nil {
+		return nil, fmt.Errorf("wcs: parse coverage descriptions: %w", err)
+	}
+	return &descs, nil
 }

--- a/v2/ows/wcs/wcs_integration_test.go
+++ b/v2/ows/wcs/wcs_integration_test.go
@@ -26,6 +26,43 @@ func TestWCS_GetCapabilities_Global_Integration(t *testing.T) {
 	}
 }
 
+func TestWCS_DescribeCoverage_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Discover an actual coverage by listing capabilities first —
+	// avoids hard-coding a coverage ID that varies across data
+	// directory variants.
+	caps, err := c.WCS.GetCapabilities(ctx, wcs.GetCapabilitiesOptions{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if len(caps.Contents.CoverageSummary) == 0 {
+		t.Skip("no published coverages — skipping DescribeCoverage")
+	}
+	id := caps.Contents.CoverageSummary[0].CoverageID
+
+	descs, err := c.WCS.DescribeCoverage(ctx, wcs.DescribeCoverageOptions{
+		CoverageIDs: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeCoverage(%q): %v", id, err)
+	}
+	if got := len(descs.CoverageDescription); got != 1 {
+		t.Fatalf("CoverageDescription: got %d, want 1", got)
+	}
+	d := descs.CoverageDescription[0]
+	if d.CoverageID != id {
+		t.Errorf("CoverageID = %q, want %q", d.CoverageID, id)
+	}
+	if d.BoundedBy.Envelope.LowerCorner == "" {
+		t.Errorf("Envelope.LowerCorner is empty: %+v", d.BoundedBy)
+	}
+	if got := len(d.RangeType.DataRecord.Field); got == 0 {
+		t.Errorf("RangeType.Fields empty — coverage with no bands shouldn't happen")
+	}
+}
+
 func TestWCS_GetCapabilities_Workspace_Integration(t *testing.T) {
 	c := testenv.NewClient(t)
 	ctx := testenv.Context(t)

--- a/v2/ows/wcs/wcs_test.go
+++ b/v2/ows/wcs/wcs_test.go
@@ -172,6 +172,172 @@ func TestGetCapabilities_NotFound(t *testing.T) {
 	}
 }
 
+const minimalCoverageDescriptionsXML = `<?xml version="1.0" encoding="UTF-8"?>
+<wcs:CoverageDescriptions
+    xmlns:wcs="http://www.opengis.net/wcs/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+    xmlns:swe="http://www.opengis.net/swe/2.0">
+  <wcs:CoverageDescription gml:id="nurc__Arc_Sample">
+    <wcs:CoverageId>nurc__Arc_Sample</wcs:CoverageId>
+    <gml:boundedBy>
+      <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326"
+                    axisLabels="Lat Long"
+                    uomLabels="deg deg"
+                    srsDimension="2">
+        <gml:lowerCorner>-90.0 -180.0</gml:lowerCorner>
+        <gml:upperCorner>90.0 180.0</gml:upperCorner>
+      </gml:Envelope>
+    </gml:boundedBy>
+    <gml:domainSet>
+      <gml:RectifiedGrid dimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+        <gml:limits>
+          <gml:GridEnvelope>
+            <gml:low>0 0</gml:low>
+            <gml:high>1023 511</gml:high>
+          </gml:GridEnvelope>
+        </gml:limits>
+        <gml:axisLabels>i j</gml:axisLabels>
+      </gml:RectifiedGrid>
+    </gml:domainSet>
+    <gmlcov:rangeType>
+      <swe:DataRecord>
+        <swe:field name="GRAY_INDEX">
+          <swe:Quantity>
+            <swe:description>GRAY_INDEX</swe:description>
+            <swe:uom code="W.m-2.Sr-1"/>
+          </swe:Quantity>
+        </swe:field>
+      </swe:DataRecord>
+    </gmlcov:rangeType>
+    <wcs:ServiceParameters>
+      <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
+      <wcs:nativeFormat>image/tiff</wcs:nativeFormat>
+    </wcs:ServiceParameters>
+  </wcs:CoverageDescription>
+</wcs:CoverageDescriptions>`
+
+func TestParseCoverageDescriptions_OK(t *testing.T) {
+	descs, err := wcs.ParseCoverageDescriptions(strings.NewReader(minimalCoverageDescriptionsXML))
+	if err != nil {
+		t.Fatalf("ParseCoverageDescriptions: %v", err)
+	}
+	if got := len(descs.CoverageDescription); got != 1 {
+		t.Fatalf("CoverageDescription: got %d, want 1", got)
+	}
+	d := descs.CoverageDescription[0]
+	if d.CoverageID != "nurc__Arc_Sample" {
+		t.Errorf("CoverageID = %q", d.CoverageID)
+	}
+	if d.BoundedBy.Envelope.LowerCorner != "-90.0 -180.0" {
+		t.Errorf("LowerCorner = %q", d.BoundedBy.Envelope.LowerCorner)
+	}
+	if d.BoundedBy.Envelope.SrsName != "http://www.opengis.net/def/crs/EPSG/0/4326" {
+		t.Errorf("SrsName = %q", d.BoundedBy.Envelope.SrsName)
+	}
+	if d.DomainSet.RectifiedGrid.Limits.GridEnvelope.High != "1023 511" {
+		t.Errorf("GridEnvelope.High = %q", d.DomainSet.RectifiedGrid.Limits.GridEnvelope.High)
+	}
+	if got := len(d.RangeType.DataRecord.Field); got != 1 {
+		t.Fatalf("Fields: got %d, want 1", got)
+	}
+	field := d.RangeType.DataRecord.Field[0]
+	if field.Name != "GRAY_INDEX" {
+		t.Errorf("Field.Name = %q", field.Name)
+	}
+	if field.Quantity.Uom.Code != "W.m-2.Sr-1" {
+		t.Errorf("Field.Uom.Code = %q", field.Quantity.Uom.Code)
+	}
+	if d.ServiceParameters.CoverageSubtype != "RectifiedGridCoverage" {
+		t.Errorf("CoverageSubtype = %q", d.ServiceParameters.CoverageSubtype)
+	}
+	if d.ServiceParameters.NativeFormat != "image/tiff" {
+		t.Errorf("NativeFormat = %q", d.ServiceParameters.NativeFormat)
+	}
+}
+
+func TestParseCoverageDescriptions_NilReader(t *testing.T) {
+	if _, err := wcs.ParseCoverageDescriptions(nil); err == nil {
+		t.Fatalf("expected error on nil reader")
+	}
+}
+
+func TestParseCoverageDescriptions_Malformed(t *testing.T) {
+	_, err := wcs.ParseCoverageDescriptions(strings.NewReader("<not-wcs/>"))
+	if err == nil {
+		t.Fatalf("expected error on non-WCS XML")
+	}
+	if !strings.Contains(err.Error(), "wcs: parse coverage descriptions") {
+		t.Errorf("error not wrapped: %v", err)
+	}
+}
+
+func TestDescribeCoverage_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("service") != "WCS" {
+			t.Errorf("service = %q (must be uppercase)", q.Get("service"))
+		}
+		if q.Get("request") != "DescribeCoverage" {
+			t.Errorf("request = %q", q.Get("request"))
+		}
+		if q.Get("coverageId") != "nurc__Arc_Sample" {
+			t.Errorf("coverageId = %q", q.Get("coverageId"))
+		}
+		_, _ = io.WriteString(w, minimalCoverageDescriptionsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	descs, err := c.WCS.DescribeCoverage(context.Background(),
+		wcs.DescribeCoverageOptions{CoverageIDs: []string{"nurc__Arc_Sample"}})
+	if err != nil {
+		t.Fatalf("DescribeCoverage: %v", err)
+	}
+	if got := len(descs.CoverageDescription); got != 1 {
+		t.Errorf("CoverageDescription: got %d, want 1", got)
+	}
+}
+
+func TestDescribeCoverage_EmptyIDs(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	_, err := c.WCS.DescribeCoverage(context.Background(), wcs.DescribeCoverageOptions{})
+	if err == nil {
+		t.Fatalf("expected error for empty CoverageIDs")
+	}
+	if !strings.Contains(err.Error(), "empty CoverageIDs") {
+		t.Errorf("error message = %q", err.Error())
+	}
+}
+
+func TestDescribeCoverage_MultipleIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("coverageId") != "a,b,c" {
+			t.Errorf("coverageId = %q", r.URL.Query().Get("coverageId"))
+		}
+		_, _ = io.WriteString(w, minimalCoverageDescriptionsXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, _ = c.WCS.DescribeCoverage(context.Background(),
+		wcs.DescribeCoverageOptions{CoverageIDs: []string{"a", "b", "c"}})
+}
+
+func TestDescribeCoverage_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such coverage", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, err := c.WCS.DescribeCoverage(context.Background(),
+		wcs.DescribeCoverageOptions{CoverageIDs: []string{"missing"}})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestClient_IsGlobal(t *testing.T) {
 	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
 	if !c.WCS.IsGlobal() {

--- a/v2/ows/wfs/example_test.go
+++ b/v2/ows/wfs/example_test.go
@@ -35,6 +35,22 @@ func ExampleClient_InWorkspace() {
 		wfs.GetCapabilitiesOptions{Version: "1.1.0"})
 }
 
+// ExampleClient_DescribeFeatureType fetches the XSD schema for a
+// published feature type and prints each attribute's name and type.
+func ExampleClient_DescribeFeatureType() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	schema, err := c.WFS.DescribeFeatureType(context.Background(),
+		wfs.DescribeFeatureTypeOptions{TypeNames: []string{"topp:states"}})
+	if err != nil {
+		return
+	}
+	for _, attr := range schema.Attributes("") {
+		fmt.Printf("  %s : %s\n", attr.Name, attr.Type)
+	}
+}
+
 // ExampleParseCapabilities decodes a capabilities document fetched
 // out-of-band — useful for parsing a saved fixture or a body from a
 // custom transport.

--- a/v2/ows/wfs/types.go
+++ b/v2/ows/wfs/types.go
@@ -138,3 +138,117 @@ type MetadataURL struct {
 	Format string `xml:"format,attr,omitempty"`
 	Href   string `xml:"http://www.w3.org/1999/xlink href,attr,omitempty"`
 }
+
+// FeatureSchema is the root of a WFS DescribeFeatureType response —
+// an XSD schema document (`<xsd:schema>`) describing the published
+// feature type's attributes.
+//
+// The type tree intentionally models a useful subset of XSD rather
+// than the full schema language; the common WFS-emitted shape is
+// `complexType > complexContent > extension > sequence > element*`,
+// and the [FeatureSchema.Attributes] helper walks that tree to
+// surface a flat list of attributes.
+type FeatureSchema struct {
+	XMLName         xml.Name        `xml:"schema"`
+	TargetNamespace string          `xml:"targetNamespace,attr,omitempty"`
+	Imports         []SchemaImport  `xml:"import"`
+	Elements        []SchemaElement `xml:"element"`
+	ComplexTypes    []ComplexType   `xml:"complexType"`
+}
+
+// SchemaImport is `<xsd:import>` — a reference to another schema
+// (typically GML).
+type SchemaImport struct {
+	Namespace      string `xml:"namespace,attr,omitempty"`
+	SchemaLocation string `xml:"schemaLocation,attr,omitempty"`
+}
+
+// SchemaElement is `<xsd:element>` at the top of a [FeatureSchema] —
+// names the published feature element and points at its
+// [ComplexType].
+type SchemaElement struct {
+	Name              string `xml:"name,attr,omitempty"`
+	Type              string `xml:"type,attr,omitempty"`
+	SubstitutionGroup string `xml:"substitutionGroup,attr,omitempty"`
+}
+
+// ComplexType is `<xsd:complexType>` — names the type and carries
+// either a top-level [Sequence] or, more commonly for WFS, a
+// [ComplexContent] wrapping an extension of `gml:AbstractFeatureType`.
+type ComplexType struct {
+	Name           string          `xml:"name,attr,omitempty"`
+	Sequence       *Sequence       `xml:"sequence,omitempty"`
+	ComplexContent *ComplexContent `xml:"complexContent,omitempty"`
+}
+
+// ComplexContent is `<xsd:complexContent>`. Its [Extension] points at
+// a base type (typically `gml:AbstractFeatureType`) and adds a
+// [Sequence] of attribute elements.
+type ComplexContent struct {
+	Extension Extension `xml:"extension"`
+}
+
+// Extension is `<xsd:extension>` — names the base type and adds a
+// [Sequence] of attribute elements.
+type Extension struct {
+	Base     string   `xml:"base,attr,omitempty"`
+	Sequence Sequence `xml:"sequence"`
+}
+
+// Sequence is `<xsd:sequence>` — the ordered list of attribute
+// elements making up a feature.
+type Sequence struct {
+	Elements []Attribute `xml:"element"`
+}
+
+// Attribute is one feature attribute — `<xsd:element>` inside the
+// sequence under a [ComplexType] (directly or via [Extension]).
+//
+// Type is the xsd:type string (e.g., `xsd:string`, `xsd:int`,
+// `gml:Point`, `gml:MultiSurfacePropertyType`). Nillable defaults
+// to false when the attribute is absent. MinOccurs is "0" for
+// optional attributes (the XSD default for `<xsd:element>` inside
+// a sequence) — kept as string to preserve the exact wire form.
+type Attribute struct {
+	Name      string `xml:"name,attr"`
+	Type      string `xml:"type,attr,omitempty"`
+	Nillable  bool   `xml:"nillable,attr,omitempty"`
+	MinOccurs string `xml:"minOccurs,attr,omitempty"`
+	MaxOccurs string `xml:"maxOccurs,attr,omitempty"`
+}
+
+// Attributes returns the attribute list for the named complex type
+// — the typical WFS shape walks `complexType > complexContent >
+// extension > sequence > element*`. Returns nil if the type is not
+// present in the schema.
+//
+// typeName is the local name (without namespace prefix); pass an
+// empty string to use the first complex type in the schema (the
+// common case where DescribeFeatureType returns one type).
+func (s *FeatureSchema) Attributes(typeName string) []Attribute {
+	if s == nil || len(s.ComplexTypes) == 0 {
+		return nil
+	}
+	var ct *ComplexType
+	if typeName == "" {
+		ct = &s.ComplexTypes[0]
+	} else {
+		for i := range s.ComplexTypes {
+			if s.ComplexTypes[i].Name == typeName {
+				ct = &s.ComplexTypes[i]
+				break
+			}
+		}
+	}
+	if ct == nil {
+		return nil
+	}
+	switch {
+	case ct.Sequence != nil:
+		return ct.Sequence.Elements
+	case ct.ComplexContent != nil:
+		return ct.ComplexContent.Extension.Sequence.Elements
+	default:
+		return nil
+	}
+}

--- a/v2/ows/wfs/wfs.go
+++ b/v2/ows/wfs/wfs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Core is the plumbing the sub-client needs from the parent [*Client].
@@ -109,4 +110,77 @@ func ParseCapabilities(r io.Reader) (*Capabilities, error) {
 		return nil, fmt.Errorf("wfs: parse capabilities: %w", err)
 	}
 	return &caps, nil
+}
+
+// DescribeFeatureTypeOptions controls a [Client.DescribeFeatureType]
+// call. TypeNames is required (the prefixed feature-type names to
+// describe); a single call may request multiple types.
+type DescribeFeatureTypeOptions struct {
+	// TypeNames is the list of prefixed feature-type names to
+	// describe (e.g., []string{"topp:states"}).
+	TypeNames []string
+
+	// Version is the WFS protocol version requested. Default
+	// "2.0.0". The XSD response shape is broadly compatible across
+	// versions; the type tree decodes both 1.1.0 and 2.0.0 output.
+	Version string
+}
+
+// DescribeFeatureType fetches the XSD schema describing one or more
+// published feature types and parses it into a [*FeatureSchema].
+// Use [FeatureSchema.Attributes] for the flat attribute list.
+//
+// Returns a *APIError wrapping the appropriate sentinel on a 4xx/5xx
+// response. An empty TypeNames list returns the schema for every
+// published feature type — that response can be large.
+func (c *Client) DescribeFeatureType(ctx context.Context, opts DescribeFeatureTypeOptions) (*FeatureSchema, error) {
+	const op = "WFS.DescribeFeatureType"
+
+	parts := []string{}
+	if c.workspace != "" {
+		parts = append(parts, c.workspace)
+	}
+	parts = append(parts, "wfs")
+	u, err := c.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	version := opts.Version
+	if version == "" {
+		version = "2.0.0"
+	}
+	query := map[string]string{
+		"service": "wfs",
+		"version": version,
+		"request": "DescribeFeatureType",
+	}
+	if len(opts.TypeNames) > 0 {
+		// WFS 2.0 expects "typeNames" (plural, comma-separated);
+		// 1.1.0 expects "typeName". Send both to keep callers
+		// version-agnostic — GeoServer ignores the irrelevant one.
+		joined := strings.Join(opts.TypeNames, ",")
+		query["typeNames"] = joined
+		query["typeName"] = joined
+	}
+
+	var schema FeatureSchema
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, query, &schema); err != nil {
+		return nil, err
+	}
+	return &schema, nil
+}
+
+// ParseFeatureSchema reads a WFS DescribeFeatureType XSD document
+// from r and decodes it into a [*FeatureSchema]. Useful for parsing
+// a document fetched out-of-band.
+func ParseFeatureSchema(r io.Reader) (*FeatureSchema, error) {
+	if r == nil {
+		return nil, errors.New("wfs: ParseFeatureSchema: nil reader")
+	}
+	var schema FeatureSchema
+	if err := xml.NewDecoder(r).Decode(&schema); err != nil {
+		return nil, fmt.Errorf("wfs: parse feature schema: %w", err)
+	}
+	return &schema, nil
 }

--- a/v2/ows/wfs/wfs_integration_test.go
+++ b/v2/ows/wfs/wfs_integration_test.go
@@ -48,6 +48,30 @@ func TestWFS_GetCapabilities_Workspace_Integration(t *testing.T) {
 	}
 }
 
+func TestWFS_DescribeFeatureType_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Use one of GeoServer's default-install feature types
+	// (sf:archsites is shipped by default with the workshop data).
+	schema, err := c.WFS.DescribeFeatureType(ctx, wfs.DescribeFeatureTypeOptions{
+		TypeNames: []string{"sf:archsites"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeFeatureType: %v", err)
+	}
+	if schema.TargetNamespace == "" {
+		t.Errorf("TargetNamespace is empty: %+v", schema)
+	}
+	if got := len(schema.ComplexTypes); got == 0 {
+		t.Fatalf("ComplexTypes empty — schema didn't decode")
+	}
+	attrs := schema.Attributes("")
+	if len(attrs) == 0 {
+		t.Errorf("Attributes empty — sf:archsites should have at least geometry + cat + str1")
+	}
+}
+
 func TestWFS_GetCapabilities_Version110_Integration(t *testing.T) {
 	c := testenv.NewClient(t)
 	ctx := testenv.Context(t)

--- a/v2/ows/wfs/wfs_test.go
+++ b/v2/ows/wfs/wfs_test.go
@@ -230,6 +230,151 @@ func TestGetCapabilities_NotFound(t *testing.T) {
 	}
 }
 
+const minimalSchemaXML = `<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:topp="http://www.openplans.org/topp"
+            targetNamespace="http://www.openplans.org/topp"
+            elementFormDefault="qualified">
+  <xsd:import namespace="http://www.opengis.net/gml/3.2"
+              schemaLocation="http://example.com/schemas/gml/3.2.1/gml.xsd"/>
+  <xsd:complexType name="statesType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element minOccurs="0" name="the_geom" nillable="true" type="gml:MultiSurfacePropertyType"/>
+          <xsd:element minOccurs="0" name="STATE_NAME" nillable="true" type="xsd:string"/>
+          <xsd:element minOccurs="0" name="STATE_FIPS" nillable="true" type="xsd:string"/>
+          <xsd:element minOccurs="0" name="PERSONS" nillable="true" type="xsd:double"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="states" substitutionGroup="gml:AbstractFeature" type="topp:statesType"/>
+</xsd:schema>`
+
+func TestParseFeatureSchema_OK(t *testing.T) {
+	schema, err := wfs.ParseFeatureSchema(strings.NewReader(minimalSchemaXML))
+	if err != nil {
+		t.Fatalf("ParseFeatureSchema: %v", err)
+	}
+	if schema.TargetNamespace != "http://www.openplans.org/topp" {
+		t.Errorf("TargetNamespace = %q", schema.TargetNamespace)
+	}
+	if got := len(schema.Imports); got != 1 {
+		t.Errorf("Imports: got %d, want 1", got)
+	}
+	if got := len(schema.ComplexTypes); got != 1 {
+		t.Fatalf("ComplexTypes: got %d, want 1", got)
+	}
+	if schema.ComplexTypes[0].Name != "statesType" {
+		t.Errorf("ComplexType.Name = %q", schema.ComplexTypes[0].Name)
+	}
+
+	attrs := schema.Attributes("statesType")
+	if got := len(attrs); got != 4 {
+		t.Fatalf("Attributes(statesType): got %d, want 4", got)
+	}
+	if attrs[0].Name != "the_geom" || attrs[0].Type != "gml:MultiSurfacePropertyType" {
+		t.Errorf("attrs[0] = %+v", attrs[0])
+	}
+	if !attrs[0].Nillable {
+		t.Errorf("attrs[0].Nillable should be true")
+	}
+	if attrs[3].Type != "xsd:double" {
+		t.Errorf("attrs[3].Type = %q", attrs[3].Type)
+	}
+
+	// Empty typeName picks the first complex type.
+	if got := len(schema.Attributes("")); got != 4 {
+		t.Errorf("Attributes(\"\"): got %d, want 4", got)
+	}
+
+	// Unknown typeName returns nil.
+	if got := schema.Attributes("unknown"); got != nil {
+		t.Errorf("Attributes(unknown) = %+v, want nil", got)
+	}
+}
+
+func TestParseFeatureSchema_NilReader(t *testing.T) {
+	if _, err := wfs.ParseFeatureSchema(nil); err == nil {
+		t.Fatalf("expected error on nil reader")
+	}
+}
+
+func TestParseFeatureSchema_Malformed(t *testing.T) {
+	_, err := wfs.ParseFeatureSchema(strings.NewReader("<not-xsd/>"))
+	if err == nil {
+		t.Fatalf("expected error on non-XSD XML")
+	}
+	if !strings.Contains(err.Error(), "wfs: parse feature schema") {
+		t.Errorf("error not wrapped: %v", err)
+	}
+}
+
+func TestDescribeFeatureType_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wfs" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("request") != "DescribeFeatureType" {
+			t.Errorf("request = %q", q.Get("request"))
+		}
+		if q.Get("typeNames") != "topp:states" {
+			t.Errorf("typeNames = %q", q.Get("typeNames"))
+		}
+		if q.Get("typeName") != "topp:states" {
+			t.Errorf("typeName = %q (1.1.0 alias)", q.Get("typeName"))
+		}
+		_, _ = io.WriteString(w, minimalSchemaXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+
+	schema, err := c.WFS.DescribeFeatureType(context.Background(),
+		wfs.DescribeFeatureTypeOptions{TypeNames: []string{"topp:states"}})
+	if err != nil {
+		t.Fatalf("DescribeFeatureType: %v", err)
+	}
+	if got := len(schema.ComplexTypes); got != 1 {
+		t.Errorf("ComplexTypes: got %d, want 1", got)
+	}
+	attrs := schema.Attributes("statesType")
+	if got := len(attrs); got != 4 {
+		t.Errorf("Attributes: got %d, want 4", got)
+	}
+}
+
+func TestDescribeFeatureType_MultipleTypeNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("typeNames") != "topp:states,topp:counties" {
+			t.Errorf("typeNames = %q", r.URL.Query().Get("typeNames"))
+		}
+		_, _ = io.WriteString(w, minimalSchemaXML)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, _ = c.WFS.DescribeFeatureType(context.Background(),
+		wfs.DescribeFeatureTypeOptions{TypeNames: []string{"topp:states", "topp:counties"}})
+}
+
+func TestDescribeFeatureType_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such type", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, _ := geoserver.New(srv.URL, geoserver.WithBasicAuth("u", "p"))
+	_, err := c.WFS.DescribeFeatureType(context.Background(),
+		wfs.DescribeFeatureTypeOptions{TypeNames: []string{"topp:missing"}})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestClient_IsGlobal(t *testing.T) {
 	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
 	if !c.WFS.IsGlobal() {


### PR DESCRIPTION
## Summary

Rounds out the read-only OWS surface with the two natural follow-ons to GetCapabilities. Same shape on both: lean Go types + a sub-client method routed through \`transport.DoXML\` + a companion \`ParseX\` free function for out-of-band decoding.

### \`v2/ows/wfs.Client.DescribeFeatureType\`

- \`FeatureSchema\` models a useful subset of XSD: \`targetNamespace\`, imports, top-level elements, and complex types. The typical WFS shape walks \`complexType > complexContent > extension > sequence\`, so \`FeatureSchema.Attributes(typeName)\` flattens that into \`[]Attribute{Name, Type, Nillable, MinOccurs, MaxOccurs}\`.
- Cross-version query handling: send both \`typeNames\` (WFS 2.0) and \`typeName\` (WFS 1.1.0) aliases so the same call works against either version.
- \`wfs.ParseFeatureSchema(io.Reader)\` for fixtures.

### \`v2/ows/wcs.Client.DescribeCoverage\`

- \`CoverageDescriptions\` wraps \`[]CoverageDescription\`. Each carries \`CoverageID\`, \`BoundedBy/Envelope\` (srsName + corner strings), \`DomainSet/RectifiedGrid\` (limits + axis labels + origin + offset vectors), \`RangeType/DataRecord/Field\` (per-band name + UoM), and \`ServiceParameters\` (CoverageSubtype + nativeFormat).
- Honors the WCS uppercase-service quirk (\`service=WCS\`).
- Empty \`CoverageIDs\` is rejected at the client (WCS rejects it server-side anyway; fail fast).
- \`wcs.ParseCoverageDescriptions(io.Reader)\` for fixtures.

## Tests

- httptest unit tests for parse + happy-path query construction + multi-id requests + 404 sentinel + empty-id rejection (WCS).
- Integration tests against the compose stack — WFS DescribeFeatureType against \`sf:archsites\` (default-install feature type); WCS DescribeCoverage discovers a coverage via \`GetCapabilities\` first to avoid hard-coded IDs.
- Godoc \`Example_*\` for both.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 18 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [ ] CI: 7 required checks + CodeQL pass on this branch
- [ ] Real-server integration legs cover the new Describe operations on both 2.27.4 LTS and 2.28.0 stable

## Docs

\`v2/CHANGELOG.md\` \`[Unreleased]\` updated. Will graduate to \`v2.0.0-alpha.4\` (or roll up into beta.1) on the next tag.