### PR TITLE
feat(v2): add file-upload publishing on stores (UploadFile + HarvestGranule)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — file-upload publishing on stores
+
+- **`v2/rest/datastores.WorkspaceClient.UploadFile(ctx, name, body, opts)`** — `PUT /workspaces/{ws}/datastores/{name}/{file|url|external}[.<ext>]`. Publishes a file-backed datastore by uploading the file contents (`UploadMethodFile`, default), pointing at a remote URL the server fetches (`UploadMethodURL`), or referencing a server-local path with no transfer (`UploadMethodExternal`). Documented `Extension` values: `shp`, `properties`, `appschema`. Default `Content-Type` is `application/zip` for file uploads, `text/plain` for URL/external; override via `UploadOptions.ContentType`.
+- **`v2/rest/coveragestores.WorkspaceClient.UploadFile(ctx, name, body, opts)`** — same shape for raster stores. Documented `Extension` values: `geotiff`, `worldimage`, `imagemosaic`. Override `ContentType` to `image/tiff` for a single GeoTIFF.
+- **`v2/rest/coveragestores.WorkspaceClient.HarvestGranule(ctx, name, body, opts)`** — `POST` to the same endpoint. Appends a new granule to an existing image-mosaic store without reconfiguring the whole store. Use `UploadMethodExternal` with a server-local path to avoid transferring large rasters across HTTP.
+- Both packages add `DoRaw` to their `Core` interface and route uploads through `transport.DoRaw` with `Accept: */*` (matches the workspace-scoped POST quirk handled by `styles.Client.Create` and the new `layers.AddStyle`).
+
 ### Added — layer–style associations
 
 - **`v2/rest/layers.WorkspaceClient.ListStyles(ctx, layer)`** and **`AddStyle(ctx, layer, styleName, opts)`** — dedicated sub-resource for managing a layer's alternative-style list (`/workspaces/{ws}/layers/{l}/styles`). `AddStyleOptions{Default: true}` atomically promotes the new style to the layer's default in one wire round-trip, replacing the previous GET + mutate + PUT dance. Removing an alternative style is not exposed as a dedicated method (GeoServer doesn't document a DELETE on this sub-resource); use `Update()` with the unwanted reference removed from `Layer.Styles`.

--- a/v2/rest/coveragestores/coveragestores.go
+++ b/v2/rest/coveragestores/coveragestores.go
@@ -18,6 +18,12 @@ type Core interface {
 	URL(parts ...string) (string, error)
 	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
 	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	// DoRaw sends a non-JSON-encoded request body and lets the caller set
+	// Content-Type and Accept explicitly. Used by [WorkspaceClient.UploadFile]
+	// and [WorkspaceClient.HarvestGranule] to PUT/POST raster bytes
+	// (GeoTIFF, image-mosaic zip, granule blob) to the `/file`, `/url`,
+	// or `/external` sub-resources.
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
 }
 
 // Client is the v2 coverage-stores sub-client. Workspace-scoped — every
@@ -154,6 +160,99 @@ func (c *WorkspaceClient) Update(ctx context.Context, name string, patch *Patch)
 		CoverageStore Patch `json:"coverageStore"`
 	}{CoverageStore: *patch}
 	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// UploadFile publishes a file-backed coverage store by uploading the
