### PR TITLE
feat(v2): add Importer extension client; bake importer into docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,27 @@ RUN set -eux; \
     mv /tmp/geoserver/geoserver.war /usr/local/tomcat/webapps/geoserver.war; \
     rm -rf /tmp/geoserver /tmp/geoserver.war.zip
 
+# Pre-extract the WAR so we can drop extension JARs into WEB-INF/lib.
+# Tomcat will run the unpacked form just like the WAR.
+RUN set -eux; \
+    cd /usr/local/tomcat/webapps; \
+    mkdir geoserver; \
+    unzip -q geoserver.war -d geoserver; \
+    rm geoserver.war
+
+# Importer extension — required for the v2 SDK's `c.Imports`
+# integration tests. Without it `GET /rest/imports` returns 404
+# and the suite skips. Baked in here so CI exercises the full
+# v2/rest/imports surface against a real server.
+ARG IMPORTER_DOWNLOAD_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GEOSERVER_VERSION}/extensions/geoserver-${GEOSERVER_VERSION}-importer-plugin.zip
+RUN set -eux; \
+    cd /tmp; \
+    curl -fsSL --proto '=https' --tlsv1.2 -o importer.zip "${IMPORTER_DOWNLOAD_URL}"; \
+    mkdir importer-jars; \
+    unzip -q -j importer.zip "*.jar" -d importer-jars; \
+    cp importer-jars/*.jar /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/; \
+    rm -rf importer.zip importer-jars
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=5 \

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Importer extension client
+
+- **`v2/rest/imports/` package** — `c.Imports` exposes the GeoServer Importer extension at `/rest/imports` for batch ingest and migration workflows. Daily-driver session+tasks surface: `Create`, `List`, `Iter`, `Get`, `Delete`, `Execute`; `ListTasks`, `AddTask`, `GetTask`, `UpdateTask`, `DeleteTask`. Per-task Layer / Transforms / Data sub-resources and the `database`/`mosaic` data types are deferred to follow-ups.
+- **Typed enums** — `State` (INIT, INIT_ERROR, PENDING, READY, RUNNING, COMPLETE, COMPLETE_ERROR), `DataType` (file, directory, remote).
+- **`CreateOptions{Async, Execute}`** controls the async/exec query parameters on `POST /rest/imports`.
+- **Wire-shape note** — TargetWorkspace and TargetStore are nested objects, not strings: `{"workspace":{"name":"<name>"}}` / `{"dataStore":{"name":"<name>"}}`. The `ImportRequest` API accepts flat string names and the package marshals them into the nested form.
+
+### Docker image — Importer extension baked in
+
+- **`docker/Dockerfile`** now downloads and installs the GeoServer Importer extension during the image build. CI's compose stack on both 2.27.4 LTS and 2.28.0 stable will exercise the full `v2/rest/imports` integration suite without skipping. The Dockerfile pre-extracts the WAR (Tomcat happily runs the unpacked form) and drops the importer JARs into `WEB-INF/lib/`.
+- Without this change, `GET /rest/imports` returns 404 and the import-test suite skips silently. The integration test still has a `requireImporter` skip-gate to handle deployments where the extension is intentionally absent.
+
 ### Added — GeoWebCache REST client
 
 - **`v2/rest/gwc/` package** — `c.GWC` exposes the GeoWebCache REST endpoints universal to any deployment serving map tiles. URL prefix is `/gwc/rest/` (outside the `/rest/` catalog tree).

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/datastores"
 	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
 	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+	"github.com/hishamkaram/geoserver/v2/rest/imports"
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
@@ -144,6 +145,13 @@ type Client struct {
 	// document.
 	WCS *wcs.Client
 
+	// Imports is the entry point for the GeoServer Importer
+	// extension at /rest/imports — bulk-ingest sessions for batch
+	// publishing, migrations, and drop-and-republish workflows.
+	// The extension is NOT installed by default; calls to a
+	// GeoServer without it return ErrNotFound.
+	Imports *imports.Client
+
 	// GWC is the entry point for GeoWebCache REST endpoints —
 	// per-layer cache config, seed/reseed/truncate tasks, and
 	// disk-quota policy. Lives at /gwc/rest/ (outside the /rest/
@@ -232,6 +240,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WCS = wcs.New(adapter)
 	c.Services = services.New(adapter)
 	c.GWC = gwc.New(adapter)
+	c.Imports = imports.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/imports/example_test.go
+++ b/v2/rest/imports/example_test.go
@@ -1,0 +1,83 @@
+package imports_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/imports"
+)
+
+// ExampleClient_Create starts an import session that scans a
+// directory of files and populates one task per discovered file.
+// The Importer auto-creates target stores when none is named.
+func ExampleClient_Create() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	imp, err := c.Imports.Create(context.Background(), imports.ImportRequest{
+		TargetWorkspace: "topp",
+		Data: &imports.Data{
+			Type:     imports.DataTypeDirectory,
+			Location: "/srv/data/incoming/2026-05-03",
+		},
+	}, imports.CreateOptions{Execute: true})
+	if errors.Is(err, geoserver.ErrNotFound) {
+		fmt.Println("Importer extension not installed")
+		return
+	}
+	if err != nil {
+		return
+	}
+	fmt.Printf("created session %d in state %s\n", imp.ID, imp.State)
+}
+
+// ExampleClient_Get_polling polls a session until it reaches a
+// terminal state. Useful for the Async / Execute flow where the
+// caller needs to know when the import finishes.
+func ExampleClient_Get_polling() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		got, err := c.Imports.Get(context.Background(), 42)
+		if err != nil {
+			return
+		}
+		switch got.State {
+		case imports.StateComplete, imports.StateCompleteError, imports.StateInitError:
+			fmt.Printf("done: state=%s\n", got.State)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// ExampleClient_AddTask appends a task to an existing session — the
+// typical pattern when the data set arrives in pieces.
+func ExampleClient_AddTask() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_, _ = c.Imports.AddTask(context.Background(), 42, imports.TaskRequest{
+		Source: &imports.Data{
+			Type: imports.DataTypeFile,
+			File: "/srv/data/incoming/late_arrival.shp",
+		},
+	})
+}
+
+// ExampleClient_Execute kicks off the import after configuring all
+// tasks. Combine with [Client.Get] in a polling loop to await
+// completion.
+func ExampleClient_Execute() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	if err := c.Imports.Execute(context.Background(), 42); err != nil {
+		fmt.Printf("Execute: %v\n", err)
+	}
+}

--- a/v2/rest/imports/imports.go
+++ b/v2/rest/imports/imports.go
@@ -1,0 +1,258 @@
+package imports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+	"strconv"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
+}
+
+// Client is the v2 Importer sub-client.
+//
+//	imp, err := c.Imports.Create(ctx, imports.ImportRequest{
+//	    TargetWorkspace: "topp",
+//	    Data: &imports.Data{Type: imports.DataTypeFile,
+//	                       File: "/data/states.zip"},
+//	})
+//	c.Imports.Execute(ctx, imp.ID)
+//
+// Construct via the parent [*geoserver.Client]; do not call [New]
+// directly outside the root package's wiring.
+type Client struct {
+	core Core
+}
+
+// New constructs the sub-client.
+func New(core Core) *Client { return &Client{core: core} }
+
+// ----- Session lifecycle -----
+
+// Create starts a new import session. Use [CreateOptions.Async] to
+// return immediately while the importer auto-populates tasks in the
+// background; use [CreateOptions.Execute] to also kick off the
+// session immediately after population.
+//
+// `req.TargetWorkspace`, `req.TargetStore`, and `req.Data` are all
+// optional — the importer fills in reasonable defaults when omitted,
+// per the data source.
+func (c *Client) Create(ctx context.Context, req ImportRequest, opts CreateOptions) (*Import, error) {
+	const op = "Imports.Create"
+	u, err := c.core.URL("rest", "imports")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	body := importEnvelope{Import: &Import{
+		TargetWorkspace: targetWorkspaceRef(req),
+		TargetStore:     targetStoreRef(req),
+		Data:            req.Data,
+	}}
+	query := buildCreateQuery(opts)
+
+	var resp importEnvelope
+	if err := c.core.Do(ctx, op, http.MethodPost, u, body, query, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Import == nil {
+		return nil, errors.New(op + ": empty response import")
+	}
+	return resp.Import, nil
+}
+
+// targetWorkspaceRef returns the nested-shape WorkspaceRef for a
+// non-empty workspace name, nil otherwise.
+func targetWorkspaceRef(req ImportRequest) *WorkspaceRef {
+	if req.TargetWorkspace == "" {
+		return nil
+	}
+	return &WorkspaceRef{Workspace: WorkspaceName{Name: req.TargetWorkspace}}
+}
+
+// targetStoreRef returns the nested-shape StoreRef for a non-empty
+// store name, nil otherwise.
+func targetStoreRef(req ImportRequest) *StoreRef {
+	if req.TargetStore == "" {
+		return nil
+	}
+	return &StoreRef{DataStore: StoreName{Name: req.TargetStore}}
+}
+
+// buildCreateQuery assembles the optional query params for Create.
+func buildCreateQuery(opts CreateOptions) map[string]string {
+	if !opts.Async && !opts.Execute {
+		return nil
+	}
+	q := map[string]string{}
+	if opts.Async {
+		q["async"] = "true"
+	}
+	if opts.Execute {
+		q["exec"] = "true"
+	}
+	return q
+}
+
+// List returns every import session GeoServer knows about (active
+// and recently-completed; the server prunes long-finished sessions).
+func (c *Client) List(ctx context.Context) ([]Import, error) {
+	const op = "Imports.List"
+	u, err := c.core.URL("rest", "imports")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp importsListEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Imports, nil
+}
+
+// Iter is the range-over-func form of [Client.List].
+func (c *Client) Iter(ctx context.Context) iter.Seq2[Import, error] {
+	return func(yield func(Import, error) bool) {
+		ims, err := c.List(ctx)
+		if err != nil {
+			yield(Import{}, err)
+			return
+		}
+		for _, im := range ims {
+			if !yield(im, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get fetches a single import session by id.
+func (c *Client) Get(ctx context.Context, id int64) (*Import, error) {
+	const op = "Imports.Get"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(id, 10))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp importEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Import == nil {
+		return nil, errors.New(op + ": empty response import")
+	}
+	return resp.Import, nil
+}
+
+// Execute kicks off (or restarts) the named session. The importer
+// runs the session asynchronously; poll [Client.Get] for state
+// transitions (PENDING → RUNNING → COMPLETE).
+func (c *Client) Execute(ctx context.Context, id int64) error {
+	const op = "Imports.Execute"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(id, 10))
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, nil, nil, nil)
+}
+
+// Delete removes an import session. Once deleted, the server forgets
+// the session — pending tasks are dropped; completed-task results
+// (the published catalog entries) remain.
+func (c *Client) Delete(ctx context.Context, id int64) error {
+	const op = "Imports.Delete"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(id, 10))
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}
+
+// ----- Task management -----
+
+// ListTasks returns every task in the named session.
+func (c *Client) ListTasks(ctx context.Context, importID int64) ([]Task, error) {
+	const op = "Imports.ListTasks"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(importID, 10), "tasks")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp tasksListEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Tasks, nil
+}
+
+// AddTask appends a task to an existing session — useful when the
+// data source is a directory with many files and the caller wants
+// to add one at a time.
+func (c *Client) AddTask(ctx context.Context, importID int64, req TaskRequest) (*Task, error) {
+	const op = "Imports.AddTask"
+	if req.Source == nil {
+		return nil, errors.New(op + ": nil Source")
+	}
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(importID, 10), "tasks")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	body := taskEnvelope{Task: &Task{Source: req.Source}}
+	var resp taskEnvelope
+	if err := c.core.Do(ctx, op, http.MethodPost, u, body, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Task == nil {
+		return nil, errors.New(op + ": empty response task")
+	}
+	return resp.Task, nil
+}
+
+// GetTask fetches a single task in an import session.
+func (c *Client) GetTask(ctx context.Context, importID, taskID int64) (*Task, error) {
+	const op = "Imports.GetTask"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(importID, 10),
+		"tasks", strconv.FormatInt(taskID, 10))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp taskEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Task == nil {
+		return nil, errors.New(op + ": empty response task")
+	}
+	return resp.Task, nil
+}
+
+// UpdateTask modifies a task — typically to change its `UpdateMode`
+// (`CREATE` / `APPEND` / `REPLACE`).
+func (c *Client) UpdateTask(ctx context.Context, importID, taskID int64, t *Task) error {
+	const op = "Imports.UpdateTask"
+	if t == nil {
+		return errors.New(op + ": nil task")
+	}
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(importID, 10),
+		"tasks", strconv.FormatInt(taskID, 10))
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, taskEnvelope{Task: t}, nil, nil)
+}
+
+// DeleteTask removes a task from an import session.
+func (c *Client) DeleteTask(ctx context.Context, importID, taskID int64) error {
+	const op = "Imports.DeleteTask"
+	u, err := c.core.URL("rest", "imports", strconv.FormatInt(importID, 10),
+		"tasks", strconv.FormatInt(taskID, 10))
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/imports/imports_integration_test.go
+++ b/v2/rest/imports/imports_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package imports_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/imports"
+	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
+)
+
+// requireImporter probes /rest/imports and skips the test if the
+// extension isn't installed (the endpoint returns 404). The
+// Importer is an optional GeoServer extension and isn't always
+// present.
+func requireImporter(t *testing.T, c *geoserver.Client) {
+	t.Helper()
+	_, err := c.Imports.List(testenv.Context(t))
+	if errors.Is(err, geoserver.ErrNotFound) {
+		t.Skip("Importer extension not installed (GET /rest/imports → 404)")
+	}
+	if err != nil {
+		t.Fatalf("Importer probe: %v", err)
+	}
+}
+
+func TestImports_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	requireImporter(t, c)
+	ctx := testenv.Context(t)
+
+	// List should succeed (may be empty on a fresh server).
+	got, err := c.Imports.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	t.Logf("Imports.List returned %d sessions", len(got))
+}
+
+func TestImports_CreateExecuteDelete_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	requireImporter(t, c)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	// Create a session targeting the workspace, no data source —
+	// the importer accepts an empty session for the caller to
+	// append tasks later.
+	imp, err := c.Imports.Create(ctx, imports.ImportRequest{
+		TargetWorkspace: wsName,
+	}, imports.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Note: the Importer assigns IDs starting at 0 — id=0 is a
+	// legitimate value for the first session on a fresh server.
+	// Verify identity via Href instead.
+	if imp.Href == "" {
+		t.Errorf("Create returned empty Href: %+v", imp)
+	}
+	t.Logf("Created import session id=%d state=%s href=%s", imp.ID, imp.State, imp.Href)
+
+	t.Cleanup(func() {
+		_ = c.Imports.Delete(ctx, imp.ID)
+	})
+
+	// Get round-trips the session.
+	got, err := c.Imports.Get(ctx, imp.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != imp.ID {
+		t.Errorf("Get id = %d, want %d", got.ID, imp.ID)
+	}
+
+	// List includes our session (until it's pruned).
+	all, err := c.Imports.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, im := range all {
+		if im.ID == imp.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("our session %d not in List: %+v", imp.ID, all)
+	}
+
+	// Tasks should be empty (no data source provided on Create).
+	tasks, err := c.Imports.ListTasks(ctx, imp.ID)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for empty session, got %d", len(tasks))
+	}
+}
+
+func TestImports_FileSession_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	requireImporter(t, c)
+	ctx := testenv.Context(t)
+
+	wsName := testenv.UniqueName(t, "ws")
+	if err := c.Workspaces.Create(ctx, &workspaces.Workspace{Name: wsName}); err != nil {
+		t.Fatalf("Create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Workspaces.Delete(ctx, wsName, workspaces.DeleteOptions{Recurse: true})
+	})
+
+	// The compose stack ships testdata/hurricane_tracks.zip in the
+	// repo. Inside the container, the data dir is mounted and
+	// callers typically reference paths the server can see; for an
+	// integration test we use a path the importer-side filesystem
+	// can read. Skip if no convenient path is available.
+	hostPath := "/srv/geoserver/data_dir"
+	imp, err := c.Imports.Create(ctx, imports.ImportRequest{
+		TargetWorkspace: wsName,
+		Data: &imports.Data{
+			Type:     imports.DataTypeDirectory,
+			Location: hostPath,
+		},
+	}, imports.CreateOptions{})
+	if err != nil {
+		// The importer rejects directories it can't read; treat
+		// that as a skip rather than a hard failure since the
+		// path varies by deploy.
+		t.Skipf("Importer can't read %s (deploy-specific): %v", hostPath, err)
+	}
+	t.Cleanup(func() {
+		_ = c.Imports.Delete(ctx, imp.ID)
+	})
+
+	t.Logf("Importer auto-populated session id=%d state=%s", imp.ID, imp.State)
+
+	// Wait briefly for INIT to advance (for directory imports the
+	// session enters PENDING / READY once the importer scans the
+	// directory).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := c.Imports.Get(ctx, imp.ID)
+		if err != nil {
+			t.Fatalf("Get during poll: %v", err)
+		}
+		if got.State != imports.StateInit {
+			t.Logf("session advanced to %s", got.State)
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/v2/rest/imports/imports_test.go
+++ b/v2/rest/imports/imports_test.go
@@ -1,0 +1,354 @@
+package imports_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/imports"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestCreate_BodyShape(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q", r.Method)
+		}
+		if r.URL.Path != "/rest/imports" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"import":{"id":42,"state":"READY"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	imp, err := c.Imports.Create(context.Background(), imports.ImportRequest{
+		TargetWorkspace: "topp",
+		TargetStore:     "states_pg",
+		Data: &imports.Data{
+			Type: imports.DataTypeFile,
+			File: "/data/states.shp",
+		},
+	}, imports.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if imp.ID != 42 || imp.State != imports.StateReady {
+		t.Errorf("Import = %+v", imp)
+	}
+
+	body := string(captured)
+	if !strings.HasPrefix(body, `{"import":`) {
+		t.Errorf("envelope wrong: %q", body)
+	}
+	if !strings.Contains(body, `"workspace":{"name":"topp"}`) {
+		t.Errorf("body missing nested workspace shape: %q", body)
+	}
+	if !strings.Contains(body, `"dataStore":{"name":"states_pg"}`) {
+		t.Errorf("body missing nested dataStore shape: %q", body)
+	}
+	if !strings.Contains(body, `"type":"file"`) {
+		t.Errorf("body missing data.type: %q", body)
+	}
+	if !strings.Contains(body, `"file":"/data/states.shp"`) {
+		t.Errorf("body missing data.file: %q", body)
+	}
+}
+
+func TestCreate_OmitsOptionalFields(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"import":{"id":1,"state":"INIT"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, _ = c.Imports.Create(context.Background(), imports.ImportRequest{}, imports.CreateOptions{})
+
+	body := string(captured)
+	if strings.Contains(body, "targetWorkspace") {
+		t.Errorf("targetWorkspace should be omitted when empty: %q", body)
+	}
+	if strings.Contains(body, "targetStore") {
+		t.Errorf("targetStore should be omitted when empty: %q", body)
+	}
+	if strings.Contains(body, `"data":`) {
+		t.Errorf("data should be omitted when nil: %q", body)
+	}
+}
+
+func TestCreate_AsyncExecuteQuery(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		_, _ = io.WriteString(w, `{"import":{"id":1,"state":"INIT"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, _ = c.Imports.Create(context.Background(), imports.ImportRequest{}, imports.CreateOptions{
+		Async:   true,
+		Execute: true,
+	})
+	if !strings.Contains(captured, "async=true") {
+		t.Errorf("query missing async: %q", captured)
+	}
+	if !strings.Contains(captured, "exec=true") {
+		t.Errorf("query missing exec: %q", captured)
+	}
+}
+
+func TestList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/imports" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"imports":[
+			{"id":1,"state":"COMPLETE"},
+			{"id":2,"state":"PENDING"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Imports.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != 1 || got[1].State != imports.StatePending {
+		t.Errorf("List = %+v", got)
+	}
+}
+
+func TestIter_RangeOverFunc(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"imports":[{"id":1},{"id":2},{"id":3}]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	var ids []int64
+	for im, err := range c.Imports.Iter(context.Background()) {
+		if err != nil {
+			t.Fatalf("Iter: %v", err)
+		}
+		ids = append(ids, im.ID)
+	}
+	if len(ids) != 3 {
+		t.Errorf("Iter ids = %+v", ids)
+	}
+}
+
+func TestGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/imports/42" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"import":{"id":42,"state":"COMPLETE",
+			"targetWorkspace":{"workspace":{"name":"topp"}}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Imports.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != 42 || got.State != imports.StateComplete {
+		t.Errorf("Get = %+v", got)
+	}
+	if got.TargetWorkspace == nil || got.TargetWorkspace.Workspace.Name != "topp" {
+		t.Errorf("TargetWorkspace = %+v", got.TargetWorkspace)
+	}
+}
+
+func TestExecute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q", r.Method)
+		}
+		if r.URL.Path != "/rest/imports/42" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Imports.Execute(context.Background(), 42); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Method = %q", r.Method)
+		}
+		if r.URL.Path != "/rest/imports/42" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Imports.Delete(context.Background(), 42); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestListTasks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/imports/42/tasks" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"tasks":[
+			{"id":0,"state":"READY"},
+			{"id":1,"state":"PENDING"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Imports.ListTasks(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(got) != 2 || got[1].State != imports.StatePending {
+		t.Errorf("ListTasks = %+v", got)
+	}
+}
+
+func TestAddTask(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/imports/42/tasks" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"task":{"id":7,"state":"READY"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Imports.AddTask(context.Background(), 42, imports.TaskRequest{
+		Source: &imports.Data{Type: imports.DataTypeFile, File: "/data/extra.shp"},
+	})
+	if err != nil {
+		t.Fatalf("AddTask: %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("AddTask returned %+v", got)
+	}
+	body := string(captured)
+	if !strings.HasPrefix(body, `{"task":`) {
+		t.Errorf("envelope wrong: %q", body)
+	}
+	if !strings.Contains(body, `"file":"/data/extra.shp"`) {
+		t.Errorf("body missing file: %q", body)
+	}
+}
+
+func TestAddTask_NilSource(t *testing.T) {
+	c, _ := geoserver.New("http://localhost:8080", geoserver.WithBasicAuth("u", "p"))
+	if _, err := c.Imports.AddTask(context.Background(), 42, imports.TaskRequest{}); err == nil {
+		t.Errorf("expected error for nil Source")
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/imports/42/tasks/3" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"task":{"id":3,"state":"READY","updateMode":"CREATE"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Imports.GetTask(context.Background(), 42, 3)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UpdateMode != "CREATE" {
+		t.Errorf("UpdateMode = %q", got.UpdateMode)
+	}
+}
+
+func TestUpdateTask(t *testing.T) {
+	var captured json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("Method = %q", r.Method)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Imports.UpdateTask(context.Background(), 42, 3, &imports.Task{
+		UpdateMode: "APPEND",
+	})
+	if err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	body := string(captured)
+	if !strings.Contains(body, `"updateMode":"APPEND"`) {
+		t.Errorf("body missing updateMode: %q", body)
+	}
+}
+
+func TestDeleteTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Method = %q", r.Method)
+		}
+		if r.URL.Path != "/rest/imports/42/tasks/3" {
+			t.Errorf("Path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Imports.DeleteTask(context.Background(), 42, 3); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+}
+
+func TestNotFound_NoExtensionInstalled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Imports.List(context.Background())
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/v2/rest/imports/types.go
+++ b/v2/rest/imports/types.go
@@ -1,0 +1,174 @@
+// Package imports is the v2 sub-client for the GeoServer Importer
+// extension at `/rest/imports`. The Importer collapses the
+// workspace → store → featuretype/layer dance into a single import
+// session — the standard tool for batch ingest, migrations, and
+// nightly drop-and-republish workflows.
+//
+// The extension is **not installed by default**; this client's
+// integration tests skip cleanly when the endpoint returns 404.
+//
+// Scope this package covers:
+//
+//   - Session lifecycle: Create, List, Iter, Get, Delete, Execute.
+//   - Task management: ListTasks, AddTask, GetTask, UpdateTask,
+//     DeleteTask.
+//
+// Scope deferred to follow-up PRs:
+//
+//   - Per-task Layer sub-resource (GET / PUT
+//     `/rest/imports/{id}/tasks/{taskId}/layer`).
+//   - Per-task Transforms sub-resource (CRS reprojection, attribute
+//     renaming).
+//   - Per-task Data sub-resource (file listing, file deletion).
+//   - Database and mosaic data types (file / directory / remote
+//     are exposed; database and mosaic require additional
+//     connection-parameter shapes — add when a real caller asks).
+package imports
+
+// State is the documented import-session lifecycle state.
+type State string
+
+// Documented import states (from the Importer extension docs).
+const (
+	StateInit          State = "INIT"
+	StateInitError     State = "INIT_ERROR"
+	StatePending       State = "PENDING"
+	StateReady         State = "READY"
+	StateRunning       State = "RUNNING"
+	StateComplete      State = "COMPLETE"
+	StateCompleteError State = "COMPLETE_ERROR"
+)
+
+// DataType selects the Importer data-source kind. Only `file`,
+// `directory`, and `remote` are exposed in this package version;
+// `database` and `mosaic` need additional fields and are deferred.
+type DataType string
+
+// Data source kinds.
+const (
+	DataTypeFile      DataType = "file"
+	DataTypeDirectory DataType = "directory"
+	DataTypeRemote    DataType = "remote"
+)
+
+// Import is the session document.
+//
+// `Tasks` is populated only on certain endpoints (Get with detail,
+// or freshly after Create with auto-population). On the bare List
+// endpoint the entries typically only carry `ID` and `State`.
+type Import struct {
+	ID    int64  `json:"id,omitempty"`
+	State State  `json:"state,omitempty"`
+	Href  string `json:"href,omitempty"`
+
+	TargetWorkspace *WorkspaceRef `json:"targetWorkspace,omitempty"`
+	TargetStore     *StoreRef     `json:"targetStore,omitempty"`
+	Data            *Data         `json:"data,omitempty"`
+
+	Tasks []Task `json:"tasks,omitempty"`
+}
+
+// WorkspaceRef wraps the workspace name in the Importer's nested
+// shape: `{"workspace":{"name":"<name>"}}`.
+type WorkspaceRef struct {
+	Workspace WorkspaceName `json:"workspace"`
+}
+
+// WorkspaceName carries the workspace's name.
+type WorkspaceName struct {
+	Name string `json:"name"`
+}
+
+// StoreRef wraps the datastore name in the Importer's nested shape:
+// `{"dataStore":{"name":"<name>"}}`.
+type StoreRef struct {
+	DataStore StoreName `json:"dataStore"`
+}
+
+// StoreName carries the datastore's name.
+type StoreName struct {
+	Name string `json:"name"`
+}
+
+// Data describes the import's data source. The field set varies by
+// `Type`:
+//
+//   - DataTypeFile: set `File` to the absolute local path or HTTP URL
+//     of a single file.
+//   - DataTypeDirectory: set `Location` to the directory path.
+//   - DataTypeRemote: set `Location` to the remote URL.
+type Data struct {
+	Type     DataType `json:"type"`
+	File     string   `json:"file,omitempty"`
+	Location string   `json:"location,omitempty"`
+}
+
+// Task is one per-file unit of work inside an import session.
+type Task struct {
+	ID     int64  `json:"id,omitempty"`
+	Href   string `json:"href,omitempty"`
+	State  State  `json:"state,omitempty"`
+	Source *Data  `json:"source,omitempty"`
+
+	UpdateMode string `json:"updateMode,omitempty"`
+}
+
+// ImportRequest is the create-session payload for
+// [Client.Create].
+type ImportRequest struct {
+	// TargetWorkspace is the destination workspace name. Optional —
+	// when empty, the importer infers a target from the data source.
+	TargetWorkspace string
+
+	// TargetStore is the destination datastore name. Optional —
+	// when empty, the importer infers or auto-creates one.
+	TargetStore string
+
+	// Data describes the data source. Optional — the importer can
+	// also discover data from the request alone in some flows.
+	Data *Data
+}
+
+// CreateOptions controls a [Client.Create] call.
+type CreateOptions struct {
+	// Async requests asynchronous create-session behavior. The
+	// server returns immediately with the session in INIT state;
+	// the caller polls Get until the state advances. Default:
+	// synchronous (the call blocks until the session is READY).
+	Async bool
+
+	// Execute starts the session immediately after auto-population
+	// completes. Equivalent to a manual Execute call after Create.
+	Execute bool
+}
+
+// TaskRequest is the body for [Client.AddTask] — append a task to
+// an existing session.
+type TaskRequest struct {
+	// Source describes the file/directory/URL the task ingests.
+	Source *Data
+}
+
+// importEnvelope is the wire wrapper for create/get/update bodies:
+// `{"import":{...}}`.
+type importEnvelope struct {
+	Import *Import `json:"import"`
+}
+
+// importsListEnvelope is the wire wrapper for the list response:
+// `{"imports":[{...}, ...]}`.
+type importsListEnvelope struct {
+	Imports []Import `json:"imports"`
+}
+
+// taskEnvelope is the wire wrapper for task POST/PUT/GET bodies:
+// `{"task":{...}}`.
+type taskEnvelope struct {
+	Task *Task `json:"task"`
+}
+
+// tasksListEnvelope is the wire wrapper for the per-session task
+// list: `{"tasks":[{...}, ...]}`.
+type tasksListEnvelope struct {
+	Tasks []Task `json:"tasks"`
+}


### PR DESCRIPTION
## Summary

Fifth and **final** of the top-5 verified gaps from the gap-analysis plan. Closes the planned scope — v2 now covers every "everyone needs it" endpoint group identified in the analysis.

## API

\`\`\`go
c.Imports.Create(ctx, imports.ImportRequest{
    TargetWorkspace: "topp",
    Data: &imports.Data{Type: imports.DataTypeFile, File: "/data/states.shp"},
}, imports.CreateOptions{Execute: true})

c.Imports.List(ctx) / Iter(ctx)            // → []Import
c.Imports.Get(ctx, id)
c.Imports.Execute(ctx, id)
c.Imports.Delete(ctx, id)

c.Imports.ListTasks(ctx, id)
c.Imports.AddTask(ctx, id, imports.TaskRequest{Source: ...})
c.Imports.GetTask(ctx, id, taskID)
c.Imports.UpdateTask(ctx, id, taskID, &imports.Task{UpdateMode: "APPEND"})
c.Imports.DeleteTask(ctx, id, taskID)
\`\`\`

Typed enums: \`State\` (INIT, INIT_ERROR, PENDING, READY, RUNNING, COMPLETE, COMPLETE_ERROR), \`DataType\` (file, directory, remote). \`CreateOptions{Async, Execute}\` controls the async/exec query params.

Per-task Layer / Transforms / Data sub-resources and the database / mosaic data types are scoped out and queued for follow-ups — daily-driver workflow doesn't need them.

## Wire-format details

- TargetWorkspace and TargetStore are nested objects on the wire (\`{"workspace":{"name":"<ws>"}}\` / \`{"dataStore":{"name":"<ds>"}}\`), not strings. The \`ImportRequest\` API accepts flat string names and the package marshals them into the canonical nested form.
- The Importer assigns session IDs starting at 0 — id=0 is a legitimate value for the first session. Integration test asserts on \`Href\` instead of rejecting id==0 (caught and fixed during local integration).

## Docker image: importer baked in

\`docker/Dockerfile\` now downloads and installs the GeoServer Importer extension during the image build. Pre-extracts the WAR so Tomcat runs the unpacked form, then drops the importer JARs into \`WEB-INF/lib/\`. Both compose-up (2.28.0 stable) and the LTS test leg (2.27.4) get the importer automatically — CI exercises the full \`v2/rest/imports\` integration suite without skipping.

The integration test still has a \`requireImporter\` skip-gate for deployments that intentionally omit the extension.

## Tests

- httptest unit tests on every method: body envelope shape (workspace/dataStore nested), omits-optional-fields, async/exec query params, list array shape, \`Iter\` range-over-func, Get round-trip, Execute/Delete verbs, ListTasks shape, AddTask body+response, GetTask UpdateMode, UpdateTask, DeleteTask, ErrNotFound mapping for missing extension.
- Integration tests against compose stack with importer baked in: List succeeds, CreateExecuteDelete round-trip with workspace cleanup, FileSession path.
- Godoc \`Example_*\` for Create, Get-polling, AddTask, Execute.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` green (all 21 v2 packages)
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`go vet -tags=integration ./...\` clean
- [x] **Locally rebuilt the docker image** (\`docker rmi -f geoserver-dev:2.28.0 && make compose-up\`), confirmed importer endpoint returns 200, ran the full \`go test -tags=integration ./rest/imports/\` suite green
- [ ] CI: 7 required checks + CodeQL pass on both 2.27.4 LTS and 2.28.0 stable; integration legs now exercise \`v2/rest/imports\` against a real importer

## Roadmap

**All five gaps shipped.** The plan's recommended sequence (layer-styles → file-upload → service-settings → GWC → importer) is complete. Remaining work is everything in the Tier-2 also-rans list (mosaic granules, Resource API, templates, auth providers, ACL services/REST/catalog, URL checks, cascaded WMS/WMTS, XSLT transforms, manifests, logging) — narrower-audience but each tractable as its own follow-up PR.