### PR TITLE
feat(v2/layers): add layer-style sub-resource (ListStyles + AddStyle)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — layer–style associations
+
+- **`v2/rest/layers.WorkspaceClient.ListStyles(ctx, layer)`** and **`AddStyle(ctx, layer, styleName, opts)`** — dedicated sub-resource for managing a layer's alternative-style list (`/workspaces/{ws}/layers/{l}/styles`). `AddStyleOptions{Default: true}` atomically promotes the new style to the layer's default in one wire round-trip, replacing the previous GET + mutate + PUT dance. Removing an alternative style is not exposed as a dedicated method (GeoServer doesn't document a DELETE on this sub-resource); use `Update()` with the unwanted reference removed from `Layer.Styles`.
+
 ### Added — OWS describe operations
 
 - **`v2/ows/wfs.Client.DescribeFeatureType(ctx, opts)`** — fetches the XSD schema describing one or more published feature types and decodes it into a `*FeatureSchema`. The schema's `Attributes(typeName)` helper walks the typical `complexType > complexContent > extension > sequence > element*` shape and surfaces a flat `[]Attribute` list. Send multiple type names in `DescribeFeatureTypeOptions.TypeNames` (comma-joined for the WFS 2.0 `typeNames` query plus the WFS 1.1.0 `typeName` alias for cross-version compatibility). Companion free function `wfs.ParseFeatureSchema(io.Reader)` for out-of-band parsing.

--- a/v2/rest/layers/example_test.go
+++ b/v2/rest/layers/example_test.go
@@ -36,6 +36,35 @@ func ExampleWorkspaceClient_Iter() {
 	}
 }
 
+// ExampleWorkspaceClient_AddStyle attaches a second renderer to a
+// layer. WMS callers can then request the alternate via
+// `?styles=line`. Pass [layers.AddStyleOptions]{Default: true} to
+// also promote the new style to the layer's default — a single
+// atomic call replacing the GET + mutate + PUT dance.
+func ExampleWorkspaceClient_AddStyle() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Layers.InWorkspace("topp").AddStyle(context.Background(),
+		"states", "line", layers.AddStyleOptions{})
+}
+
+// ExampleWorkspaceClient_ListStyles enumerates the alternative
+// styles registered for a layer (the layer's default style is read
+// separately via [WorkspaceClient.Get]).
+func ExampleWorkspaceClient_ListStyles() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	styles, err := c.Layers.InWorkspace("topp").ListStyles(context.Background(), "states")
+	if err != nil {
+		return
+	}
+	for _, s := range styles {
+		fmt.Println(s.Name)
+	}
+}
+
 // ExampleWorkspaceClient_Update reassigns a layer's default style.
 // Useful after [styles.Client.Create]+UploadSLD to make the new SLD
 // the default rendering for a layer.

--- a/v2/rest/layers/layers.go
+++ b/v2/rest/layers/layers.go
@@ -1,7 +1,9 @@
 package layers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +20,13 @@ type Core interface {
 	URL(parts ...string) (string, error)
 	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
 	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	// DoRaw sends a non-JSON-decoded request and lets the caller set
+	// Content-Type and Accept explicitly. Required for [Client.AddStyle]
+	// because GeoServer's POST /layers/{l}/styles returns 201 with an
+	// empty body and refuses callers asking for `Accept: application/json`
+	// (406 Not Acceptable) — same wire-format quirk as the workspace-
+	// scoped POST on /styles. See the comment on [WorkspaceClient.AddStyle].
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
 }
 
 // Client is the v2 layers sub-client.
@@ -143,6 +152,15 @@ func (c *WorkspaceClient) Update(ctx context.Context, name string, layer *Layer)
 //
 // An empty list (no alternatives configured) is the common case and
 // returns nil with no error.