+// raster contents (or pointing at a remote URL or a server-local path).
+//
+// The endpoint shape is `PUT /workspaces/{ws}/coveragestores/{name}/{method}[.{ext}]`
+// where method is one of `file`, `url`, `external`:
+//
+//   - [UploadMethodFile] (default): body is the raster bytes (a single
+//     GeoTIFF, or a zip containing a mosaic + index files). Default
+//     Content-Type `application/zip`.
+//   - [UploadMethodURL]: body is a URL string the server fetches.
+//     Default Content-Type `text/plain`.
+//   - [UploadMethodExternal]: body is a server-local filesystem path
+//     string. No file transfer happens. Default Content-Type `text/plain`.
+//
+// Documented `opts.Extension` values for coverage stores: `geotiff`,
+// `worldimage`, `imagemosaic`. Other values are accepted by GeoServer
+// at the wire level but not officially supported.
+//
+// If `opts.Update` is non-empty, it's sent as the `update` query parameter.
+//
+// To add a new granule to an existing image mosaic without
+// reconfiguring the whole store, use [WorkspaceClient.HarvestGranule].
+func (c *WorkspaceClient) UploadFile(ctx context.Context, name string, body io.Reader, opts UploadOptions) error {
+	return c.putFile(ctx, "CoverageStores.UploadFile", http.MethodPut, name, body, opts)
+}
+
+// HarvestGranule appends a new granule to an existing structured
+// (image-mosaic) coverage store without reconfiguring the store.
+//
+// The endpoint shape is `POST /workspaces/{ws}/coveragestores/{name}/{method}[.{ext}]`
+// — same URL as [WorkspaceClient.UploadFile] but `POST` instead of
+// `PUT`. The body is the granule's raster bytes (typically a single
+// GeoTIFF whose extent fits inside the mosaic's coverage envelope).
+//
+// Use `opts.Method = UploadMethodExternal` and pass a server-local
+// path in the body if the granule is already on the server's
+// filesystem (avoids transferring large rasters across HTTP).
+func (c *WorkspaceClient) HarvestGranule(ctx context.Context, name string, body io.Reader, opts UploadOptions) error {
+	return c.putFile(ctx, "CoverageStores.HarvestGranule", http.MethodPost, name, body, opts)
+}
+
+// putFile is the shared HTTP plumbing for [WorkspaceClient.UploadFile]
+// (PUT, replaces store) and [WorkspaceClient.HarvestGranule] (POST,
+// appends granule).
+func (c *WorkspaceClient) putFile(ctx context.Context, op, httpMethod, name string, body io.Reader, opts UploadOptions) error {
+	if c.workspace == "" {
+		return errors.New(op + ": empty workspace name")
+	}
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if body == nil {
+		return errors.New(op + ": nil body")
+	}
+
+	method := opts.Method
+	if method == "" {
+		method = UploadMethodFile
+	}
+	switch method {
+	case UploadMethodFile, UploadMethodURL, UploadMethodExternal:
+	default:
+		return fmt.Errorf("%s: invalid Method %q (want file / url / external)", op, method)
+	}
+
+	segment := string(method)
+	if opts.Extension != "" {
+		segment = segment + "." + opts.Extension
+	}
+
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "coveragestores", name, segment)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	contentType := opts.ContentType
+	if contentType == "" {
+		switch method {
+		case UploadMethodURL, UploadMethodExternal:
+			contentType = "text/plain"
+		default:
+			contentType = "application/zip"
+		}
+	}
+
+	var query map[string]string
+	if opts.Update != "" {
+		query = map[string]string{"update": opts.Update}
+	}
+
+	return c.core.DoRaw(ctx, op, httpMethod, u, body, contentType, "*/*", query)
 }
 
 // Delete removes a coverage store. With opts.Recurse=true, also removes

--- a/v2/rest/coveragestores/coveragestores_test.go
+++ b/v2/rest/coveragestores/coveragestores_test.go
@@ -286,3 +286,121 @@ func TestGet_URLEscaping(t *testing.T) {
 		t.Fatalf("URL is double-encoded: %q", capturedURI)
 	}
 }
