### PR TITLE
feat(v2): add GeoWebCache REST client (gwc package)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — GeoWebCache REST client
+
+- **`v2/rest/gwc/` package** — `c.GWC` exposes the GeoWebCache REST endpoints universal to any deployment serving map tiles. URL prefix is `/gwc/rest/` (outside the `/rest/` catalog tree).
+- **`c.GWC.Layers()`** — `List(ctx)` returns layer names; `Get/Put(ctx, name, *LayerConfig)` use XML wire format (`<GeoServerLayer>` with `<mimeFormats>`, `<gridSubsets>`, `<metaWidthHeight>`, `<parameterFilters>`, etc.); `Delete(ctx, name)` removes the cache config.
+- **`c.GWC.Seed()`** — `Submit(ctx, layer, *SeedRequest)` is asynchronous (POST returns immediately); `Status(ctx, layer)` and `StatusAll(ctx)` decode the `{"long-array-array":[[tilesProcessed, totalTiles, remainingSeconds, taskId, taskStatus], ...]}` wire shape into a flat `[]SeedTask`; `KillAll(ctx)` terminates running tasks. Typed `SeedOp` enum (`OpSeed` / `OpReseed` / `OpTruncate`) and `SeedTaskStatus` enum (`StatusAborted` / `StatusPending` / `StatusRunning` / `StatusDone`).
+- **`c.GWC.DiskQuota()`** — `Get/Update(ctx, *DiskQuota)` for global LFU/LRU eviction policy and disk-usage cap.
+
+### Wire-format quirks (gwc package)
+
+Discovered via local integration testing against live GeoServer 2.28.0 — three quirks the docs don't surface:
+
+- **DiskQuota PUT requires XML, not JSON**, and uses `<globalQuota><value>NUMBER</value><units>UNIT</units></globalQuota>` rather than the `<bytes>NUMBER</bytes>` form GET returns. The server-side parser (XStream's `QuotaXSTreamConverter`) is asymmetric between read and write paths. `DiskQuotaClient.Update` translates `Quota.Bytes` to the `value/units` XML form (always serializing as `B` bytes) and PUTs to `/gwc/rest/diskquota.xml`.
+- **GWC returns 500 (not 404) for unknown layers** on `Layers.Get`. Integration test accepts either `ErrServerError` or `ErrNotFound`; unit test verifies the strict 404→`ErrNotFound` mapping.
+- **`/gwc/rest/seed.json`** returns `{"long-array-array":[[...]]}` — a positional 5-element array per running task. `SeedStatus.UnmarshalJSON` decodes this into a typed `[]SeedTask` slice with named fields.
+
 ### Added — per-service OWS settings
 
 - **`v2/rest/services/` package** — per-service OWS configuration for WMS / WFS / WCS / WMTS. The companion to `v2/rest/settings/` (which covers the global `/rest/settings` document). New entry-point `c.Services` exposes `.WMS()` / `.WFS()` / `.WCS()` / `.WMTS()`, each returning a typed client with `Get`/`Update` (global) and `.InWorkspace(ws)` returning a workspace-scoped client with `Get`/`Update`/`Delete` (DELETE removes the per-workspace override and falls back to the global config).

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/coveragestores"
 	"github.com/hishamkaram/geoserver/v2/rest/datastores"
 	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
@@ -143,6 +144,13 @@ type Client struct {
 	// document.
 	WCS *wcs.Client
 
+	// GWC is the entry point for GeoWebCache REST endpoints —
+	// per-layer cache config, seed/reseed/truncate tasks, and
+	// disk-quota policy. Lives at /gwc/rest/ (outside the /rest/
+	// catalog tree). Reach the typed sub-clients via
+	// `c.GWC.Layers()`, `Seed()`, `DiskQuota()`.
+	GWC *gwc.Client
+
 	// Services is the entry point for per-service OWS configuration
 	// (`/services/{wms,wfs,wcs,wmts}/settings`). Reach the typed
 	// per-service clients via `c.Services.WMS()`, `WFS()`, `WCS()`,
@@ -223,6 +231,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WFS = wfs.New(adapter)
 	c.WCS = wcs.New(adapter)
 	c.Services = services.New(adapter)
+	c.GWC = gwc.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/gwc/example_test.go
+++ b/v2/rest/gwc/example_test.go
@@ -1,0 +1,103 @@
+package gwc_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+)
+
+// ExampleClient_Layers lists every layer GeoWebCache is configured
+// to cache.
+func ExampleClient_Layers() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	names, err := c.GWC.Layers().List(context.Background())
+	if err != nil {
+		return
+	}
+	for _, n := range names {
+		fmt.Println(n)
+	}
+}
+
+// ExampleLayersClient_Get reads the per-layer cache configuration —
+// gridsets, MIME types, expire times, parameter filters.
+func ExampleLayersClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	cfg, err := c.GWC.Layers().Get(context.Background(), "topp:states")
+	if err != nil {
+		return
+	}
+	fmt.Printf("%s enabled=%v\n", cfg.Name, cfg.Enabled)
+	if cfg.MimeFormats != nil {
+		for _, m := range cfg.MimeFormats.String {
+			fmt.Println(" ", m)
+		}
+	}
+}
+
+// ExampleSeedClient_Submit invalidates the cached tiles for a layer
+// after a data update — the daily-driver workflow for any production
+// deployment serving WMS via tiles.
+//
+// The call is asynchronous: Submit returns immediately and the task
+// runs in the background. Use [SeedClient.Status] to poll progress.
+func ExampleSeedClient_Submit() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	err := c.GWC.Seed().Submit(context.Background(), "topp:states", &gwc.SeedRequest{
+		SRS:         gwc.SRS{Number: 4326},
+		ZoomStart:   0,
+		ZoomStop:    8,
+		Format:      "image/png",
+		Type:        gwc.OpTruncate,
+		ThreadCount: 2,
+		GridSetID:   "EPSG:4326",
+		Bounds: &gwc.Bounds{Coords: gwc.BoundsCoords{
+			Double: []float64{-180, -90, 180, 90},
+		}},
+	})
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("layer doesn't exist")
+	}
+}
+
+// ExampleSeedClient_StatusAll polls progress on every running
+// seed/reseed/truncate task across all layers.
+func ExampleSeedClient_StatusAll() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	st, err := c.GWC.Seed().StatusAll(context.Background())
+	if err != nil {
+		return
+	}
+	for _, t := range st.Tasks {
+		fmt.Printf("task %d: %d/%d tiles, %ds left, status=%s\n",
+			t.TaskID, t.TilesProcessed, t.TotalTiles, t.RemainingSeconds, t.Status)
+	}
+}
+
+// ExampleDiskQuotaClient_Get reads the disk-quota policy controlling
+// LFU/LRU eviction and the maximum disk usage for the tile cache.
+func ExampleDiskQuotaClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	dq, err := c.GWC.DiskQuota().Get(context.Background())
+	if err != nil {
+		return
+	}
+	fmt.Printf("enabled=%v policy=%s", dq.Enabled, dq.GlobalExpirationPolicyName)
+	if dq.GlobalQuota != nil {
+		fmt.Printf(" cap=%d bytes", dq.GlobalQuota.Bytes)
+	}
+	fmt.Println()
+}

