### PR TITLE
chore(ci): wire Codecov for v1 + v2 with separate flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,52 @@
+# Codecov config — pairs with the upload steps in .github/workflows/ci.yml.
+# Two coverage flags are reported separately so v1 and v2 don't blur into
+# a single project number:
+#   - flag "v1": coverage of the root module (github.com/hishamkaram/geoserver)
+#   - flag "v2": coverage of the v2 submodule (github.com/hishamkaram/geoserver/v2)
+#
+# Codecov tokenless upload works for public repos via the GitHub Actions
+# integration; no CODECOV_TOKEN secret is required.
+
+coverage:
+  status:
+    project:
+      default:
+        # Don't fail PRs on coverage drops; the badge surfaces the trend
+        # without a hard gate. The maintainer can promote to a strict
+        # target later once a baseline is established.
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        # Same — informational only.
+        target: auto
+        threshold: 1%
+        informational: true
+
+# Per-flag definitions so v1 + v2 are tracked separately on the dashboard.
+flags:
+  v1:
+    paths:
+      - "!v2/"
+    carryforward: true
+  v2:
+    paths:
+      - "v2/"
+    carryforward: true
+
+# Ignore non-production code from the coverage calculation.
+ignore:
+  - "**/*_test.go"
+  - "**/example_test.go"
+  - "**/*_integration_test.go"
+  - "v2/examples/"
+  - "v2/internal/testenv/"
+  - "examples/"
+  - "scripts/"
+  - "testdata/"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
           name: coverage-go${{ matrix.go }}
           path: coverage.out
           retention-days: 14
+      - name: Upload coverage to Codecov (v1)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          flags: v1
+          name: v1-go${{ matrix.go }}
+          fail_ci_if_error: false
 
   unit-v2:
     name: Unit tests v2 (Go 1.25)
@@ -81,7 +88,22 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Unit tests
-        run: go test -race -short ./...
+        run: go test -race -short -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out | tail -n 1
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-v2-go1.25
+          path: v2/coverage.out
+          retention-days: 14
+      - name: Upload coverage to Codecov (v2)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./v2/coverage.out
+          flags: v2
+          name: v2-go1.25
+          fail_ci_if_error: false
 
   vuln:
     name: govulncheck

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Go client library for the [GeoServer](https://geoserver.org/) REST API. Manage
 [![CI](https://github.com/hishamkaram/geoserver/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/hishamkaram/geoserver/actions/workflows/ci.yml)
 [![Integration tests](https://github.com/hishamkaram/geoserver/actions/workflows/integration.yml/badge.svg?branch=master)](https://github.com/hishamkaram/geoserver/actions/workflows/integration.yml)
 [![CodeQL](https://github.com/hishamkaram/geoserver/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/hishamkaram/geoserver/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/hishamkaram/geoserver/branch/master/graph/badge.svg?flag=v1)](https://codecov.io/gh/hishamkaram/geoserver)
+[![codecov v2](https://codecov.io/gh/hishamkaram/geoserver/branch/master/graph/badge.svg?flag=v2)](https://codecov.io/gh/hishamkaram/geoserver)
 [![License: MIT](https://img.shields.io/github/license/hishamkaram/geoserver.svg)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/hishamkaram/geoserver?include_prereleases&sort=semver)](https://github.com/hishamkaram/geoserver/releases)
 


### PR DESCRIPTION
## Summary

Workstream A.9 from the original revival plan, originally deferred. Coverage profiles already upload as CI artifacts; this just adds an upload-to-Codecov step on top, plus a \`.codecov.yml\` config and the README badge row.

### Wiring

- \`unit\` job (v1) — already produces \`coverage.out\`. Add a \`codecov-action@v5\` step pointing at it with \`flag=v1\`.
- \`unit-v2\` job (v2) — was running plain \`go test -race -short\`. Add \`-coverprofile=coverage.out -covermode=atomic\`, the coverage summary, the artifact upload, and a \`codecov-action@v5\` step with \`flag=v2\`.

### \`.codecov.yml\`

- Two flags (\`v1\`, \`v2\`) so the dashboard tracks them separately rather than blurring the v1 stable line into the v2 alpha surface.
- Project + patch coverage targets are **informational only** — the badge and PR comments surface the trend without a hard merge gate. Promote to strict once a baseline settles.
- Path filters route \`v2/**\` to the v2 flag, everything else to v1.
- Standard ignores: tests, examples, scripts, testdata, internal testenv.
- \`carryforward: true\` so a flag without uploads on a given PR keeps its previous baseline rather than going to zero.

Tokenless upload works for public repos via the GitHub Actions integration; **no CODECOV_TOKEN secret is required**.

### README

Two new badges in the existing badge row — \`codecov\` (v1 flag) and \`codecov v2\` (v2 flag).

## Test plan

- [x] Both \`ci.yml\` and \`.codecov.yml\` parse as valid YAML
- [ ] CI: 7 required checks + CodeQL pass
- [ ] Codecov uploads land for both flags on this PR's CI run; PR comment + dashboard show v1 / v2 numbers separately
- [ ] After merge, README badges resolve (will show "unknown" briefly until codecov.io processes the master upload)