+
+func TestUploadFile_GeoTIFF(t *testing.T) {
+	var captured struct {
+		Method, Path, ContentType, Accept string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		captured.Accept = r.Header.Get("Accept")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.CoverageStores.InWorkspace("nurc").UploadFile(context.Background(), "world_dem",
+		strings.NewReader("FAKETIFF"),
+		coveragestores.UploadOptions{Extension: "geotiff", ContentType: "image/tiff"}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if captured.Method != http.MethodPut {
+		t.Errorf("Method = %q, want PUT", captured.Method)
+	}
+	if captured.Path != "/rest/workspaces/nurc/coveragestores/world_dem/file.geotiff" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+	if captured.ContentType != "image/tiff" {
+		t.Errorf("Content-Type = %q, want image/tiff", captured.ContentType)
+	}
+	if captured.Accept != "*/*" {
+		t.Errorf("Accept = %q, want */*", captured.Accept)
+	}
+}
+
+func TestUploadFile_ImageMosaic(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.CoverageStores.InWorkspace("nurc").UploadFile(context.Background(), "mosaic",
+		strings.NewReader("FAKEZIP"),
+		coveragestores.UploadOptions{Extension: "imagemosaic"}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if capturedPath != "/rest/workspaces/nurc/coveragestores/mosaic/file.imagemosaic" {
+		t.Errorf("Path = %q", capturedPath)
+	}
+}
+
+func TestHarvestGranule_OK(t *testing.T) {
+	var captured struct{ Method, Path, ContentType string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	// External method: pass a server-local path string as the body.
+	if err := c.CoverageStores.InWorkspace("nurc").HarvestGranule(context.Background(), "mosaic",
+		strings.NewReader("/srv/geoserver/granules/2026_05_03.tif"),
+		coveragestores.UploadOptions{Method: coveragestores.UploadMethodExternal, Extension: "imagemosaic"}); err != nil {
+		t.Fatalf("HarvestGranule: %v", err)
+	}
+	if captured.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", captured.Method)
+	}
+	if captured.Path != "/rest/workspaces/nurc/coveragestores/mosaic/external.imagemosaic" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+	if captured.ContentType != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain", captured.ContentType)
+	}
+}
+
+func TestUploadFile_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	cases := []struct {
+		name string
+		ws   string
+		cs   string
+		body io.Reader
+	}{
+		{"empty workspace", "", "world_dem", strings.NewReader("")},
+		{"empty name", "nurc", "", strings.NewReader("")},
+		{"nil body", "nurc", "world_dem", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.CoverageStores.InWorkspace(tc.ws).UploadFile(context.Background(), tc.cs, tc.body,
+				coveragestores.UploadOptions{Extension: "geotiff"})
+			if err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestUploadFile_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no workspace", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.CoverageStores.InWorkspace("missing").UploadFile(context.Background(), "world_dem",
+		strings.NewReader(""), coveragestores.UploadOptions{Extension: "geotiff"})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/v2/rest/coveragestores/example_test.go
+++ b/v2/rest/coveragestores/example_test.go
@@ -2,6 +2,8 @@ package coveragestores_test
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
 	"github.com/hishamkaram/geoserver/v2/rest/coveragestores"
@@ -31,6 +33,42 @@ func ExampleWorkspaceClient_Create() {
 			URL:     "file:data/coverages/world_dem.tif",
 			Type:    "GeoTIFF",
 			Enabled: true,
+		})
+}
+
+// ExampleWorkspaceClient_UploadFile publishes a GeoTIFF by
+// uploading the raster bytes — the modern alternative to copying
+// the file into the data directory by hand and calling Reload.
+func ExampleWorkspaceClient_UploadFile() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	f, err := os.Open("world_dem.tif")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_ = c.CoverageStores.InWorkspace("nurc").UploadFile(context.Background(),
+		"world_dem", f, coveragestores.UploadOptions{
+			Extension:   "geotiff",
+			ContentType: "image/tiff",
+		})
+}
+
+// ExampleWorkspaceClient_HarvestGranule appends a new granule to an
+// existing image-mosaic store. Use UploadMethodExternal with a
+// server-local path to avoid transferring large rasters across HTTP.
+func ExampleWorkspaceClient_HarvestGranule() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.CoverageStores.InWorkspace("nurc").HarvestGranule(context.Background(),
+		"world_mosaic",
+		strings.NewReader("/srv/geoserver/granules/2026_05_03.tif"),
+		coveragestores.UploadOptions{
+			Method:    coveragestores.UploadMethodExternal,
+			Extension: "imagemosaic",
 		})
 }
 

--- a/v2/rest/coveragestores/types.go
+++ b/v2/rest/coveragestores/types.go
@@ -51,6 +51,50 @@ type DeleteOptions struct {
 	Recurse bool
 }
 
