### PR TITLE
feat(v2): add per-service OWS settings (services package)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — per-service OWS settings
+
+- **`v2/rest/services/` package** — per-service OWS configuration for WMS / WFS / WCS / WMTS. The companion to `v2/rest/settings/` (which covers the global `/rest/settings` document). New entry-point `c.Services` exposes `.WMS()` / `.WFS()` / `.WCS()` / `.WMTS()`, each returning a typed client with `Get`/`Update` (global) and `.InWorkspace(ws)` returning a workspace-scoped client with `Get`/`Update`/`Delete` (DELETE removes the per-workspace override and falls back to the global config).
+- **Per-service settings types** — `WMSSettings` (watermark, interpolation, max\* tunables, GFI/GetMap MIME-checking flags), `WFSSettings` (maxFeatures, serviceLevel BASIC/TRANSACTIONAL/COMPLETE, GML output config), `WCSSettings` (gmlPrefixing, latLon, max\*Memory in KB), `WMTSSettings` (no unique fields beyond ServiceInfo). All embed the common `ServiceInfo` block.
+
+### Wire-format quirks (services package)
+
+Discovered via local integration testing against live GeoServer 2.28.0 — three quirks the upstream OpenAPI YAML doesn't document:
+
+- **`versions`** uses a class-name wrapper key (`org.geotools.util.Version`) and collapses single-element arrays to a scalar object. `Versions{List []string}` decodes both shapes into a flat slice; marshal emits the canonical array form.
+- **`keywords.string`** collapses single-element arrays to a scalar string. `Keywords{Strings []string}` decodes both; marshal emits the array form.
+- **`metadataLink`** is sent as `""` (empty string) when unset, not as `null` or absent. Custom UnmarshalJSON on `*MetadataLink` treats the empty-string form as "unset" — the resulting pointer is non-nil but with all-zero fields.
+
 ### Added — file-upload publishing on stores
 
 - **`v2/rest/datastores.WorkspaceClient.UploadFile(ctx, name, body, opts)`** — `PUT /workspaces/{ws}/datastores/{name}/{file|url|external}[.<ext>]`. Publishes a file-backed datastore by uploading the file contents (`UploadMethodFile`, default), pointing at a remote URL the server fetches (`UploadMethodURL`), or referencing a server-local path with no transfer (`UploadMethodExternal`). Documented `Extension` values: `shp`, `properties`, `appschema`. Default `Content-Type` is `application/zip` for file uploads, `text/plain` for URL/external; override via `UploadOptions.ContentType`.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
 	"github.com/hishamkaram/geoserver/v2/rest/security"
+	"github.com/hishamkaram/geoserver/v2/rest/services"
 	"github.com/hishamkaram/geoserver/v2/rest/settings"
 	"github.com/hishamkaram/geoserver/v2/rest/styles"
 	"github.com/hishamkaram/geoserver/v2/rest/system"
@@ -141,6 +142,13 @@ type Client struct {
 	// [wcs.Client.InWorkspace] for a workspace-scoped capabilities
 	// document.
 	WCS *wcs.Client
+
+	// Services is the entry point for per-service OWS configuration
+	// (`/services/{wms,wfs,wcs,wmts}/settings`). Reach the typed
+	// per-service clients via `c.Services.WMS()`, `WFS()`, `WCS()`,
+	// `WMTS()`. Each exposes `Get`/`Update` for global settings and
+	// `.InWorkspace(ws)` for per-workspace overrides (`Get`/`Update`/`Delete`).
+	Services *services.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -214,6 +222,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WMS = wms.New(adapter)
 	c.WFS = wfs.New(adapter)
 	c.WCS = wcs.New(adapter)
+	c.Services = services.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/services/example_test.go
+++ b/v2/rest/services/example_test.go
@@ -1,0 +1,66 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/services"
+)
+
+// ExampleClient_WMS reads the global WMS settings and tightens the
+// rendering-time cap so a slow style can't monopolize the worker pool.
+func ExampleClient_WMS() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	wms, err := c.Services.WMS().Get(context.Background())
+	if err != nil {
+		return
+	}
+	wms.MaxRenderingTime = 30 // seconds
+	_ = c.Services.WMS().Update(context.Background(), wms)
+}
+
+// ExampleWFSClient_InWorkspace caps WFS GetFeature responses for one
+// tenant. The per-workspace override doesn't affect the global config
+// or other workspaces.
+func ExampleWFSClient_InWorkspace() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Services.WFS().InWorkspace("topp").Update(context.Background(),
+		&services.WFSSettings{
+			ServiceInfo:  services.ServiceInfo{Enabled: true, Title: "topp WFS"},
+			MaxFeatures:  10000,
+			ServiceLevel: "BASIC",
+		})
+}
+
+// ExampleWMSWorkspaceClient_Delete removes the per-workspace WMS
+// override so the workspace falls back to the global configuration.
+func ExampleWMSWorkspaceClient_Delete() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	err := c.Services.WMS().InWorkspace("topp").Delete(context.Background())
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("no override existed")
+	}
+}
+
+// ExampleWCSClient sets WCS memory caps to keep one bad request from
+// OOM'ing the JVM. Memory values are integers in kilobytes despite
+// the upstream OpenAPI YAML's documented (boolean) shape — see the
+// WCSSettings doc.
+func ExampleWCSClient() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Services.WCS().Update(context.Background(), &services.WCSSettings{
+		ServiceInfo:     services.ServiceInfo{Enabled: true},
+		MaxInputMemory:  1024 * 1024, // 1 GiB
+		MaxOutputMemory: 2048 * 1024, // 2 GiB
+	})
+}