--- a/v2/rest/gwc/gwc.go
+++ b/v2/rest/gwc/gwc.go
@@ -1,0 +1,278 @@
+package gwc
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+// Defined here as an interface so this subpackage doesn't import the
+// root package.
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoXML(ctx context.Context, op, method, requestURL string, query map[string]string, out any) error
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
+}
+
+// Client is the v2 GeoWebCache sub-client. Reach the per-resource
+// clients via the accessors:
+//
+//	c.GWC.Layers().List(ctx)
+//	c.GWC.Seed().Submit(ctx, "topp:states", &gwc.SeedRequest{...})
+//	c.GWC.DiskQuota().Get(ctx)
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core Core
+}
+
+// New constructs the entry-point client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// Layers returns the per-layer cache configuration client.
+func (c *Client) Layers() *LayersClient { return &LayersClient{core: c.core} }
+
+// Seed returns the seed/reseed/truncate task client.
+func (c *Client) Seed() *SeedClient { return &SeedClient{core: c.core} }
+
+// DiskQuota returns the disk-quota policy client.
+func (c *Client) DiskQuota() *DiskQuotaClient { return &DiskQuotaClient{core: c.core} }
+
+// ----- Layers -----
+
+// LayersClient covers `/gwc/rest/layers` and `/gwc/rest/layers/<layer>.xml`.
+// The per-layer endpoint is XML-only; List uses the JSON form for a
+// flat array of layer names.
+type LayersClient struct {
+	core Core
+}
+
+// List returns the names of every layer GeoWebCache knows about
+// (qualified `<workspace>:<layer>` form for workspace-scoped layers).
+func (c *LayersClient) List(ctx context.Context) ([]string, error) {
+	const op = "GWC.Layers.List"
+	u, err := c.core.URL("gwc", "rest", "layers.json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var out []string
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Get fetches the per-layer cache configuration for `name` (use the
+// qualified `<workspace>:<layer>` form for workspace-scoped layers,
+// e.g. `topp:states`).
+//
+// XML-only response; returns a *APIError wrapping ErrNotFound for
+// unknown layers.
+func (c *LayersClient) Get(ctx context.Context, name string) (*LayerConfig, error) {
+	const op = "GWC.Layers.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("gwc", "rest", "layers", name+".xml")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var out LayerConfig
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Put replaces (or creates) the per-layer cache configuration. The
+// request body is the XML-serialized [LayerConfig].
+func (c *LayersClient) Put(ctx context.Context, name string, layer *LayerConfig) error {
+	const op = "GWC.Layers.Put"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if layer == nil {
+		return errors.New(op + ": nil layer config")
+	}
+	u, err := c.core.URL("gwc", "rest", "layers", name+".xml")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body, err := xml.Marshal(layer)
+	if err != nil {
+		return fmt.Errorf("%s: encode body: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, bytes.NewReader(body),
+		"application/xml", "*/*", nil)
+}
+
+// Delete removes the per-layer cache configuration. The catalog layer
+// itself is unaffected.
+func (c *LayersClient) Delete(ctx context.Context, name string) error {
+	const op = "GWC.Layers.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("gwc", "rest", "layers", name+".xml")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}
+
+// ----- Seed -----
+
+// SeedClient covers `/gwc/rest/seed/...` — submit and poll
+// asynchronous seed/reseed/truncate tasks.
+type SeedClient struct {
+	core Core
+}
+
+// Submit kicks off a new seed/reseed/truncate task on `layer`. The
+// call is asynchronous: the server returns 200 immediately and runs
+// the task in the background. Poll [SeedClient.Status] (per-layer)
+// or [SeedClient.StatusAll] (global) for progress; cancel via
+// [SeedClient.KillAll].
+//
+// The `name` field on req must match `layer` (GeoServer rejects
+// mismatches). Pass [OpSeed], [OpReseed], or [OpTruncate] for `Type`.
+func (c *SeedClient) Submit(ctx context.Context, layer string, req *SeedRequest) error {
+	const op = "GWC.Seed.Submit"
+	if layer == "" {
+		return errors.New(op + ": empty layer name")
+	}
+	if req == nil {
+		return errors.New(op + ": nil seed request")
+	}
+	if req.Name == "" {
+		req.Name = layer
+	}
+	if req.Type == "" {
+		return errors.New(op + ": empty SeedRequest.Type (want seed | reseed | truncate)")
+	}
+	u, err := c.core.URL("gwc", "rest", "seed", layer+".json")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := seedRequestEnvelope{SeedRequest: req}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Status returns the running-tasks list for the named layer.
+func (c *SeedClient) Status(ctx context.Context, layer string) (*SeedStatus, error) {
+	const op = "GWC.Seed.Status"
+	if layer == "" {
+		return nil, errors.New(op + ": empty layer name")
+	}
+	u, err := c.core.URL("gwc", "rest", "seed", layer+".json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var out SeedStatus
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// StatusAll returns the running-tasks list across every layer. Each
+// task's TaskID is unique server-wide.
+func (c *SeedClient) StatusAll(ctx context.Context) (*SeedStatus, error) {
+	const op = "GWC.Seed.StatusAll"
+	u, err := c.core.URL("gwc", "rest", "seed.json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var out SeedStatus
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// KillAll terminates every running seed task. Wire form is `POST
+// /gwc/rest/seed` with `kill_all=all` as a form parameter.
+func (c *SeedClient) KillAll(ctx context.Context) error {
+	const op = "GWC.Seed.KillAll"
+	u, err := c.core.URL("gwc", "rest", "seed")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPost, u,
+		bytes.NewReader([]byte("kill_all=all")),
+		"application/x-www-form-urlencoded", "*/*", nil)
+}
+
+// ----- DiskQuota -----
+
+// DiskQuotaClient covers `/gwc/rest/diskquota.json`.
+type DiskQuotaClient struct {
+	core Core
+}
+
+// Get returns the current disk-quota policy.
+func (c *DiskQuotaClient) Get(ctx context.Context) (*DiskQuota, error) {
+	const op = "GWC.DiskQuota.Get"
+	u, err := c.core.URL("gwc", "rest", "diskquota.json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env diskQuotaEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.Config == nil {
+		env.Config = &DiskQuota{}
+	}
+	return env.Config, nil
+}
+
+// Update writes the disk-quota policy. Disk-quota is global (not
+// per-layer); the change applies to all cached tiles immediately.
+//
+// Wire-format quirk handled here: GWC's read endpoint accepts JSON
+// with `globalQuota.bytes`, but its PUT endpoint goes through a
+// different parser (`QuotaXSTreamConverter`) that requires XML and
+// uses `<globalQuota><value>N</value><units>B</units></globalQuota>`.
+// The Update method translates [Quota.Bytes] into the XML
+// value/units form (always serializing as `B` bytes for fidelity)
+// and sends via XML.
+func (c *DiskQuotaClient) Update(ctx context.Context, dq *DiskQuota) error {
+	const op = "GWC.DiskQuota.Update"
+	if dq == nil {
+		return errors.New(op + ": nil disk quota")
+	}
+	u, err := c.core.URL("gwc", "rest", "diskquota.xml")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	xmlForm := diskQuotaPutXML{
+		Enabled:                    dq.Enabled,
+		CacheCleanUpFrequency:      dq.CacheCleanUpFrequency,
+		CacheCleanUpUnits:          dq.CacheCleanUpUnits,
+		MaxConcurrentCleanUps:      dq.MaxConcurrentCleanUps,
+		GlobalExpirationPolicyName: dq.GlobalExpirationPolicyName,
+	}
+	if dq.GlobalQuota != nil {
+		xmlForm.GlobalQuota = &quotaPutXMLVal{
+			Value: dq.GlobalQuota.Bytes,
+			Units: "B",
+		}
+	}
+	body, err := xml.Marshal(xmlForm)
+	if err != nil {
+		return fmt.Errorf("%s: encode body: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, bytes.NewReader(body),
+		"application/xml", "*/*", nil)
+}

--- a/v2/rest/gwc/gwc_integration_test.go
+++ b/v2/rest/gwc/gwc_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package gwc_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+)
+
+func TestGWC_Layers_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.GWC.Layers().List(ctx)
+	if err != nil {
+		t.Fatalf("Layers.List: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected at least one cached layer in default install")
+	}
+}
+
+func TestGWC_Layers_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// topp:states is shipped with the default GeoServer install.
+	cfg, err := c.GWC.Layers().Get(ctx, "topp:states")
+	if err != nil {
+		t.Fatalf("Layers.Get: %v", err)
+	}
+	if cfg.Name != "topp:states" {
+		t.Errorf("Name = %q", cfg.Name)
+	}
+	if cfg.MimeFormats == nil || len(cfg.MimeFormats.String) == 0 {
+		t.Errorf("MimeFormats empty: %+v", cfg.MimeFormats)
+	}
+	if cfg.GridSubsets == nil || len(cfg.GridSubsets.GridSubset) == 0 {
+		t.Errorf("GridSubsets empty: %+v", cfg.GridSubsets)
+	}
+}
+
+func TestGWC_Layers_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Wire-quirk: GWC returns 500 (with body "Unknown layer: ...")
+	// for unknown layers rather than 404. Both ErrNotFound (mocked
+	// path) and ErrServerError (real path) surface as a non-nil
+	// typed error, so we accept either; the unit test covers the
+	// strict 404 → ErrNotFound mapping separately.
+	_, err := c.GWC.Layers().Get(ctx, "definitely:not_a_layer_zz")
+	if err == nil {
+		t.Fatalf("expected error for unknown layer")
+	}
+	if !errors.Is(err, geoserver.ErrNotFound) && !errors.Is(err, geoserver.ErrServerError) {
+		t.Fatalf("err = %v, want ErrNotFound or ErrServerError", err)
+	}
+}
+
+func TestGWC_Seed_Truncate_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Truncate is the safest seed op for an integration test —
+	// no actual tile generation, just cache invalidation.
+	err := c.GWC.Seed().Submit(ctx, "topp:states", &gwc.SeedRequest{
+		SRS:         gwc.SRS{Number: 4326},
+		ZoomStart:   0,
+		ZoomStop:    2,
+		Format:      "image/png",
+		Type:        gwc.OpTruncate,
+		ThreadCount: 1,
+		GridSetID:   "EPSG:4326",
+		Bounds: &gwc.Bounds{Coords: gwc.BoundsCoords{
+			Double: []float64{-180, -90, 180, 90},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Seed.Submit truncate: %v", err)
+	}
+
+	// Status query should succeed (may or may not list the just-
+	// submitted task — truncate is fast).
+	if _, err := c.GWC.Seed().StatusAll(ctx); err != nil {
+		t.Fatalf("Seed.StatusAll: %v", err)
+	}
+	if _, err := c.GWC.Seed().Status(ctx, "topp:states"); err != nil {
+		t.Fatalf("Seed.Status: %v", err)
+	}
+}
+
+func TestGWC_DiskQuota_GetUpdate_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	original, err := c.GWC.DiskQuota().Get(ctx)
+	if err != nil {
+		t.Fatalf("DiskQuota.Get: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.GWC.DiskQuota().Update(ctx, original)
+	})
+
+	if original.GlobalExpirationPolicyName == "" {
+		t.Errorf("GlobalExpirationPolicyName empty: %+v", original)
+	}
+
+	// Round-trip: flip the enabled flag, write, read back, restore.
+	modified := *original
+	modified.Enabled = !original.Enabled
+	if err := c.GWC.DiskQuota().Update(ctx, &modified); err != nil {
+		t.Fatalf("DiskQuota.Update: %v", err)
+	}
+	after, err := c.GWC.DiskQuota().Get(ctx)
+	if err != nil {
+		t.Fatalf("DiskQuota.Get after update: %v", err)
+	}
+	if after.Enabled != modified.Enabled {
+		t.Errorf("Enabled didn't round-trip: got %v, want %v", after.Enabled, modified.Enabled)
+	}
+}

--- a/v2/rest/gwc/gwc_test.go
+++ b/v2/rest/gwc/gwc_test.go
@@ -1,0 +1,426 @@
+package gwc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// ===== Layers =====
+
+func TestLayers_List(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gwc/rest/layers.json" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `["topp:states","sf:archsites","ne:countries"]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.Layers().List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 || got[0] != "topp:states" {
+		t.Errorf("List = %+v", got)
+	}
+}
+
+func TestLayers_Get_XML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// URL builder percent-encodes the colon in qualified names.
+		if r.URL.Path != "/gwc/rest/layers/topp%3Astates.xml" && r.URL.Path != "/gwc/rest/layers/topp:states.xml" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>
+<GeoServerLayer>
+  <id>LayerInfoImpl-x</id>
+  <enabled>true</enabled>
+  <inMemoryCached>true</inMemoryCached>
+  <name>topp:states</name>
+  <mimeFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </mimeFormats>
+  <gridSubsets>
+    <gridSubset><gridSetName>EPSG:4326</gridSetName></gridSubset>
+    <gridSubset><gridSetName>EPSG:900913</gridSetName></gridSubset>
+  </gridSubsets>
+  <metaWidthHeight><int>4</int><int>4</int></metaWidthHeight>
+  <expireCache>0</expireCache>
+  <gutter>0</gutter>
+</GeoServerLayer>`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.Layers().Get(context.Background(), "topp:states")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "topp:states" || !got.Enabled {
+		t.Errorf("Get = %+v", got)
+	}
+	if got.MimeFormats == nil || len(got.MimeFormats.String) != 2 {
+		t.Errorf("MimeFormats = %+v", got.MimeFormats)
+	}
+	if got.GridSubsets == nil || len(got.GridSubsets.GridSubset) != 2 {
+		t.Errorf("GridSubsets = %+v", got.GridSubsets)
+	}
+	if got.MetaWidthHeight == nil || len(got.MetaWidthHeight.Int) != 2 {
+		t.Errorf("MetaWidthHeight = %+v", got.MetaWidthHeight)
+	}
+}
+
+func TestLayers_Put_XMLBody(t *testing.T) {
+	var captured struct {
+		Method, Path, ContentType string
+		Body                      []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		captured.Body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.GWC.Layers().Put(context.Background(), "topp:states", &gwc.LayerConfig{
+		Name:        "topp:states",
+		Enabled:     true,
+		MimeFormats: &gwc.MimeFormats{String: []string{"image/png"}},
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if captured.Method != http.MethodPut {
+		t.Errorf("Method = %q", captured.Method)
+	}
+	if captured.ContentType != "application/xml" {
+		t.Errorf("Content-Type = %q", captured.ContentType)
+	}
+	if !strings.HasPrefix(string(captured.Body), "<GeoServerLayer>") {
+		t.Errorf("body not XML-shaped: %q", string(captured.Body))
+	}
+	if !strings.Contains(string(captured.Body), "<name>topp:states</name>") {
+		t.Errorf("body missing name: %q", string(captured.Body))
+	}
+}
+
+func TestLayers_Delete(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("Method = %q", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.GWC.Layers().Delete(context.Background(), "topp:states"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !called {
+		t.Errorf("server not called")
+	}
+}
+
+func TestLayers_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	if _, err := c.GWC.Layers().Get(context.Background(), ""); err == nil {
+		t.Errorf("Get empty name: expected error")
+	}
+	if err := c.GWC.Layers().Put(context.Background(), "", &gwc.LayerConfig{}); err == nil {
+		t.Errorf("Put empty name: expected error")
+	}
+	if err := c.GWC.Layers().Put(context.Background(), "x", nil); err == nil {
+		t.Errorf("Put nil config: expected error")
+	}
+	if err := c.GWC.Layers().Delete(context.Background(), ""); err == nil {
+		t.Errorf("Delete empty name: expected error")
+	}
+}
+
+// ===== Seed =====
+
+func TestSeed_Submit_BodyShape(t *testing.T) {
+	var capturedBody json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q", r.Method)
+		}
+		// URL builder percent-encodes the colon.
+		if !strings.Contains(r.URL.Path, "topp") || !strings.HasSuffix(r.URL.Path, ".json") {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.GWC.Seed().Submit(context.Background(), "topp:states", &gwc.SeedRequest{
+		SRS:         gwc.SRS{Number: 4326},
+		ZoomStart:   0,
+		ZoomStop:    5,
+		Format:      "image/png",
+		Type:        gwc.OpTruncate,
+		ThreadCount: 1,
+		GridSetID:   "EPSG:4326",
+		Bounds: &gwc.Bounds{Coords: gwc.BoundsCoords{
+			Double: []float64{-180, -90, 180, 90},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	body := string(capturedBody)
+	if !strings.HasPrefix(body, `{"seedRequest":`) {
+		t.Errorf("body envelope wrong: %q", body)
+	}
+	if !strings.Contains(body, `"name":"topp:states"`) {
+		t.Errorf("body missing name (auto-fill from layer arg): %q", body)
+	}
+	if !strings.Contains(body, `"type":"truncate"`) {
+		t.Errorf("body missing type: %q", body)
+	}
+	if !strings.Contains(body, `"srs":{"number":4326}`) {
+		t.Errorf("body missing srs: %q", body)
+	}
+	if !strings.Contains(body, `"double":[-180,-90,180,90]`) {
+		t.Errorf("body missing bounds: %q", body)
+	}
+}
+
+func TestSeed_Submit_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+
+	if err := c.GWC.Seed().Submit(context.Background(), "", &gwc.SeedRequest{Type: gwc.OpSeed}); err == nil {
+		t.Errorf("Submit empty layer: expected error")
+	}
+	if err := c.GWC.Seed().Submit(context.Background(), "topp:states", nil); err == nil {
+		t.Errorf("Submit nil request: expected error")
+	}
+	if err := c.GWC.Seed().Submit(context.Background(), "topp:states", &gwc.SeedRequest{}); err == nil {
+		t.Errorf("Submit empty Type: expected error")
+	}
+}
+
+func TestSeed_Status_LongArrayArrayUnmarshal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"long-array-array":[
+			[100, 1000, 30, 1, 1],
+			[2000, 5000, 0, 2, 2]
+		]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.Seed().StatusAll(context.Background())
+	if err != nil {
+		t.Fatalf("StatusAll: %v", err)
+	}
+	if len(got.Tasks) != 2 {
+		t.Fatalf("Tasks = %+v", got.Tasks)
+	}
+	if got.Tasks[0].TaskID != 1 || got.Tasks[0].Status != gwc.StatusRunning {
+		t.Errorf("Tasks[0] = %+v", got.Tasks[0])
+	}
+	if got.Tasks[1].Status != gwc.StatusDone {
+		t.Errorf("Tasks[1].Status = %v", got.Tasks[1].Status)
+	}
+}
+
+func TestSeed_StatusAll_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"long-array-array":[]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.Seed().StatusAll(context.Background())
+	if err != nil {
+		t.Fatalf("StatusAll: %v", err)
+	}
+	if len(got.Tasks) != 0 {
+		t.Errorf("expected empty Tasks, got %+v", got.Tasks)
+	}
+}
+
+func TestSeed_TaskStatus_String(t *testing.T) {
+	cases := []struct {
+		s    gwc.SeedTaskStatus
+		want string
+	}{
+		{gwc.StatusAborted, "ABORTED"},
+		{gwc.StatusPending, "PENDING"},
+		{gwc.StatusRunning, "RUNNING"},
+		{gwc.StatusDone, "DONE"},
+		{gwc.SeedTaskStatus(99), "UNKNOWN(99)"},
+	}
+	for _, tc := range cases {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("Status(%d).String() = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestSeed_KillAll(t *testing.T) {
+	var captured struct {
+		Method, Path, ContentType, Body string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		captured.Body = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.GWC.Seed().KillAll(context.Background()); err != nil {
+		t.Fatalf("KillAll: %v", err)
+	}
+	if captured.Path != "/gwc/rest/seed" {
+		t.Errorf("Path = %q", captured.Path)
+	}
+	if captured.ContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q", captured.ContentType)
+	}
+	if captured.Body != "kill_all=all" {
+		t.Errorf("Body = %q", captured.Body)
+	}
+}
+
+// ===== DiskQuota =====
+
+func TestDiskQuota_Get_ClassNameEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gwc/rest/diskquota.json" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"org.geowebcache.diskquota.DiskQuotaConfig":{
+			"enabled":true,
+			"cacheCleanUpFrequency":10,
+			"cacheCleanUpUnits":"MINUTES",
+			"globalExpirationPolicyName":"LRU",
+			"globalQuota":{"id":0,"bytes":1073741824}
+		}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.DiskQuota().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Enabled || got.GlobalExpirationPolicyName != "LRU" {
+		t.Errorf("Get = %+v", got)
+	}
+	if got.GlobalQuota == nil || got.GlobalQuota.Bytes != 1073741824 {
+		t.Errorf("GlobalQuota = %+v", got.GlobalQuota)
+	}
+}
+
+func TestDiskQuota_Update_XMLBody(t *testing.T) {
+	var captured struct {
+		Method, Path, ContentType string
+		Body                      []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+		captured.Body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.GWC.DiskQuota().Update(context.Background(), &gwc.DiskQuota{
+		Enabled:                    true,
+		GlobalExpirationPolicyName: "LFU",
+		GlobalQuota:                &gwc.Quota{Bytes: 2 * 1024 * 1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if captured.Method != http.MethodPut {
+		t.Errorf("Method = %q", captured.Method)
+	}
+	if captured.Path != "/gwc/rest/diskquota.xml" {
+		t.Errorf("Path = %q (want .xml suffix — JSON PUT is rejected by GWC)", captured.Path)
+	}
+	if captured.ContentType != "application/xml" {
+		t.Errorf("Content-Type = %q (must be XML, GWC's PUT parser rejects JSON)", captured.ContentType)
+	}
+	body := string(captured.Body)
+	if !strings.HasPrefix(body, `<org.geowebcache.diskquota.DiskQuotaConfig>`) {
+		t.Errorf("body root wrong: %q", body)
+	}
+	if !strings.Contains(body, `<globalExpirationPolicyName>LFU</globalExpirationPolicyName>`) {
+		t.Errorf("body missing policy: %q", body)
+	}
+	// Wire-quirk assertion: must use value/units, NOT bytes.
+	if !strings.Contains(body, `<value>2147483648</value>`) {
+		t.Errorf("body missing <value>: %q", body)
+	}
+	if !strings.Contains(body, `<units>B</units>`) {
+		t.Errorf("body missing <units>: %q", body)
+	}
+	if strings.Contains(body, `<bytes>`) {
+		t.Errorf("body has <bytes> (forbidden by GWC PUT parser): %q", body)
+	}
+}
+
+func TestDiskQuota_Update_Validation(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	if err := c.GWC.DiskQuota().Update(context.Background(), nil); err == nil {
+		t.Errorf("Update nil: expected error")
+	}
+}
+
+// ===== Cross-cutting =====
+
+func TestErrorMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such layer", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GWC.Layers().Get(context.Background(), "missing:layer")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/v2/rest/gwc/types.go
+++ b/v2/rest/gwc/types.go
@@ -1,0 +1,289 @@
+// Package gwc is the v2 sub-client for the GeoWebCache REST endpoints
+// at `/gwc/rest/` — universal for any GeoServer deployment serving
+// map tiles. The current surface covers the three groups documented
+// at `/latest/en/user/geowebcache/rest/`:
+//
+//   - Layers — per-layer cache config (gridsets, MIME types,
+//     parameter filters, enabled flag). Wire format is XML-only.
+//   - Seed — submit and poll seed/reseed/truncate tasks.
+//     Asynchronous: POST returns immediately; status is GET-polled.
+//   - DiskQuota — disk-quota policy (LFU/LRU eviction, max disk usage).
+//
+// Other GWC endpoints (masstruncate, blobstores, gridsets, statistics,
+// global) live in the standalone GeoWebCache project docs and aren't
+// covered here yet — same wire-shape pattern, can land in a follow-up.
+//
+// URL prefix note: `/gwc/rest/` lives outside the v1/v2 `/rest/` tree;
+// the URL builder accepts arbitrary path segments, so `c.core.URL(
+// "gwc", "rest", "layers")` produces the right path.
+package gwc
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+)
+
+// ----- Layers (XML wire format) -----
+
+// LayerConfig is the per-layer cache configuration document
+// (`<GeoServerLayer>`). Sent and received as XML via
+// `/gwc/rest/layers/<layer>.xml`.
+type LayerConfig struct {
+	XMLName          xml.Name          `xml:"GeoServerLayer"`
+	ID               string            `xml:"id,omitempty"`
+	Enabled          bool              `xml:"enabled"`
+	InMemoryCached   bool              `xml:"inMemoryCached,omitempty"`
+	Name             string            `xml:"name"`
+	MimeFormats      *MimeFormats      `xml:"mimeFormats,omitempty"`
+	GridSubsets      *GridSubsets      `xml:"gridSubsets,omitempty"`
+	MetaWidthHeight  *MetaWidthHeight  `xml:"metaWidthHeight,omitempty"`
+	ExpireCache      int               `xml:"expireCache,omitempty"`
+	ExpireClients    int               `xml:"expireClients,omitempty"`
+	ParameterFilters *ParameterFilters `xml:"parameterFilters,omitempty"`
+	Gutter           int               `xml:"gutter,omitempty"`
+}
+
+// MimeFormats wraps the supported tile MIME-types list.
+type MimeFormats struct {
+	String []string `xml:"string"`
+}
+
+// GridSubsets wraps the per-CRS gridset bindings.
+type GridSubsets struct {
+	GridSubset []GridSubset `xml:"gridSubset"`
+}
+
+// GridSubset is one CRS-binding entry on a layer (typically
+// `EPSG:4326` and `EPSG:900913`).
+type GridSubset struct {
+	GridSetName string  `xml:"gridSetName"`
+	MinX        float64 `xml:"extent>coords>double,omitempty"`
+}
+
+// MetaWidthHeight wraps the meta-tile size (e.g. `<int>4</int><int>4</int>`
+// for a 4×4 meta-tile).
+type MetaWidthHeight struct {
+	Int []int `xml:"int"`
+}
+
+// ParameterFilters wraps the per-layer query-param filter list.
+// The most common entry is StyleParameterFilter, which lets callers
+// request alternate styles via `?STYLES=...` against the cached tile
+// set.
+type ParameterFilters struct {
+	StyleParameterFilter []StyleParameterFilter `xml:"styleParameterFilter,omitempty"`
+}
+
+// StyleParameterFilter declares the cache-key contribution of the
+// `STYLES` WMS parameter.
+type StyleParameterFilter struct {
+	Key          string `xml:"key"`
+	DefaultValue string `xml:"defaultValue"`
+}
+
+// ----- Seed -----
+
+// SeedRequest is the body for `POST /gwc/rest/seed/<layer>.json`.
+// The wire envelope key is `seedRequest`.
+//
+// `Type` is one of `seed` (cache new tiles), `reseed` (regenerate
+// existing tiles), or `truncate` (invalidate without regenerating).
+// Use the [OpSeed], [OpReseed], [OpTruncate] constants.
+//
+// `Format` is the tile MIME type (e.g., `image/png`, `image/jpeg`),
+// distinct from the URL's `<format>` segment which selects the
+// request/response document format (json / xml).
+type SeedRequest struct {
+	Name        string          `json:"name"`
+	SRS         SRS             `json:"srs"`
+	ZoomStart   int             `json:"zoomStart"`
+	ZoomStop    int             `json:"zoomStop"`
+	Format      string          `json:"format"`
+	Type        SeedOp          `json:"type"`
+	ThreadCount int             `json:"threadCount,omitempty"`
+	Bounds      *Bounds         `json:"bounds,omitempty"`
+	GridSetID   string          `json:"gridSetId,omitempty"`
+	Parameters  *SeedParameters `json:"parameters,omitempty"`
+}
+
+// SeedOp enumerates the documented seed-task operations.
+type SeedOp string
+
+// Seed-task operation kinds.
+const (
+	// OpSeed caches new tiles (no-op if already cached).
+	OpSeed SeedOp = "seed"
+	// OpReseed regenerates tiles whether or not they already exist.
+	OpReseed SeedOp = "reseed"
+	// OpTruncate invalidates the cache without regenerating tiles.
+	OpTruncate SeedOp = "truncate"
+)
+
+// SRS is the spatial-reference-system identifier.
+type SRS struct {
+	Number int `json:"number"`
+}
+
+// Bounds is the seed task's geographic envelope. The wire shape uses
+// the `coords.double[]` array form GeoServer expects.
+type Bounds struct {
+	Coords BoundsCoords `json:"coords"`
+}
+
+// BoundsCoords wraps the four-corner array (minX, minY, maxX, maxY).
+type BoundsCoords struct {
+	Double []float64 `json:"double"`
+}
+
+// SeedParameters supplies the per-task parameter filter values
+// (e.g., to cache only the `polygon` style for a given layer).
+type SeedParameters struct {
+	Entry []SeedParameterEntry `json:"entry"`
+}
+
+// SeedParameterEntry is one (key, value) pair in a parameter map.
+// On the wire this is a 2-element JSON array.
+type SeedParameterEntry [2]string
+
+// seedRequestEnvelope wraps SeedRequest in the canonical wire shape.
+type seedRequestEnvelope struct {
+	SeedRequest *SeedRequest `json:"seedRequest"`
+}
+
+// SeedStatus is the response from `GET /gwc/rest/seed.json` (global)
+// or `GET /gwc/rest/seed/<layer>.json` (per-layer). Each entry in the
+// outer array describes one running task as a fixed-position
+// 5-element inner array; helper accessors decode the positional
+// fields by name.
+//
+// Wire shape: `{"long-array-array":[[tilesProcessed, totalTiles,
+// remainingSeconds, taskId, taskStatus], ...]}`. Status codes:
+// -1=ABORTED, 0=PENDING, 1=RUNNING, 2=DONE.
+type SeedStatus struct {
+	Tasks []SeedTask
+}
+
+// SeedTask is one running or recently-finished seed task.
+type SeedTask struct {
+	TilesProcessed   int64
+	TotalTiles       int64
+	RemainingSeconds int64
+	TaskID           int64
+	Status           SeedTaskStatus
+}
+
+// SeedTaskStatus is the status code for a [SeedTask].
+type SeedTaskStatus int
+
+// Seed-task status codes.
+const (
+	StatusAborted SeedTaskStatus = -1
+	StatusPending SeedTaskStatus = 0
+	StatusRunning SeedTaskStatus = 1
+	StatusDone    SeedTaskStatus = 2
+)
+
+// String returns a human-readable status label.
+func (s SeedTaskStatus) String() string {
+	switch s {
+	case StatusAborted:
+		return "ABORTED"
+	case StatusPending:
+		return "PENDING"
+	case StatusRunning:
+		return "RUNNING"
+	case StatusDone:
+		return "DONE"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", int(s))
+	}
+}
+
+// seedStatusWire is the on-wire envelope.
+type seedStatusWire struct {
+	LongArrayArray [][]int64 `json:"long-array-array"`
+}
+
+// UnmarshalJSON decodes the {"long-array-array":[[...]]} wire shape
+// into a flat [SeedTask] slice.
+func (s *SeedStatus) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+	var w seedStatusWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return fmt.Errorf("seed status: %w", err)
+	}
+	s.Tasks = make([]SeedTask, 0, len(w.LongArrayArray))
+	for _, row := range w.LongArrayArray {
+		var t SeedTask
+		if len(row) > 0 {
+			t.TilesProcessed = row[0]
+		}
+		if len(row) > 1 {
+			t.TotalTiles = row[1]
+		}
+		if len(row) > 2 {
+			t.RemainingSeconds = row[2]
+		}
+		if len(row) > 3 {
+			t.TaskID = row[3]
+		}
+		if len(row) > 4 {
+			t.Status = SeedTaskStatus(row[4])
+		}
+		s.Tasks = append(s.Tasks, t)
+	}
+	return nil
+}
+
+// ----- DiskQuota -----
+
+// DiskQuota is the disk-quota policy at `/gwc/rest/diskquota.json`.
+// Wire envelope: `{"org.geowebcache.diskquota.DiskQuotaConfig":{...}}`
+// — a class-name wrapper similar to the [services.Versions] pattern.
+type DiskQuota struct {
+	Enabled                    bool   `json:"enabled"`
+	CacheCleanUpFrequency      int    `json:"cacheCleanUpFrequency,omitempty"`
+	CacheCleanUpUnits          string `json:"cacheCleanUpUnits,omitempty"`
+	MaxConcurrentCleanUps      int    `json:"maxConcurrentCleanUps,omitempty"`
+	GlobalExpirationPolicyName string `json:"globalExpirationPolicyName,omitempty"`
+	GlobalQuota                *Quota `json:"globalQuota,omitempty"`
+}
+
+// Quota is the disk-usage cap for a [DiskQuota] config.
+type Quota struct {
+	ID    int   `json:"id,omitempty"`
+	Bytes int64 `json:"bytes"`
+}
+
+// diskQuotaEnvelope wraps DiskQuota in the class-name wire shape on
+// the GET path. Note the JSON form is read-only; the PUT path
+// requires XML — see [diskQuotaPutXML].
+type diskQuotaEnvelope struct {
+	Config *DiskQuota `json:"org.geowebcache.diskquota.DiskQuotaConfig"`
+}
+
+// diskQuotaPutXML is the XML wire shape required by `PUT
+// /gwc/rest/diskquota.xml`. The GWC server-side parser
+// (`QuotaXSTreamConverter`) on PUT expects `<globalQuota>` to use
+// `<value>NUMBER</value><units>UNIT</units>` rather than the
+// `<bytes>NUMBER</bytes>` form GET returns. This is a known GWC
+// asymmetry between the read and write parsers.
+type diskQuotaPutXML struct {
+	XMLName                    xml.Name        `xml:"org.geowebcache.diskquota.DiskQuotaConfig"`
+	Enabled                    bool            `xml:"enabled"`
+	CacheCleanUpFrequency      int             `xml:"cacheCleanUpFrequency,omitempty"`
+	CacheCleanUpUnits          string          `xml:"cacheCleanUpUnits,omitempty"`
+	MaxConcurrentCleanUps      int             `xml:"maxConcurrentCleanUps,omitempty"`
+	GlobalExpirationPolicyName string          `xml:"globalExpirationPolicyName,omitempty"`
+	GlobalQuota                *quotaPutXMLVal `xml:"globalQuota,omitempty"`
+}
+
+// quotaPutXMLVal is the value/units form GWC PUT requires.
+type quotaPutXMLVal struct {
+	Value int64  `xml:"value"`
+	Units string `xml:"units"`
+}


### PR DESCRIPTION
## Summary

Fourth of the top-5 verified gaps — **rank #1 in the gap-analysis plan** ("universal for any deployment serving map tiles"). Ships the verified subset (layers + seed + diskquota) per the live \`/latest/\` docs; tier-2 GWC endpoints (masstruncate, blobstores, gridsets, statistics, global) live in the standalone GeoWebCache project docs and can land in a follow-up.

### API

\`\`\`go
c.GWC.Layers().List(ctx)             // []string of layer names
c.GWC.Layers().Get(ctx, name)        // *LayerConfig (XML)
c.GWC.Layers().Put(ctx, name, layer)
c.GWC.Layers().Delete(ctx, name)

c.GWC.Seed().Submit(ctx, layer, &gwc.SeedRequest{Type: gwc.OpTruncate, ...})  // async
c.GWC.Seed().Status(ctx, layer)      // per-layer running tasks
c.GWC.Seed().StatusAll(ctx)          // global running tasks
c.GWC.Seed().KillAll(ctx)

c.GWC.DiskQuota().Get(ctx)           // *DiskQuota
c.GWC.DiskQuota().Update(ctx, dq)    // XML body (see quirk #1)
\`\`\`

### Wire-format quirks (discovered via local integration testing)

Three wire bugs/asymmetries discovered against live GeoServer 2.28.0 — handled with care:

1. **DiskQuota PUT requires XML, NOT JSON**, and uses \`<globalQuota><value>NUMBER</value><units>UNIT</units></globalQuota>\` instead of the \`<bytes>NUMBER</bytes>\` form GET returns. The GWC server-side parser (XStream's \`QuotaXSTreamConverter\`) is asymmetric between read and write paths. \`DiskQuotaClient.Update\` translates \`Quota.Bytes\` to the value/units XML form (always \`B\` bytes) and PUTs to \`/gwc/rest/diskquota.xml\`.
2. **GWC returns 500 (not 404) with body \`"Unknown layer: ..."\`** for unknown layers on \`Layers.Get\`. Integration test accepts either \`ErrServerError\` or \`ErrNotFound\`; unit test verifies the strict 404→\`ErrNotFound\` mapping separately.
3. **\`/gwc/rest/seed.json\`** returns \`{"long-array-array":[[...]]}\` — a positional 5-element array per task. \`SeedStatus.UnmarshalJSON\` decodes it into a typed \`[]SeedTask\` with named fields.

### URL prefix

\`/gwc/rest/\` lives outside the \`/rest/\` catalog tree. The existing \`coreAdapter.URL\` helper joins arbitrary path segments with no forced prefix, so \`c.core.URL("gwc", "rest", "layers")\` works.

## Tests

- Unit tests for every method: List flat-array, Get XML decode, Put XML body, Delete verb, Submit body envelope + auto-fill of name, Status long-array-array unmarshal (populated + empty), \`SeedTaskStatus.String\` enum mapping, KillAll form-encoded body, DiskQuota class-name JSON envelope on GET, DiskQuota XML body shape on PUT (asserts \`value\`/\`units\` and forbids \`<bytes>\`), validation, \`ErrNotFound\` mapping.
- Integration tests: \`List\`, \`Get\` on \`topp:states\`, "unknown layer" 500-or-404, \`Submit\` truncate (zoom 0–2), \`Status\`, \`DiskQuota\` round-trip with cleanup.
- Godoc \`Example_*\` on every public method.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 20 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [x] **Integration tests run locally** against live GeoServer 2.28.0 before push (per the local-integration-first rule); the DiskQuota XML quirk and the 500-not-404 quirk were caught and fixed in the local run, not in CI.
- [ ] CI: 7 required checks + CodeQL pass on both 2.27.4 LTS and 2.28.0 stable

## Roadmap

**Four of five gaps shipped.** Remaining: Importer extension (#5 in the plan).