+// UploadMethod selects the file-upload sub-resource on
+// [WorkspaceClient.UploadFile] / [WorkspaceClient.HarvestGranule].
+type UploadMethod string
+
+// Upload methods. The default ([UploadMethodFile]) ships the file
+// body across the wire; the other two reference data already
+// reachable from the server.
+const (
+	// UploadMethodFile uploads the raster bytes in the request body.
+	// Routes to `PUT /file[.<ext>]`. Default.
+	UploadMethodFile UploadMethod = "file"
+	// UploadMethodURL provides a URL string the server fetches.
+	// Routes to `PUT /url[.<ext>]`.
+	UploadMethodURL UploadMethod = "url"
+	// UploadMethodExternal provides a server-local filesystem path
+	// string. No file transfer happens. Routes to `PUT /external[.<ext>]`.
+	UploadMethodExternal UploadMethod = "external"
+)
+
+// UploadOptions controls a [WorkspaceClient.UploadFile] or
+// [WorkspaceClient.HarvestGranule] call.
+type UploadOptions struct {
+	// Extension selects the URL suffix (e.g., "geotiff",
+	// "worldimage", "imagemosaic"). May be empty if GeoServer can
+	// infer from the body, but the documented forms always include
+	// an extension.
+	Extension string
+
+	// Method selects the sub-resource. Default [UploadMethodFile].
+	Method UploadMethod
+
+	// ContentType overrides the Content-Type header. Defaults are:
+	//   - file:     application/zip
+	//   - url:      text/plain
+	//   - external: text/plain
+	// Override when uploading a non-zipped binary (e.g.,
+	// `image/tiff` for a single GeoTIFF granule).
+	ContentType string
+
+	// Update sets the optional `update` query parameter (typically
+	// `overwrite` or `append`). Empty means use the server default.
+	Update string
+}
+
 // listResponse mirrors GeoServer's `{"coverageStores":{"coverageStore":[…]}}`.
 type listResponse struct {
 	CoverageStores struct {

--- a/v2/rest/datastores/datastores.go
+++ b/v2/rest/datastores/datastores.go
@@ -19,6 +19,11 @@ type Core interface {
 	URL(parts ...string) (string, error)
 	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
 	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	// DoRaw sends a non-JSON-encoded request body and lets the caller set
+	// Content-Type and Accept explicitly. Used by [WorkspaceClient.UploadFile]
+	// to PUT a Shapefile zip (binary), a URL string, or a server-local path
+	// to GeoServer's `/file`, `/url`, `/external` sub-resources.
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
 }
 
 // Client is the v2 datastores sub-client. It is a thin entry point —
@@ -199,6 +204,77 @@ func (c *WorkspaceClient) Update(ctx context.Context, name string, patch *Patch)
 		DataStore Patch `json:"dataStore"`
 	}{DataStore: *patch}
 	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// UploadFile publishes a file-backed datastore by uploading the file
+// contents (or pointing at a remote URL or a server-local path).
+//
+// The endpoint shape is `PUT /workspaces/{ws}/datastores/{name}/{method}[.{ext}]`
+// where method is one of `file`, `url`, `external`:
+//
+//   - [UploadMethodFile] (default): body is the file's binary contents
+//     (typically a zipped Shapefile + sidecars). Default Content-Type
+//     `application/zip`.
+//   - [UploadMethodURL]: body is a URL string the server fetches.
+//     Default Content-Type `text/plain`.
+//   - [UploadMethodExternal]: body is a server-local filesystem path
+//     string. No file transfer happens. Default Content-Type `text/plain`.
+//
+// Documented `opts.Extension` values for datastores: `shp`, `properties`,
+// `appschema`. Other values are accepted by GeoServer at the wire level
+// but not officially supported.
+//
+// If `opts.Update` is non-empty, it's sent as the `update` query parameter
+// (typically `overwrite` to replace, or `append` for store types that
+// support adding to existing data).
+func (c *WorkspaceClient) UploadFile(ctx context.Context, name string, body io.Reader, opts UploadOptions) error {
+	const op = "Datastores.UploadFile"
+	if c.workspace == "" {
+		return errors.New(op + ": empty workspace name")
+	}
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if body == nil {
+		return errors.New(op + ": nil body")
+	}
+
+	method := opts.Method
+	if method == "" {
+		method = UploadMethodFile
+	}
+	switch method {
+	case UploadMethodFile, UploadMethodURL, UploadMethodExternal:
+	default:
+		return fmt.Errorf("%s: invalid Method %q (want file / url / external)", op, method)
+	}
+
+	segment := string(method)
+	if opts.Extension != "" {
+		segment = segment + "." + opts.Extension
+	}
+
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "datastores", name, segment)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	contentType := opts.ContentType
+	if contentType == "" {
+		switch method {
+		case UploadMethodURL, UploadMethodExternal:
+			contentType = "text/plain"
+		default:
+			contentType = "application/zip"
+		}
+	}
+
+	var query map[string]string
+	if opts.Update != "" {
+		query = map[string]string{"update": opts.Update}
+	}
+
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, body, contentType, "*/*", query)
 }
 
 // Delete removes a datastore. With opts.Recurse=true, also removes all