--- a/v2/rest/services/services.go
+++ b/v2/rest/services/services.go
@@ -1,0 +1,399 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+// Defined here as an interface so this subpackage doesn't import the
+// root package (which would create an import cycle).
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Client is the v2 services entry-point sub-client. Use the per-OWS
+// accessors to reach the typed clients:
+//
+//	c.Services.WMS().Get(ctx)
+//	c.Services.WFS().InWorkspace("topp").Update(ctx, settings)
+//	c.Services.WCS().InWorkspace("nurc").Delete(ctx)
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core Core
+}
+
+// New constructs the entry-point client. Used by the root
+// [*geoserver.Client] wiring; library users access the same
+// instance via `c.Services`.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// WMS returns the global-scope WMS settings client.
+func (c *Client) WMS() *WMSClient { return &WMSClient{core: c.core} }
+
+// WFS returns the global-scope WFS settings client.
+func (c *Client) WFS() *WFSClient { return &WFSClient{core: c.core} }
+
+// WCS returns the global-scope WCS settings client.
+func (c *Client) WCS() *WCSClient { return &WCSClient{core: c.core} }
+
+// WMTS returns the global-scope WMTS settings client. Note: the
+// upstream schema documents no unique fields for WMTS beyond
+// [ServiceInfo].
+func (c *Client) WMTS() *WMTSClient { return &WMTSClient{core: c.core} }
+
+// urlParts builds the URL path parts for a service-settings
+// endpoint. workspace is empty for the global form.
+func urlParts(slug, workspace string) []string {
+	parts := []string{"rest", "services", slug}
+	if workspace != "" {
+		parts = append(parts, "workspaces", workspace)
+	}
+	parts = append(parts, "settings")
+	return parts
+}
+
+// ----- WMS -----
+
+// WMSClient is the WMS settings client.
+type WMSClient struct{ core Core }
+
+// InWorkspace returns a workspace-scoped WMS settings client. The
+// workspace-scoped client has a Delete method that removes the
+// override and falls back to the global config.
+func (c *WMSClient) InWorkspace(workspace string) *WMSWorkspaceClient {
+	return &WMSWorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// Get fetches the global WMS settings document.
+func (c *WMSClient) Get(ctx context.Context) (*WMSSettings, error) {
+	return getWMS(ctx, c.core, "WMS.Get", "")
+}
+
+// Update writes the global WMS settings via PUT.
+func (c *WMSClient) Update(ctx context.Context, s *WMSSettings) error {
+	return putWMS(ctx, c.core, "WMS.Update", "", s)
+}
+
+// WMSWorkspaceClient is the per-workspace WMS settings client.
+type WMSWorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace name this client is scoped to.
+func (c *WMSWorkspaceClient) Workspace() string { return c.workspace }
+
+// Get fetches the per-workspace WMS settings override. Returns a
+// *APIError wrapping ErrNotFound if no override is configured.
+func (c *WMSWorkspaceClient) Get(ctx context.Context) (*WMSSettings, error) {
+	if c.workspace == "" {
+		return nil, errors.New("WMS.InWorkspace.Get: empty workspace name")
+	}
+	return getWMS(ctx, c.core, "WMS.InWorkspace.Get", c.workspace)
+}
+
+// Update writes the per-workspace WMS settings override.
+func (c *WMSWorkspaceClient) Update(ctx context.Context, s *WMSSettings) error {
+	if c.workspace == "" {
+		return errors.New("WMS.InWorkspace.Update: empty workspace name")
+	}
+	return putWMS(ctx, c.core, "WMS.InWorkspace.Update", c.workspace, s)
+}
+
+// Delete removes the per-workspace WMS settings override; the
+// workspace falls back to the global configuration.
+func (c *WMSWorkspaceClient) Delete(ctx context.Context) error {
+	if c.workspace == "" {
+		return errors.New("WMS.InWorkspace.Delete: empty workspace name")
+	}
+	return deleteService(ctx, c.core, "WMS.InWorkspace.Delete", "wms", c.workspace)
+}
+
+// ----- WFS -----
+
+// WFSClient is the WFS settings client.
+type WFSClient struct{ core Core }
+
+// InWorkspace returns a workspace-scoped WFS settings client.
+func (c *WFSClient) InWorkspace(workspace string) *WFSWorkspaceClient {
+	return &WFSWorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// Get fetches the global WFS settings document.
+func (c *WFSClient) Get(ctx context.Context) (*WFSSettings, error) {
+	return getWFS(ctx, c.core, "WFS.Get", "")
+}
+
+// Update writes the global WFS settings via PUT.
+func (c *WFSClient) Update(ctx context.Context, s *WFSSettings) error {
+	return putWFS(ctx, c.core, "WFS.Update", "", s)
+}
+
+// WFSWorkspaceClient is the per-workspace WFS settings client.
+type WFSWorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace name this client is scoped to.
+func (c *WFSWorkspaceClient) Workspace() string { return c.workspace }
+
+// Get fetches the per-workspace WFS settings override.
+func (c *WFSWorkspaceClient) Get(ctx context.Context) (*WFSSettings, error) {
+	if c.workspace == "" {
+		return nil, errors.New("WFS.InWorkspace.Get: empty workspace name")
+	}
+	return getWFS(ctx, c.core, "WFS.InWorkspace.Get", c.workspace)
+}
+
+// Update writes the per-workspace WFS settings override.
+func (c *WFSWorkspaceClient) Update(ctx context.Context, s *WFSSettings) error {
+	if c.workspace == "" {
+		return errors.New("WFS.InWorkspace.Update: empty workspace name")
+	}
+	return putWFS(ctx, c.core, "WFS.InWorkspace.Update", c.workspace, s)
+}
+
+// Delete removes the per-workspace WFS settings override.
+func (c *WFSWorkspaceClient) Delete(ctx context.Context) error {
+	if c.workspace == "" {
+		return errors.New("WFS.InWorkspace.Delete: empty workspace name")
+	}
+	return deleteService(ctx, c.core, "WFS.InWorkspace.Delete", "wfs", c.workspace)
+}
+
+// ----- WCS -----
+
+// WCSClient is the WCS settings client.
+type WCSClient struct{ core Core }
+
+// InWorkspace returns a workspace-scoped WCS settings client.
+func (c *WCSClient) InWorkspace(workspace string) *WCSWorkspaceClient {
+	return &WCSWorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// Get fetches the global WCS settings document.
+func (c *WCSClient) Get(ctx context.Context) (*WCSSettings, error) {
+	return getWCS(ctx, c.core, "WCS.Get", "")
+}
+
+// Update writes the global WCS settings via PUT.
+func (c *WCSClient) Update(ctx context.Context, s *WCSSettings) error {
+	return putWCS(ctx, c.core, "WCS.Update", "", s)
+}
+
+// WCSWorkspaceClient is the per-workspace WCS settings client.
+type WCSWorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace name this client is scoped to.
+func (c *WCSWorkspaceClient) Workspace() string { return c.workspace }
+
+// Get fetches the per-workspace WCS settings override.
+func (c *WCSWorkspaceClient) Get(ctx context.Context) (*WCSSettings, error) {
+	if c.workspace == "" {
+		return nil, errors.New("WCS.InWorkspace.Get: empty workspace name")
+	}
+	return getWCS(ctx, c.core, "WCS.InWorkspace.Get", c.workspace)
+}
+
+// Update writes the per-workspace WCS settings override.
+func (c *WCSWorkspaceClient) Update(ctx context.Context, s *WCSSettings) error {
+	if c.workspace == "" {
+		return errors.New("WCS.InWorkspace.Update: empty workspace name")
+	}
+	return putWCS(ctx, c.core, "WCS.InWorkspace.Update", c.workspace, s)
+}
+
+// Delete removes the per-workspace WCS settings override.
+func (c *WCSWorkspaceClient) Delete(ctx context.Context) error {
+	if c.workspace == "" {
+		return errors.New("WCS.InWorkspace.Delete: empty workspace name")
+	}
+	return deleteService(ctx, c.core, "WCS.InWorkspace.Delete", "wcs", c.workspace)
+}
+
+// ----- WMTS -----
+
+// WMTSClient is the WMTS settings client.
+type WMTSClient struct{ core Core }
+
+// InWorkspace returns a workspace-scoped WMTS settings client.
+func (c *WMTSClient) InWorkspace(workspace string) *WMTSWorkspaceClient {
+	return &WMTSWorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// Get fetches the global WMTS settings document.
+func (c *WMTSClient) Get(ctx context.Context) (*WMTSSettings, error) {
+	return getWMTS(ctx, c.core, "WMTS.Get", "")
+}
+
+// Update writes the global WMTS settings via PUT.
+func (c *WMTSClient) Update(ctx context.Context, s *WMTSSettings) error {
+	return putWMTS(ctx, c.core, "WMTS.Update", "", s)
+}
+
+// WMTSWorkspaceClient is the per-workspace WMTS settings client.
+type WMTSWorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace name this client is scoped to.
+func (c *WMTSWorkspaceClient) Workspace() string { return c.workspace }
+
+// Get fetches the per-workspace WMTS settings override.
+func (c *WMTSWorkspaceClient) Get(ctx context.Context) (*WMTSSettings, error) {
+	if c.workspace == "" {
+		return nil, errors.New("WMTS.InWorkspace.Get: empty workspace name")
+	}
+	return getWMTS(ctx, c.core, "WMTS.InWorkspace.Get", c.workspace)
+}
+
+// Update writes the per-workspace WMTS settings override.
+func (c *WMTSWorkspaceClient) Update(ctx context.Context, s *WMTSSettings) error {
+	if c.workspace == "" {
+		return errors.New("WMTS.InWorkspace.Update: empty workspace name")
+	}
+	return putWMTS(ctx, c.core, "WMTS.InWorkspace.Update", c.workspace, s)
+}
+
+// Delete removes the per-workspace WMTS settings override.
+func (c *WMTSWorkspaceClient) Delete(ctx context.Context) error {
+	if c.workspace == "" {
+		return errors.New("WMTS.InWorkspace.Delete: empty workspace name")
+	}
+	return deleteService(ctx, c.core, "WMTS.InWorkspace.Delete", "wmts", c.workspace)
+}
+
+// ----- internal helpers (per-service Get/Update; shared Delete) -----
+//
+// Each service's helpers know the slug, the envelope wrapper, and
+// the concrete Settings type. The per-service WMSClient/WFSClient/...
+// methods route through these.
+
+func getWMS(ctx context.Context, core Core, op, ws string) (*WMSSettings, error) {
+	u, err := core.URL(urlParts("wms", ws)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env wmsEnvelope
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.WMS == nil {
+		env.WMS = &WMSSettings{}
+	}
+	return env.WMS, nil
+}
+
+func putWMS(ctx context.Context, core Core, op, ws string, s *WMSSettings) error {
+	if s == nil {
+		return errors.New(op + ": nil settings")
+	}
+	u, err := core.URL(urlParts("wms", ws)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return core.Do(ctx, op, http.MethodPut, u, wmsEnvelope{WMS: s}, nil, nil)
+}
+
+func getWFS(ctx context.Context, core Core, op, ws string) (*WFSSettings, error) {
+	u, err := core.URL(urlParts("wfs", ws)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env wfsEnvelope
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.WFS == nil {
+		env.WFS = &WFSSettings{}
+	}
+	return env.WFS, nil
+}
+
+func putWFS(ctx context.Context, core Core, op, ws string, s *WFSSettings) error {
+	if s == nil {
+		return errors.New(op + ": nil settings")
+	}
+	u, err := core.URL(urlParts("wfs", ws)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return core.Do(ctx, op, http.MethodPut, u, wfsEnvelope{WFS: s}, nil, nil)
+}
+
+func getWCS(ctx context.Context, core Core, op, ws string) (*WCSSettings, error) {
+	u, err := core.URL(urlParts("wcs", ws)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env wcsEnvelope
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.WCS == nil {
+		env.WCS = &WCSSettings{}
+	}
+	return env.WCS, nil
+}
+
+func putWCS(ctx context.Context, core Core, op, ws string, s *WCSSettings) error {
+	if s == nil {
+		return errors.New(op + ": nil settings")
+	}
+	u, err := core.URL(urlParts("wcs", ws)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return core.Do(ctx, op, http.MethodPut, u, wcsEnvelope{WCS: s}, nil, nil)
+}
+
+func getWMTS(ctx context.Context, core Core, op, ws string) (*WMTSSettings, error) {
+	u, err := core.URL(urlParts("wmts", ws)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env wmtsEnvelope
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.WMTS == nil {
+		env.WMTS = &WMTSSettings{}
+	}
+	return env.WMTS, nil
+}
+
+func putWMTS(ctx context.Context, core Core, op, ws string, s *WMTSSettings) error {
+	if s == nil {
+		return errors.New(op + ": nil settings")
+	}
+	u, err := core.URL(urlParts("wmts", ws)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return core.Do(ctx, op, http.MethodPut, u, wmtsEnvelope{WMTS: s}, nil, nil)
+}
+
+// deleteService is shared because DELETE is identical across all
+// four services (no body, no per-service envelope).
+func deleteService(ctx context.Context, core Core, op, slug, ws string) error {
+	u, err := core.URL(urlParts(slug, ws)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/services/services_integration_test.go
+++ b/v2/rest/services/services_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package services_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/services"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+func TestServices_WMS_Global_GetUpdate_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.Services.WMS().Get(ctx)
+	if err != nil {
+		t.Fatalf("WMS.Get global: %v", err)
+	}
+	if got.Name == "" {
+		t.Errorf("WMS Name is empty: %+v", got.ServiceInfo)
+	}
+
+	// Round-trip: bump MaxRenderingTime, write, read back, restore.
+	original := got.MaxRenderingTime
+	t.Cleanup(func() {
+		got.MaxRenderingTime = original
+		_ = c.Services.WMS().Update(ctx, got)
+	})
+
+	got.MaxRenderingTime = original + 7
+	if err := c.Services.WMS().Update(ctx, got); err != nil {
+		t.Fatalf("WMS.Update global: %v", err)
+	}
+	after, err := c.Services.WMS().Get(ctx)
+	if err != nil {
+		t.Fatalf("WMS.Get after update: %v", err)
+	}
+	if after.MaxRenderingTime != original+7 {
+		t.Errorf("MaxRenderingTime didn't round-trip: got %d, want %d", after.MaxRenderingTime, original+7)
+	}
+}
+
+func TestServices_WFS_PerWorkspace_Override_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	wfs := c.Services.WFS().InWorkspace(wsName)
+
+	// No override yet — Get should return ErrNotFound (some
+	// GeoServer versions return 200 with an empty body; both are
+	// acceptable for the SDK contract).
+	_, err := wfs.Get(ctx)
+	if err != nil && !errors.Is(err, geoserver.ErrNotFound) {
+		t.Logf("Get pre-override (acceptable): %v", err)
+	}
+
+	// Create the override.
+	if err := wfs.Update(ctx, &services.WFSSettings{
+		ServiceInfo: services.ServiceInfo{Enabled: true, Title: "Override"},
+		MaxFeatures: 250,
+	}); err != nil {
+		t.Fatalf("Update override: %v", err)
+	}
+
+	got, err := wfs.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after override: %v", err)
+	}
+	if got.MaxFeatures != 250 {
+		t.Errorf("MaxFeatures = %d, want 250", got.MaxFeatures)
+	}
+
+	// Delete falls back to the global config. After delete, Get
+	// should return ErrNotFound (or 200 empty per server version).
+	if err := wfs.Delete(ctx); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+}
+
+func TestServices_WCS_Global_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.Services.WCS().Get(ctx)
+	if err != nil {
+		t.Fatalf("WCS.Get: %v", err)
+	}
+	if got.Name == "" {
+		t.Errorf("WCS Name is empty: %+v", got.ServiceInfo)
+	}
+}
+
+func TestServices_WMTS_Global_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.Services.WMTS().Get(ctx)
+	if err != nil {
+		// WMTS may not be enabled in every install; treat 404 as a
+		// skip rather than a hard failure.
+		if errors.Is(err, geoserver.ErrNotFound) {
+			t.Skipf("WMTS service not enabled on this GeoServer")
+		}
+		t.Fatalf("WMTS.Get: %v", err)
+	}
+	if got.Name == "" {
+		t.Errorf("WMTS Name is empty: %+v", got.ServiceInfo)
+	}
+}

--- a/v2/rest/services/services_test.go
+++ b/v2/rest/services/services_test.go
@@ -1,0 +1,416 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/services"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// ===== WMS =====
+
+func TestWMS_Get_Global(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/services/wms/settings" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"wms":{
+            "enabled":true,
+            "name":"WMS",
+            "title":"My WMS",
+            "maxRenderingTime":120,
+            "maxBuffer":50,
+            "watermark":{"enabled":true,"position":"BOT_RIGHT","transparency":80},
+            "interpolation":"Bilinear"
+        }}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Enabled || got.Title != "My WMS" {
+		t.Errorf("ServiceInfo not decoded: %+v", got.ServiceInfo)
+	}
+	if got.MaxRenderingTime != 120 || got.MaxBuffer != 50 {
+		t.Errorf("WMS-only fields: MaxRenderingTime=%d MaxBuffer=%d", got.MaxRenderingTime, got.MaxBuffer)
+	}
+	if got.Watermark == nil || got.Watermark.Position != "BOT_RIGHT" || got.Watermark.Transparency != 80 {
+		t.Errorf("Watermark = %+v", got.Watermark)
+	}
+	if got.Interpolation != "Bilinear" {
+		t.Errorf("Interpolation = %q", got.Interpolation)
+	}
+}
+
+func TestWMS_Update_Global_Envelope(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("Method = %q", r.Method)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Services.WMS().Update(context.Background(), &services.WMSSettings{
+		ServiceInfo:      services.ServiceInfo{Enabled: true, Title: "T"},
+		MaxRenderingTime: 60,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !strings.HasPrefix(string(captured), `{"wms":`) {
+		t.Errorf("body envelope wrong: %q", string(captured))
+	}
+	if !strings.Contains(string(captured), `"maxRenderingTime":60`) {
+		t.Errorf("body missing maxRenderingTime: %q", string(captured))
+	}
+}
+
+func TestWMS_Update_NilSettings(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	if err := c.Services.WMS().Update(context.Background(), nil); err == nil {
+		t.Errorf("expected error for nil settings")
+	}
+}
+
+func TestWMS_InWorkspace_GetUpdateDelete(t *testing.T) {
+	gets := 0
+	puts := 0
+	deletes := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/rest/services/wms/workspaces/topp/settings"
+		if r.URL.Path != want {
+			t.Errorf("Path = %q, want %q", r.URL.Path, want)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			gets++
+			_, _ = io.WriteString(w, `{"wms":{"name":"WMS","title":"topp WMS"}}`)
+		case http.MethodPut:
+			puts++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			deletes++
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	ws := c.Services.WMS().InWorkspace("topp")
+
+	if got, err := ws.Get(context.Background()); err != nil || got.Title != "topp WMS" {
+		t.Fatalf("Get: %v %+v", err, got)
+	}
+	if err := ws.Update(context.Background(), &services.WMSSettings{
+		ServiceInfo: services.ServiceInfo{Title: "new"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := ws.Delete(context.Background()); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if gets != 1 || puts != 1 || deletes != 1 {
+		t.Errorf("verb counts = G%d P%d D%d", gets, puts, deletes)
+	}
+}
+
+func TestWMS_InWorkspace_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	emptyWS := c.Services.WMS().InWorkspace("")
+
+	if _, err := emptyWS.Get(context.Background()); err == nil {
+		t.Errorf("expected error from Get with empty workspace")
+	}
+	if err := emptyWS.Update(context.Background(), &services.WMSSettings{}); err == nil {
+		t.Errorf("expected error from Update with empty workspace")
+	}
+	if err := emptyWS.Delete(context.Background()); err == nil {
+		t.Errorf("expected error from Delete with empty workspace")
+	}
+}
+
+func TestWMS_Get_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no override", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Services.WMS().InWorkspace("missing").Get(context.Background())
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// ===== WFS =====
+
+func TestWFS_Get_Global(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/services/wfs/settings" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"wfs":{
+            "name":"WFS",
+            "maxFeatures":1000,
+            "serviceLevel":"COMPLETE",
+            "featureBounding":true,
+            "hitsIgnoreMaxFeatures":false
+        }}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WFS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.MaxFeatures != 1000 || got.ServiceLevel != "COMPLETE" || !got.FeatureBounding {
+		t.Errorf("WFS fields wrong: %+v", got)
+	}
+}
+
+func TestWFS_Update_Envelope(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_ = c.Services.WFS().Update(context.Background(), &services.WFSSettings{
+		ServiceInfo:  services.ServiceInfo{Title: "WFS"},
+		MaxFeatures:  500,
+		ServiceLevel: "BASIC",
+	})
+	if !strings.HasPrefix(string(captured), `{"wfs":`) {
+		t.Errorf("body envelope wrong: %q", string(captured))
+	}
+	if !strings.Contains(string(captured), `"maxFeatures":500`) {
+		t.Errorf("body missing maxFeatures: %q", string(captured))
+	}
+	if !strings.Contains(string(captured), `"serviceLevel":"BASIC"`) {
+		t.Errorf("body missing serviceLevel: %q", string(captured))
+	}
+}
+
+// ===== WCS =====
+
+func TestWCS_Get_Global(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/services/wcs/settings" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		// MaxInputMemory and MaxOutputMemory are integers despite the
+		// upstream YAML doc-bug; this fixture sends them as integers.
+		_, _ = io.WriteString(w, `{"wcs":{
+            "name":"WCS",
+            "gmlPrefixing":true,
+            "latLon":false,
+            "maxInputMemory":1048576,
+            "maxOutputMemory":2097152
+        }}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WCS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.GMLPrefixing || got.LatLon {
+		t.Errorf("bool fields = %+v", got)
+	}
+	if got.MaxInputMemory != 1_048_576 || got.MaxOutputMemory != 2_097_152 {
+		t.Errorf("memory fields: in=%d out=%d", got.MaxInputMemory, got.MaxOutputMemory)
+	}
+}
+
+// ===== WMTS =====
+
+func TestWMTS_Get_Global(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/services/wmts/settings" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"wmts":{"name":"WMTS","title":"My WMTS","verbose":true}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMTS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Title != "My WMTS" || !got.Verbose {
+		t.Errorf("WMTS = %+v", got)
+	}
+}
+
+func TestWMTS_Update_Envelope(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_ = c.Services.WMTS().Update(context.Background(), &services.WMTSSettings{
+		ServiceInfo: services.ServiceInfo{Title: "T"},
+	})
+	if !strings.HasPrefix(string(captured), `{"wmts":`) {
+		t.Errorf("body envelope wrong: %q", string(captured))
+	}
+}
+
+// ===== Wire-format quirks =====
+
+func TestWireFormat_Versions_Array(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"wms":{"versions":{"org.geotools.util.Version":[
+			{"version":"1.1.1"},{"version":"1.3.0"}
+		]}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Versions == nil || len(got.Versions.List) != 2 {
+		t.Fatalf("Versions.List = %+v, want 2 entries", got.Versions)
+	}
+	if got.Versions.List[0] != "1.1.1" || got.Versions.List[1] != "1.3.0" {
+		t.Errorf("Versions = %+v", got.Versions.List)
+	}
+}
+
+func TestWireFormat_Versions_SingleObjectCollapse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"wmts":{"versions":{"org.geotools.util.Version":
+			{"version":"1.0.0"}
+		}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMTS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Versions == nil || len(got.Versions.List) != 1 || got.Versions.List[0] != "1.0.0" {
+		t.Fatalf("single-object collapse not handled: %+v", got.Versions)
+	}
+}
+
+func TestWireFormat_Keywords_Array(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"wms":{"keywords":{"string":["WMS","GEOSERVER"]}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Keywords == nil || len(got.Keywords.Strings) != 2 {
+		t.Fatalf("Keywords.Strings = %+v, want 2 entries", got.Keywords)
+	}
+}
+
+func TestWireFormat_Keywords_SingleStringCollapse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"wmts":{"keywords":{"string":"WMTS"}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMTS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Keywords == nil || len(got.Keywords.Strings) != 1 || got.Keywords.Strings[0] != "WMTS" {
+		t.Fatalf("single-string collapse not handled: %+v", got.Keywords)
+	}
+}
+
+func TestWireFormat_MetadataLink_EmptyString(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GeoServer sends `"metadataLink": ""` when no link is configured.
+		_, _ = io.WriteString(w, `{"wms":{"name":"WMS","metadataLink":""}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Services.WMS().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// Implementation note: the field is *MetadataLink and the empty-
+	// string form leaves a non-nil pointer to a zero struct. Both the
+	// "nil pointer" and "non-nil zero struct" cases are documented as
+	// equivalent to "unset"; check for empty fields rather than nil.
+	if got.MetadataLink != nil && (got.MetadataLink.Type != "" || got.MetadataLink.Content != "") {
+		t.Errorf("expected empty MetadataLink, got %+v", got.MetadataLink)
+	}
+}
+
+func TestWireFormat_Versions_Marshal_CanonicalArray(t *testing.T) {
+	v := services.Versions{List: []string{"2.0.0"}}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"org.geotools.util.Version":[`) {
+		t.Errorf("Marshal didn't emit class-name wrapper: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"version":"2.0.0"`) {
+		t.Errorf("Marshal didn't include version: %s", string(out))
+	}
+}
+
+// ===== Cross-cutting =====
+
+func TestServerError_PassThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Services.WMS().Get(context.Background())
+	if !errors.Is(err, geoserver.ErrServerError) {
+		t.Fatalf("err = %v, want ErrServerError", err)
+	}
+}

--- a/v2/rest/services/types.go
+++ b/v2/rest/services/types.go
@@ -1,0 +1,297 @@
+// Package services is the v2 sub-client for GeoServer's per-service
+// OWS configuration endpoints — `/rest/services/{wms,wfs,wcs,wmts}/settings`.
+//
+// The companion to [v2/rest/settings] (which covers the global
+// `/rest/settings` document). This package handles the per-service
+// tunables that don't live there: WFS `maxFeatures`, WMS
+// `maxRenderingTime` + watermark + interpolation, WCS memory caps,
+// plus per-workspace overrides for tenanted deployments.
+//
+// Service slugs supported here: `wms`, `wfs`, `wcs`, `wmts`. The
+// `oseo` (OpenSearch for Earth Observation) extension shares the
+// same wire shape and can be added in a follow-up if a real caller
+// needs it.
+//
+// Every per-service Settings type embeds [ServiceInfo] (the common
+// metadata block) and adds service-specific fields. The wire
+// envelope key is the lowercase service slug — `{"wms":{...}}`,
+// `{"wfs":{...}}`, etc.
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// ServiceInfo is the common metadata block every OWS service shares.
+// Embedded into [WMSSettings], [WFSSettings], [WCSSettings], and
+// [WMTSSettings].
+//
+// Wire-shape note: the schema spells "abstract" as `abstrct` (typo
+// preserved on the wire); the Go field name is `Abstract` and the
+// JSON tag captures the actual wire key.
+type ServiceInfo struct {
+	Enabled           bool          `json:"enabled,omitempty"`
+	Name              string        `json:"name,omitempty"`
+	Title             string        `json:"title,omitempty"`
+	Maintainer        string        `json:"maintainer,omitempty"`
+	Abstract          string        `json:"abstrct,omitempty"`
+	AccessConstraints string        `json:"accessConstraints,omitempty"`
+	Fees              string        `json:"fees,omitempty"`
+	Versions          *Versions     `json:"versions,omitempty"`
+	Keywords          *Keywords     `json:"keywords,omitempty"`
+	MetadataLink      *MetadataLink `json:"metadataLink,omitempty"`
+	CiteCompliant     bool          `json:"citeCompliant,omitempty"`
+	OnlineResource    string        `json:"onlineResource,omitempty"`
+	SchemaBaseURL     string        `json:"schemaBaseURL,omitempty"`
+	Verbose           bool          `json:"verbose,omitempty"`
+}
+
+// Versions wraps the supported-version list as a flat string slice.
+//
+// Wire-shape note: GeoServer wraps the version list in a class-name
+// key (`org.geotools.util.Version`) and collapses single-element
+// arrays to a scalar object. Both shapes:
+//
+//	"versions": {"org.geotools.util.Version": [{"version":"1.1.1"}, {"version":"1.3.0"}]}
+//	"versions": {"org.geotools.util.Version": {"version":"1.0.0"}}
+//
+// are decoded into Versions{List: ["1.1.1","1.3.0"]} and
+// Versions{List: ["1.0.0"]} respectively. Marshal always emits the
+// canonical array form so write payloads are GeoServer-compatible.
+type Versions struct {
+	List []string
+}
+
+const versionsKey = "org.geotools.util.Version"
+
+type versionsWire struct {
+	Org json.RawMessage `json:"org.geotools.util.Version,omitempty"`
+}
+
+type versionEntry struct {
+	Version string `json:"version,omitempty"`
+}
+
+// UnmarshalJSON accepts the wire shapes documented above.
+func (v *Versions) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+	var w versionsWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return fmt.Errorf("versions: %w", err)
+	}
+	if len(w.Org) == 0 || bytes.Equal(w.Org, []byte("null")) {
+		return nil
+	}
+	if w.Org[0] == '[' {
+		var entries []versionEntry
+		if err := json.Unmarshal(w.Org, &entries); err != nil {
+			return fmt.Errorf("versions: decode array: %w", err)
+		}
+		v.List = make([]string, 0, len(entries))
+		for _, e := range entries {
+			v.List = append(v.List, e.Version)
+		}
+		return nil
+	}
+	var single versionEntry
+	if err := json.Unmarshal(w.Org, &single); err != nil {
+		return fmt.Errorf("versions: decode single: %w", err)
+	}
+	if single.Version != "" {
+		v.List = []string{single.Version}
+	}
+	return nil
+}
+
+// MarshalJSON emits the canonical array form.
+func (v Versions) MarshalJSON() ([]byte, error) {
+	if len(v.List) == 0 {
+		return []byte("null"), nil
+	}
+	entries := make([]versionEntry, len(v.List))
+	for i, s := range v.List {
+		entries[i] = versionEntry{Version: s}
+	}
+	return json.Marshal(map[string]any{versionsKey: entries})
+}
+
+// Keywords wraps the keyword list as a flat string slice.
+//
+// Wire-shape note: GeoServer collapses single-element keyword arrays
+// to a scalar string. Both shapes:
+//
+//	"keywords": {"string": ["WMS","GEOSERVER"]}
+//	"keywords": {"string": "WMTS"}
+//
+// are decoded into Keywords{Strings: [...]}. Marshal always emits the
+// canonical array form.
+type Keywords struct {
+	Strings []string
+}
+
+type keywordsWire struct {
+	String json.RawMessage `json:"string,omitempty"`
+}
+
+// UnmarshalJSON accepts both wire shapes documented above.
+func (k *Keywords) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+	var w keywordsWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return fmt.Errorf("keywords: %w", err)
+	}
+	if len(w.String) == 0 || bytes.Equal(w.String, []byte("null")) {
+		return nil
+	}
+	if w.String[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(w.String, &arr); err != nil {
+			return fmt.Errorf("keywords: decode array: %w", err)
+		}
+		k.Strings = arr
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(w.String, &single); err != nil {
+		return fmt.Errorf("keywords: decode single: %w", err)
+	}
+	if single != "" {
+		k.Strings = []string{single}
+	}
+	return nil
+}
+
+// MarshalJSON emits the canonical array form.
+func (k Keywords) MarshalJSON() ([]byte, error) {
+	if len(k.Strings) == 0 {
+		return []byte("null"), nil
+	}
+	return json.Marshal(struct {
+		String []string `json:"string"`
+	}{String: k.Strings})
+}
+
+// MetadataLink is the optional metadata-pointer block. Most callers
+// leave this nil.
+//
+// Wire-shape note: GeoServer sends `"metadataLink": ""` (empty string)
+// when no link is configured, instead of omitting the field or
+// sending `null`. The custom UnmarshalJSON treats the empty-string
+// form as "unset" — the resulting *MetadataLink is non-nil but with
+// all-zero fields. Callers can check `link.Type == "" && link.Content == ""`
+// to detect the unset case if needed; equivalent behavior to
+// `link == nil` on a freshly-decoded value where the wire was empty.
+type MetadataLink struct {
+	Type         string `json:"type,omitempty"`
+	MetadataType string `json:"metadataType,omitempty"`
+	Content      string `json:"content,omitempty"`
+}
+
+// UnmarshalJSON accepts both `{type,metadataType,content}` and the
+// GeoServer empty-string-when-unset form.
+func (m *MetadataLink) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) || bytes.Equal(data, []byte(`""`)) {
+		return nil
+	}
+	type alias MetadataLink
+	return json.Unmarshal(data, (*alias)(m))
+}
+
+// WMSSettings is the WMS service config (`/services/wms/settings`,
+// envelope key `wms`). Schema corresponds to the upstream `WMSInfo`
+// type.
+type WMSSettings struct {
+	ServiceInfo
+	Watermark                             *Watermark `json:"watermark,omitempty"`
+	Interpolation                         string     `json:"interpolation,omitempty"`
+	MaxBuffer                             int        `json:"maxBuffer,omitempty"`
+	MaxRequestMemory                      int        `json:"maxRequestMemory,omitempty"`
+	MaxRenderingTime                      int        `json:"maxRenderingTime,omitempty"`
+	MaxRenderingErrors                    int        `json:"maxRenderingErrors,omitempty"`
+	GetFeatureInfoMimeTypeCheckingEnabled bool       `json:"getFeatureInfoMimeTypeCheckingEnabled,omitempty"`
+	GetMapMimeTypeCheckingEnabled         bool       `json:"getMapMimeTypeCheckingEnabled,omitempty"`
+	DynamicStylingDisabled                bool       `json:"dynamicStylingDisabled,omitempty"`
+}
+
+// Watermark is the WMS-only overlay block.
+//
+// Position values: TOP_LEFT, TOP_CENTER, TOP_RIGHT, MID_LEFT,
+// MID_CENTER, MID_RIGHT, BOT_LEFT, BOT_CENTER, BOT_RIGHT.
+// Transparency is 0–255 (0 = opaque, 255 = fully transparent).
+type Watermark struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	Position     string `json:"position,omitempty"`
+	Transparency int    `json:"transparency,omitempty"`
+}
+
+// WFSSettings is the WFS service config (`/services/wfs/settings`,
+// envelope key `wfs`).
+//
+// ServiceLevel values: BASIC, TRANSACTIONAL, COMPLETE.
+type WFSSettings struct {
+	ServiceInfo
+	MaxFeatures             int     `json:"maxFeatures,omitempty"`
+	ServiceLevel            string  `json:"serviceLevel,omitempty"`
+	FeatureBounding         bool    `json:"featureBounding,omitempty"`
+	EncodeFeatureMember     bool    `json:"encodeFeatureMember,omitempty"`
+	CanonicalSchemaLocation bool    `json:"canonicalSchemaLocation,omitempty"`
+	HitsIgnoreMaxFeatures   bool    `json:"hitsIgnoreMaxFeatures,omitempty"`
+	GML                     *GMLMap `json:"gml,omitempty"`
+}
+
+// GMLMap is the per-WFS-version GML output configuration map.
+type GMLMap struct {
+	Entry []GMLEntry `json:"entry,omitempty"`
+}
+
+// GMLEntry is one entry in [GMLMap]: WFS version → SrsNameStyle.
+type GMLEntry struct {
+	Version      string `json:"@key,omitempty"`
+	SrsNameStyle string `json:"$,omitempty"`
+}
+
+// WCSSettings is the WCS service config (`/services/wcs/settings`,
+// envelope key `wcs`).
+//
+// MaxInputMemory and MaxOutputMemory: the upstream OpenAPI YAML
+// types these as `boolean` — that's a documented schema bug; the
+// runtime values are integers (kilobytes). Go uses int64 here.
+type WCSSettings struct {
+	ServiceInfo
+	GMLPrefixing    bool  `json:"gmlPrefixing,omitempty"`
+	LatLon          bool  `json:"latLon,omitempty"`
+	MaxInputMemory  int64 `json:"maxInputMemory,omitempty"`
+	MaxOutputMemory int64 `json:"maxOutputMemory,omitempty"`
+}
+
+// WMTSSettings is the WMTS service config (`/services/wmts/settings`,
+// envelope key `wmts`). The upstream schema documents no unique fields
+// for WMTS beyond [ServiceInfo]; this type embeds it plain.
+type WMTSSettings struct {
+	ServiceInfo
+}
+
+// Per-service envelope wrappers. The wire shape is
+// `{"<slug>": {<settings fields>}}`.
+
+type wmsEnvelope struct {
+	WMS *WMSSettings `json:"wms"`
+}
+
+type wfsEnvelope struct {
+	WFS *WFSSettings `json:"wfs"`
+}
+
+type wcsEnvelope struct {
+	WCS *WCSSettings `json:"wcs"`
+}
+
+type wmtsEnvelope struct {
+	WMTS *WMTSSettings `json:"wmts"`
+}


### PR DESCRIPTION
## Summary

Third of the top-5 verified gaps — **rank #4 in the gap-analysis plan**.

Adds \`v2/rest/services/\` for per-service OWS configuration under \`/rest/services/{wms,wfs,wcs,wmts}/settings\` — the companion to the existing \`v2/rest/settings/\` package (which covers only the global \`/rest/settings\` document).

## API

\`\`\`go
c.Services.WMS().Get(ctx)            // → *WMSSettings (global)
c.Services.WMS().Update(ctx, s)      // PUT global config
c.Services.WMS().InWorkspace("topp").Get(ctx)
c.Services.WMS().InWorkspace("topp").Update(ctx, s)
c.Services.WMS().InWorkspace("topp").Delete(ctx)  // falls back to global
\`\`\`

Same shape for \`WFS\`, \`WCS\`, \`WMTS\`. Per-service types (\`WMSSettings\`, \`WFSSettings\`, \`WCSSettings\`, \`WMTSSettings\`) all embed the common \`ServiceInfo\` block (enabled/name/title/maintainer/abstrct [wire-typo preserved]/accessConstraints/fees/versions/keywords/metadataLink/citeCompliant/onlineResource/schemaBaseURL/verbose).

### Per-service unique fields

- **WMS** — watermark, interpolation, max\* tunables, GFI/GetMap MIME-checking flags, dynamicStylingDisabled
- **WFS** — maxFeatures, serviceLevel (BASIC/TRANSACTIONAL/COMPLETE), featureBounding, encodeFeatureMember, canonicalSchemaLocation, hitsIgnoreMaxFeatures, GML output config
- **WCS** — gmlPrefixing, latLon, maxInputMemory, maxOutputMemory (int64 in KB; the upstream YAML's boolean type is a doc bug)
- **WMTS** — no unique fields beyond ServiceInfo

## Wire-format quirks (discovered via local integration testing)

Three quirks the upstream OpenAPI YAML doesn't document — handled with custom Marshal/Unmarshal:

1. **\`versions\`** wraps the version list in a class-name key (\`org.geotools.util.Version\`) and collapses single-element arrays to a scalar object. \`Versions{List []string}\` decodes both shapes; marshal emits the canonical array form.
2. **\`keywords.string\`** collapses single-element arrays to a scalar string. \`Keywords{Strings []string}\` decodes both; marshal emits the array form.
3. **\`metadataLink\`** is sent as \`""\` (empty string) when unset, not as \`null\` or absent. Custom \`UnmarshalJSON\` on \`*MetadataLink\` treats the empty-string form as "unset" — pointer non-nil but all-zero.

## Tests

- Unit tests for each service: Get/Update happy path, envelope key correctness, per-workspace verb counts, empty-workspace validation, nil-settings rejection, \`ErrNotFound\` + \`ErrServerError\` sentinel mapping.
- Wire-quirk tests: versions array form, single-object collapse, keywords array form, single-string collapse, metadataLink empty-string, Versions Marshal canonical shape.
- Integration tests: WMS global Get + Update round-trip (MaxRenderingTime), WFS per-workspace override lifecycle (Update → Get → Delete), WCS Get, WMTS Get (skip if extension not enabled).
- Godoc \`Example_*\` for each entry point.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 19 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [x] **Integration tests run locally** against live GeoServer 2.28.0 before push (per the local-integration-first rule); discovered the three wire quirks and fixed them before pushing
- [ ] CI: 7 required checks + CodeQL pass on both 2.27.4 LTS and 2.28.0 stable

## Roadmap

Three of five gaps shipped. Remaining:

4. GWC seed + layer config + diskquota (#1 in the plan)
5. Importer extension (#5 in the plan)