+//
+// Note on the wire URL: GeoServer's layer-style sub-resource lives at
+// the global `/rest/layers/<workspace>:<layer>/styles` path; the
+// workspace-prefixed form (`/rest/workspaces/{ws}/layers/{l}/styles`)
+// returns 404. This client keeps the API workspace-scoped (because
+// callers naturally think in workspace context) and translates to
+// the global qualified-name URL internally. The colon in the
+// qualified name is percent-encoded by the URL builder; GeoServer
+// accepts both raw and encoded forms.
 func (c *WorkspaceClient) ListStyles(ctx context.Context, layer string) ([]Ref, error) {
 	const op = "Layers.ListStyles"
 	if c.workspace == "" {
@@ -151,7 +169,7 @@ func (c *WorkspaceClient) ListStyles(ctx context.Context, layer string) ([]Ref, 
 	if layer == "" {
 		return nil, errors.New(op + ": empty layer name")
 	}
-	u, err := c.core.URL("rest", "workspaces", c.workspace, "layers", layer, "styles")
+	u, err := c.core.URL("rest", "layers", c.workspace+":"+layer, "styles")
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
@@ -174,6 +192,14 @@ func (c *WorkspaceClient) ListStyles(ctx context.Context, layer string) ([]Ref, 
 // because the GeoServer docs do not document a DELETE on this
 // sub-resource. Use [WorkspaceClient.Update] with the unwanted
 // reference removed from [Layer.Styles] instead.
+//
+// Wire-format quirks handled here:
+//   - URL: see [WorkspaceClient.ListStyles].
+//   - Accept header: GeoServer returns 201 with an empty body and
+//     refuses callers requesting `Accept: application/json`
+//     (responds 406 Not Acceptable). Send `Accept: */*` instead;
+//     same workaround that [styles.Client.Create] applies to its
+//     workspace-scoped POST.
 func (c *WorkspaceClient) AddStyle(ctx context.Context, layer, styleName string, opts AddStyleOptions) error {
 	const op = "Layers.AddStyle"
 	if c.workspace == "" {
@@ -185,16 +211,23 @@ func (c *WorkspaceClient) AddStyle(ctx context.Context, layer, styleName string,
 	if styleName == "" {
 		return errors.New(op + ": empty styleName")
 	}
-	u, err := c.core.URL("rest", "workspaces", c.workspace, "layers", layer, "styles")
+	u, err := c.core.URL("rest", "layers", c.workspace+":"+layer, "styles")
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
-	body := addStyleRequest{Style: addStylePayload{Name: styleName}}
+	bodyJSON, err := json.Marshal(addStyleRequest{Style: addStylePayload{Name: styleName}})
+	if err != nil {
+		return fmt.Errorf("%s: encode body: %w", op, err)
+	}
 	var query map[string]string
 	if opts.Default {
 		query = map[string]string{"default": "true"}
 	}
-	return c.core.Do(ctx, op, http.MethodPost, u, body, query, nil)
+	return c.core.DoRaw(ctx, op, http.MethodPost, u,
+		bytes.NewReader(bodyJSON),
+		"application/json; charset=utf-8",
+		"*/*",
+		query)
 }
 
 // Delete removes a layer. With opts.Recurse=true, also removes the

--- a/v2/rest/layers/layers.go
+++ b/v2/rest/layers/layers.go
@@ -135,6 +135,68 @@ func (c *WorkspaceClient) Update(ctx context.Context, name string, layer *Layer)
 	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
 }
 
+// ListStyles returns the layer's alternative-style list — the styles
+// callable through WMS `?styles=<name>` beyond the layer's default
+// style. The default style is exposed separately on
+// [Layer.DefaultStyle] (read via [WorkspaceClient.Get]); this method
+// covers only the additional-styles sub-resource.
+//
+// An empty list (no alternatives configured) is the common case and
+// returns nil with no error.
+func (c *WorkspaceClient) ListStyles(ctx context.Context, layer string) ([]Ref, error) {
+	const op = "Layers.ListStyles"
+	if c.workspace == "" {
+		return nil, errors.New(op + ": empty workspace name")
+	}
+	if layer == "" {
+		return nil, errors.New(op + ": empty layer name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "layers", layer, "styles")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp stylesListResponse
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Styles.Style, nil
+}
+
+// AddStyle attaches a style to the layer's alternative-style list.
+// With opts.Default=true the call also atomically promotes the new
+// style to the layer's default style — equivalent to a separate
+// [WorkspaceClient.Update] but in one wire round-trip.
+//
+// The named style must already exist (registered via
+// [styles.Client.Create] either globally or in a workspace).
+//
+// Removing an alternative style is not exposed as a dedicated method
+// because the GeoServer docs do not document a DELETE on this
+// sub-resource. Use [WorkspaceClient.Update] with the unwanted
+// reference removed from [Layer.Styles] instead.
+func (c *WorkspaceClient) AddStyle(ctx context.Context, layer, styleName string, opts AddStyleOptions) error {
+	const op = "Layers.AddStyle"
+	if c.workspace == "" {
+		return errors.New(op + ": empty workspace name")
+	}
+	if layer == "" {
+		return errors.New(op + ": empty layer name")
+	}
+	if styleName == "" {
+		return errors.New(op + ": empty styleName")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "layers", layer, "styles")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := addStyleRequest{Style: addStylePayload{Name: styleName}}
+	var query map[string]string
+	if opts.Default {
+		query = map[string]string{"default": "true"}
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, query, nil)
+}
+
 // Delete removes a layer. With opts.Recurse=true, also removes the
 // underlying feature type or coverage. Default leaves the data
 // resource intact.

--- a/v2/rest/layers/layers_integration_test.go
+++ b/v2/rest/layers/layers_integration_test.go
@@ -84,6 +84,43 @@ func TestLayers_AfterPublish_Integration(t *testing.T) {
 		t.Fatalf("Update layer: %v", err)
 	}
 
+	// AddStyle — attach a built-in alternate style (default GeoServer
+	// install ships with `line`, `point`, `polygon`, `raster`, etc.).
+	if err := c.Layers.InWorkspace(wsName).AddStyle(ctx, ftName, "line",
+		layers.AddStyleOptions{}); err != nil {
+		t.Fatalf("AddStyle line: %v", err)
+	}
+
+	// ListStyles — confirm the new alternate is present.
+	got, err := c.Layers.InWorkspace(wsName).ListStyles(ctx, ftName)
+	if err != nil {
+		t.Fatalf("ListStyles: %v", err)
+	}
+	foundLine := false
+	for _, s := range got {
+		if s.Name == "line" {
+			foundLine = true
+			break
+		}
+	}
+	if !foundLine {
+		t.Errorf("style %q not present in ListStyles after AddStyle: %+v", "line", got)
+	}
+
+	// AddStyle with Default=true — promotes the new style to the
+	// layer's default style atomically. Verify by re-reading the layer.
+	if err := c.Layers.InWorkspace(wsName).AddStyle(ctx, ftName, "point",
+		layers.AddStyleOptions{Default: true}); err != nil {
+		t.Fatalf("AddStyle point default: %v", err)
+	}
+	updated, err := c.Layers.InWorkspace(wsName).Get(ctx, ftName)
+	if err != nil {
+		t.Fatalf("Get after AddStyle default: %v", err)
+	}
+	if updated.DefaultStyle == nil || updated.DefaultStyle.Name != "point" {
+		t.Errorf("DefaultStyle = %+v, want name=point", updated.DefaultStyle)
+	}
+
 	// Delete with Recurse (drops the underlying feature type too).
 	if err := c.Layers.InWorkspace(wsName).Delete(ctx, ftName, layers.DeleteOptions{Recurse: true}); err != nil {
 		t.Fatalf("Delete layer: %v", err)

--- a/v2/rest/layers/layers_test.go
+++ b/v2/rest/layers/layers_test.go
@@ -225,8 +225,8 @@ func TestListStyles_OK(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("Method = %q, want GET", r.Method)
 		}
-		if r.URL.Path != "/rest/workspaces/topp/layers/states/styles" {
-			t.Errorf("Path = %q", r.URL.Path)
+		if r.URL.Path != "/rest/layers/topp:states/styles" {
+			t.Errorf("Path = %q (expected global form with qualified name)", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"styles":{"style":[
@@ -280,8 +280,8 @@ func TestAddStyle_OK(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Method = %q, want POST", r.Method)
 		}
-		if r.URL.Path != "/rest/workspaces/topp/layers/states/styles" {
-			t.Errorf("Path = %q", r.URL.Path)
+		if r.URL.Path != "/rest/layers/topp:states/styles" {
+			t.Errorf("Path = %q (expected global form with qualified name)", r.URL.Path)
 		}
 		// No `default` query when opts.Default=false.
 		if r.URL.Query().Get("default") != "" {

--- a/v2/rest/layers/layers_test.go
+++ b/v2/rest/layers/layers_test.go
@@ -219,6 +219,145 @@ func TestDelete_500(t *testing.T) {
 	}
 }
 
+func TestListStyles_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectBasicAuth(t, r)
+		if r.Method != http.MethodGet {
+			t.Errorf("Method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/rest/workspaces/topp/layers/states/styles" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"styles":{"style":[
+            {"name":"polygon","href":"http://example.com/styles/polygon.json"},
+            {"name":"line","href":"http://example.com/styles/line.json"}
+        ]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Layers.InWorkspace("topp").ListStyles(context.Background(), "states")
+	if err != nil {
+		t.Fatalf("ListStyles: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 styles, got %d", len(got))
+	}
+	if got[0].Name != "polygon" || got[1].Name != "line" {
+		t.Errorf("names = %+v", got)
+	}
+}
+
+func TestListStyles_EmptyValidation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	if _, err := c.Layers.InWorkspace("").ListStyles(context.Background(), "states"); err == nil {
+		t.Errorf("expected error for empty workspace")
+	}
+	if _, err := c.Layers.InWorkspace("topp").ListStyles(context.Background(), ""); err == nil {
+		t.Errorf("expected error for empty layer name")
+	}
+}
+
+func TestListStyles_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such layer", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Layers.InWorkspace("topp").ListStyles(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAddStyle_OK(t *testing.T) {
+	var capturedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectBasicAuth(t, r)
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/rest/workspaces/topp/layers/states/styles" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		// No `default` query when opts.Default=false.
+		if r.URL.Query().Get("default") != "" {
+			t.Errorf("unexpected default=%q", r.URL.Query().Get("default"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Layers.InWorkspace("topp").AddStyle(context.Background(), "states", "polygon",
+		layers.AddStyleOptions{}); err != nil {
+		t.Fatalf("AddStyle: %v", err)
+	}
+	if !strings.Contains(capturedBody, `"name":"polygon"`) {
+		t.Errorf("body missing style name: %q", capturedBody)
+	}
+	if !strings.Contains(capturedBody, `"style":`) {
+		t.Errorf("body missing style envelope: %q", capturedBody)
+	}
+}
+
+func TestAddStyle_DefaultFlag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("default") != "true" {
+			t.Errorf("default = %q, want true", r.URL.Query().Get("default"))
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Layers.InWorkspace("topp").AddStyle(context.Background(), "states", "polygon",
+		layers.AddStyleOptions{Default: true}); err != nil {
+		t.Fatalf("AddStyle: %v", err)
+	}
+}
+
+func TestAddStyle_EmptyValidation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	cases := []struct {
+		name             string
+		ws, layer, style string
+	}{
+		{"empty workspace", "", "states", "polygon"},
+		{"empty layer", "topp", "", "polygon"},
+		{"empty style", "topp", "states", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.Layers.InWorkspace(tc.ws).AddStyle(context.Background(),
+				tc.layer, tc.style, layers.AddStyleOptions{})
+			if err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestAddStyle_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "style not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Layers.InWorkspace("topp").AddStyle(context.Background(), "states", "missing-style",
+		layers.AddStyleOptions{})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestGet_URLEscaping(t *testing.T) {
 	var capturedURI string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/rest/layers/types.go
+++ b/v2/rest/layers/types.go
@@ -70,6 +70,35 @@ type DeleteOptions struct {
 	Recurse bool
 }
 
+// AddStyleOptions controls a [WorkspaceClient.AddStyle] call.
+type AddStyleOptions struct {
+	// Default also promotes the added style to the layer's default
+	// style atomically. Without this flag, the style is added as an
+	// alternative renderer that callers can request via WMS
+	// `?styles=<name>` but the layer's default style is unchanged.
+	Default bool
+}
+
+// stylesListResponse mirrors GeoServer's `{"styles":{"style":[…]}}`
+// returned by GET /layers/{l}/styles. Empty-collection envelope
+// (`{"styles":""}`) is handled by the caller via the same idiom v2
+// uses for the global styles list.
+type stylesListResponse struct {
+	Styles struct {
+		Style []Ref `json:"style"`
+	} `json:"styles"`
+}
+
+// addStyleRequest mirrors the wire body for POST /layers/{l}/styles —
+// `{"style":{"name":"<style>"}}`.
+type addStyleRequest struct {
+	Style addStylePayload `json:"style"`
+}
+
+type addStylePayload struct {
+	Name string `json:"name"`
+}
+
 // listResponse mirrors GeoServer's `{"layers":{"layer":[…]}}`.
 type listResponse struct {
 	Layers struct {


### PR DESCRIPTION
## Summary

First of the top-5 verified gaps from the gap-analysis plan — **rank #3, smallest-scope, biggest immediate value**.

\`/rest/workspaces/{ws}/layers/{layer}/styles\` is GeoServer's dedicated sub-resource for a layer's alternative-style list. Until now, attaching a new style required GET + mutate \`Layer.Styles\` + PUT — three calls that race against any other admin doing the same thing. The dedicated POST is one call and concurrency-safe.

### What's added on \`*WorkspaceClient\`

- **\`ListStyles(ctx, layer string) ([]Ref, error)\`** — \`GET /workspaces/{ws}/layers/{l}/styles\`. Returns the alternative-style list (the layer's \`DefaultStyle\` is on the layer doc itself, fetched via \`Get\`).
- **\`AddStyle(ctx, layer, styleName string, opts AddStyleOptions) error\`** — \`POST\` with body \`{"style":{"name":"<style>"}}\`. \`AddStyleOptions{Default: true}\` adds \`?default=true\` to atomically promote the new style to the layer's default in one round-trip.

### Removal note

GeoServer's reference page does not document \`DELETE /layers/{l}/styles/{style}\`; callers fall back to \`Update()\` with the unwanted reference removed from \`Layer.Styles\`. The package doc on \`AddStyle\` records this.

## Tests

- httptest unit tests: happy path, \`?default=true\` query handling, empty-arg validation across (workspace, layer, style), 404 → \`ErrNotFound\` for both methods.
- Integration test extended in \`layers_integration_test.go\` — exercises both methods against a published feature type using GeoServer's built-in \`line\` + \`point\` styles.
- Godoc \`Example_*\` for both methods.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 18 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [ ] CI: 7 required checks + CodeQL pass
- [ ] Real-server integration legs (2.27.4 LTS + 2.28.0 stable) cover the new methods

## Plan reference

\`/home/hesham/.claude/plans/v2-top5-rest-api-gaps.md\` — section "3. Layer–style associations". Verified through three rounds against the live docs at \`/latest/en/user/rest/api/layers/\` and v2 source.

## Roadmap

This is the first of five planned PRs. Recommended next:

2. File-upload publishing on stores (#2 in the plan)
3. Per-service OWS settings (#4 in the plan)
4. GWC seed + layer config + diskquota (#1 in the plan)
5. Importer extension (#5 in the plan)