--- a/v2/rest/datastores/datastores_integration_test.go
+++ b/v2/rest/datastores/datastores_integration_test.go
@@ -4,6 +4,7 @@ package datastores_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
@@ -118,5 +119,52 @@ func TestDatastores_PostGIS_CRUD_Integration(t *testing.T) {
 	}
 	if len(leftover) != 0 {
 		t.Fatalf("expected empty after Delete, got %+v", leftover)
+	}
+}
+
+// TestDatastores_UploadFile_Shapefile_Integration uploads a zipped
+// Shapefile via PUT /workspaces/{ws}/datastores/{name}/file.shp and
+// verifies the store gets created. Reuses the hurricane_tracks fixture
+// shipped with the repo at testdata/.
+func TestDatastores_UploadFile_Shapefile_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+	dsName := testenv.UniqueName(t, "ds")
+
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	// Open a real zipped shapefile from the repo testdata. Path is
+	// relative to the test working directory (v2/rest/datastores/).
+	zipPath := "../../../testdata/hurricane_tracks.zip"
+	f, err := os.Open(zipPath)
+	if err != nil {
+		t.Skipf("shapefile fixture not available at %s: %v", zipPath, err)
+	}
+	defer f.Close()
+
+	ws := c.Datastores.InWorkspace(wsName)
+	if err := ws.UploadFile(ctx, dsName, f, datastores.UploadOptions{
+		Extension: "shp",
+	}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+
+	// Verify the store materialized.
+	got, err := ws.Get(ctx, dsName)
+	if err != nil {
+		t.Fatalf("Get after UploadFile: %v", err)
+	}
+	if got.Name != dsName {
+		t.Errorf("Name = %q, want %q", got.Name, dsName)
+	}
+	if got.Type == "" {
+		t.Errorf("Type empty in returned datastore: %+v", got)
 	}
 }

--- a/v2/rest/datastores/datastores_test.go
+++ b/v2/rest/datastores/datastores_test.go
@@ -531,6 +531,159 @@ func TestGet_URLEscaping_BothSegments(t *testing.T) {
 	}
 }
 
+func TestUploadFile_Default(t *testing.T) {
+	var captured struct {
+		Method, Path, ContentType, Accept string
+		Body                              []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		captured.Accept = r.Header.Get("Accept")
+		captured.Body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	body := strings.NewReader("FAKEZIP")
+	if err := c.Datastores.InWorkspace("topp").UploadFile(context.Background(), "states_shp", body,
+		datastores.UploadOptions{Extension: "shp"}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if captured.Method != http.MethodPut {
+		t.Errorf("Method = %q, want PUT", captured.Method)
+	}
+	if captured.Path != "/rest/workspaces/topp/datastores/states_shp/file.shp" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+	if captured.ContentType != "application/zip" {
+		t.Errorf("Content-Type = %q, want application/zip", captured.ContentType)
+	}
+	if captured.Accept != "*/*" {
+		t.Errorf("Accept = %q, want */*", captured.Accept)
+	}
+	if string(captured.Body) != "FAKEZIP" {
+		t.Errorf("Body = %q", string(captured.Body))
+	}
+}
+
+func TestUploadFile_URLMethod(t *testing.T) {
+	var captured struct{ Path, ContentType string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Datastores.InWorkspace("topp").UploadFile(context.Background(), "states_shp",
+		strings.NewReader("file:///data/states.shp"),
+		datastores.UploadOptions{Method: datastores.UploadMethodURL, Extension: "shp"}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if captured.Path != "/rest/workspaces/topp/datastores/states_shp/url.shp" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+	if captured.ContentType != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain", captured.ContentType)
+	}
+}
+
+func TestUploadFile_ExternalMethod(t *testing.T) {
+	var captured struct{ Path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Path = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Datastores.InWorkspace("topp").UploadFile(context.Background(), "states_shp",
+		strings.NewReader("/srv/geoserver/data/states.shp"),
+		datastores.UploadOptions{Method: datastores.UploadMethodExternal, Extension: "shp"}); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	if captured.Path != "/rest/workspaces/topp/datastores/states_shp/external.shp" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+}
+
+func TestUploadFile_UpdateQuery(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("update")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_ = c.Datastores.InWorkspace("topp").UploadFile(context.Background(), "states_shp",
+		strings.NewReader(""), datastores.UploadOptions{Extension: "shp", Update: "overwrite"})
+	if captured != "overwrite" {
+		t.Errorf("update = %q, want overwrite", captured)
+	}
+}
+
+func TestUploadFile_ContentTypeOverride(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_ = c.Datastores.InWorkspace("topp").UploadFile(context.Background(), "states_shp",
+		strings.NewReader(""),
+		datastores.UploadOptions{Extension: "shp", ContentType: "application/octet-stream"})
+	if captured != "application/octet-stream" {
+		t.Errorf("Content-Type = %q", captured)
+	}
+}
+
+func TestUploadFile_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	cases := []struct {
+		name string
+		ws   string
+		ds   string
+		body io.Reader
+		opts datastores.UploadOptions
+	}{
+		{"empty workspace", "", "states", strings.NewReader(""), datastores.UploadOptions{Extension: "shp"}},
+		{"empty name", "topp", "", strings.NewReader(""), datastores.UploadOptions{Extension: "shp"}},
+		{"nil body", "topp", "states", nil, datastores.UploadOptions{Extension: "shp"}},
+		{"invalid method", "topp", "states", strings.NewReader(""),
+			datastores.UploadOptions{Method: datastores.UploadMethod("bogus"), Extension: "shp"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.Datastores.InWorkspace(tc.ws).UploadFile(context.Background(), tc.ds, tc.body, tc.opts)
+			if err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestUploadFile_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no workspace", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Datastores.InWorkspace("missing").UploadFile(context.Background(), "states",
+		strings.NewReader(""), datastores.UploadOptions{Extension: "shp"})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestInWorkspace_Workspace(t *testing.T) {
 	c, err := geoserver.New("http://localhost:8080/geoserver")
 	if err != nil {

--- a/v2/rest/datastores/example_test.go
+++ b/v2/rest/datastores/example_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
 	"github.com/hishamkaram/geoserver/v2/rest/datastores"
@@ -18,6 +20,39 @@ func ExampleClient_InWorkspace() {
 
 	ws := c.Datastores.InWorkspace("topp")
 	_ = ws // ws.Get / ws.Create / ws.List / ws.Update / ws.Delete
+}
+
+// ExampleWorkspaceClient_UploadFile publishes a Shapefile by
+// uploading a zipped bundle (the .shp + .shx + .dbf + .prj
+// sidecars). For non-PostgreSQL data this is the fast path —
+// no need to copy files into the data directory by hand.
+func ExampleWorkspaceClient_UploadFile() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	f, err := os.Open("states.zip")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_ = c.Datastores.InWorkspace("topp").UploadFile(context.Background(),
+		"states_shp", f, datastores.UploadOptions{Extension: "shp"})
+}
+
+// ExampleWorkspaceClient_UploadFile_external registers a
+// server-local Shapefile path without transferring bytes — the
+// store points at a file already on the GeoServer host.
+func ExampleWorkspaceClient_UploadFile_external() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Datastores.InWorkspace("topp").UploadFile(context.Background(),
+		"states_shp", strings.NewReader("/srv/geoserver/data/states.shp"),
+		datastores.UploadOptions{
+			Method:    datastores.UploadMethodExternal,
+			Extension: "shp",
+		})
 }
 
 // ExampleWorkspaceClient_Create_postGIS publishes a PostGIS connection

--- a/v2/rest/datastores/types.go
+++ b/v2/rest/datastores/types.go
@@ -71,6 +71,48 @@ type DeleteOptions struct {
 	Recurse bool
 }
 
+// UploadMethod selects the file-upload sub-resource on
+// [WorkspaceClient.UploadFile].
+type UploadMethod string
+
+// Upload methods. The default ([UploadMethodFile]) ships the file
+// body across the wire; the other two reference data already
+// reachable from the server.
+const (
+	// UploadMethodFile uploads the file's binary contents in the
+	// request body. Routes to `PUT /file[.<ext>]`. Default.
+	UploadMethodFile UploadMethod = "file"
+	// UploadMethodURL provides a URL string the server fetches.
+	// Routes to `PUT /url[.<ext>]`.
+	UploadMethodURL UploadMethod = "url"
+	// UploadMethodExternal provides a server-local filesystem path
+	// string. No file transfer happens. Routes to `PUT /external[.<ext>]`.
+	UploadMethodExternal UploadMethod = "external"
+)
+
+// UploadOptions controls a [WorkspaceClient.UploadFile] call.
+type UploadOptions struct {
+	// Extension selects the URL suffix (e.g. "shp", "properties",
+	// "appschema"). May be empty if GeoServer can infer from the
+	// body, but the documented forms always include an extension.
+	Extension string
+
+	// Method selects the sub-resource. Default [UploadMethodFile].
+	Method UploadMethod
+
+	// ContentType overrides the Content-Type header. Defaults are:
+	//   - file:     application/zip
+	//   - url:      text/plain
+	//   - external: text/plain
+	// Override when uploading a non-zipped binary (e.g.,
+	// `application/octet-stream` for a raw shapefile).
+	ContentType string
+
+	// Update sets the optional `update` query parameter (typically
+	// `overwrite` or `append`). Empty means use the server default.
+	Update string
+}
+
 // Connector produces the [Datastore] payload sent to GeoServer when
 // creating a datastore. The standard convenience types [PostGIS] and
 // [JNDI] satisfy this interface; callers needing a different driver


### PR DESCRIPTION
## Summary

Second of the top-5 verified gaps — **rank #2, universal for non-PostgreSQL data**.

\`PUT /workspaces/{ws}/{stores}/{name}/{file|url|external}[.<ext>]\` is the GeoServer endpoint for publishing a file-backed store (Shapefile, GeoTIFF, image mosaic, etc.) without copying the file into the data directory by hand.

### Datastores

\`WorkspaceClient.UploadFile(ctx, name, body, opts)\` maps the \`PUT\`. \`opts.Method\` picks the sub-resource:

- \`UploadMethodFile\` (default): body is the file's binary contents (typically a zipped Shapefile + sidecars). Default \`Content-Type: application/zip\`.
- \`UploadMethodURL\`: body is a URL string the server fetches. Default \`Content-Type: text/plain\`.
- \`UploadMethodExternal\`: body is a server-local filesystem path string. No file transfer happens. Default \`Content-Type: text/plain\`.

Documented \`Extension\`: \`shp\`, \`properties\`, \`appschema\`. \`opts.Update\` sets the optional \`update\` query parameter (\`overwrite\` / \`append\`).

### CoverageStores

\`WorkspaceClient.UploadFile(ctx, name, body, opts)\` — same shape for raster stores. Documented \`Extension\`: \`geotiff\`, \`worldimage\`, \`imagemosaic\`. Override \`ContentType\` to \`image/tiff\` for a single GeoTIFF.

\`WorkspaceClient.HarvestGranule(ctx, name, body, opts)\` — \`POST\` to the same endpoint. Appends a granule to an existing image-mosaic store without reconfiguring it. Use \`UploadMethodExternal\` with a server-local path to avoid transferring large rasters across HTTP.

### Wire-format quirk handled

Both packages add \`DoRaw\` to their \`Core\` interface and route uploads through \`transport.DoRaw\` with \`Accept: */*\`. GeoServer's POST/PUT on these endpoints returns 201/202 with an empty body and refuses callers asking for \`application/json\` (406) — same workaround as \`styles.Client.Create\` and the new \`layers.AddStyle\`.

## Tests

- httptest unit tests for both packages: default file method, URL method, external method, update query, content-type override, empty-arg validation across (workspace, name, body), 404 → \`ErrNotFound\` sentinel, POST shape for \`HarvestGranule\`.
- **Integration test (datastores)**: uploads \`testdata/hurricane_tracks.zip\` against the live compose stack via \`UploadFile\` and verifies the resulting store materializes. Skips cleanly if the fixture isn't present.
- Godoc \`Example_*\` for file upload, external upload, GeoTIFF upload, granule harvest.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 18 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [x] **Integration tests run locally against live GeoServer** (per the new feedback rule): \`go test -tags=integration ./rest/datastores/ ./rest/coveragestores/\` passed against compose-stack 2.28.0 before push
- [ ] CI: 7 required checks + CodeQL pass on both 2.27.4 LTS and 2.28.0 stable

## Plan reference

\`/home/hesham/.claude/plans/v2-top5-rest-api-gaps.md\` — section "2. File-upload publishing on stores". Verified through three rounds against the live docs and v2 source.

## Roadmap

Two of five gaps shipped. Recommended next:

3. Per-service OWS settings (#4 in the plan) — WMS/WFS/WCS/WMTS settings under \`c.Services\`
4. GWC seed + layer config + diskquota (#1 in the plan)
5. Importer extension (#5 in the plan)