### PR TITLE
feat(v2): add ACL services / REST / catalog sub-clients

### DIFF
--- a/docker/env/geoserver.env
+++ b/docker/env/geoserver.env
@@ -5,3 +5,11 @@ GEOSERVER_ADMIN_PASSWORD=geoserver
 INITIAL_MEMORY=2G
 MAXIMUM_MEMORY=4G
 XFRAME_OPTIONS=false
+# Disable Spring Security's StrictHttpFirewall in the test stack so the
+# v2 SDK can exercise endpoints whose URL paths legitimately contain ";"
+# (e.g. paths under /rest/security/acl/rest). Production deployments
+# that need those endpoints must take the same step (or accept the
+# limitation that REST ACL rule deletion via REST is unavailable
+# without further Spring Security configuration; see
+# v2/rest/acl/rest.go for the documented wire-format limit).
+GEOSERVER_USE_STRICT_FIREWALL=false

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — ACL services / REST / catalog
+
+Closes the security tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). The v2 ACL sub-client previously covered only `c.ACL.Layers()`; this round adds the three sibling surfaces under `/rest/security/acl/`.
+
+- **`c.ACL.Services()`** — service ACL rules (`/rest/security/acl/services`). Rule key is the dotted pair `service.operation` (e.g. `wms.GetMap`, `*.*`). `List` / `Add` / `Update` / `Delete` mirror the layers shape.
+- **`c.ACL.REST()`** — REST ACL rules (`/rest/security/acl/rest`). Rule key is `<URL Ant pattern>:<HTTP methods>` in body form, `<pattern>;<methods>` in URL-path form for DELETE. `List` / `Add` / `Update` / `Delete`.
+- **`c.ACL.Catalog()`** — singleton catalog mode (`/rest/security/acl/catalog`). `Get` / `Update` (HIDE / MIXED / CHALLENGE) plus `Reload` (`/rest/security/acl/catalog/reload`) to reload the security configuration from disk.
+- **`c.ACL.Layers().Update`** — additive PUT method to edit an existing layer rule's role list (matches the new shape on Services and REST). Previously only Add (POST) was wired.
+- **Typed enums and rule structs** — `ServiceRule`, `RESTRule`, `CatalogMode` (with `CatalogModeHide` / `CatalogModeMixed` / `CatalogModeChallenge`); plus `Encode` / `Decode` helpers for round-tripping the wire format.
+
+### Wire-format quirks (acl package)
+
+- **Services validator forbids wildcard service + non-wildcard operation.** GeoServer rejects `{"*.GetMap":"..."}` with 422 "Invalid rule *.GetMap, when namespace is * then also layer must be *". Use either `*.*` (full wildcard) or a real `service.operation` pair (e.g. `wms.GetMap`).
+- **REST rule body uses `:` separator, URL path uses `;`.** GeoServer documents the body example as `"/**:GET":"ADMIN"` but the path-segment form for DELETE as `/**;GET`. `RESTRule.Encode` emits the body form; `RESTRule.EncodePathSegment` emits the URL form. `DecodeRESTRule` accepts both.
+- **REST DELETE is effectively non-functional on default GeoServer installs.** GeoServer's HTTP firewall (Spring Security) rejects URL paths containing `;` and `%2F` by default. `;` can be unblocked with `GEOSERVER_USE_STRICT_FIREWALL=false` (the dev/test docker stack now sets this); `%2F` requires Java-level Spring Security configuration that is not exposed via env vars or REST. `RESTClient.Delete` is wired for completeness but documented as requiring custom server configuration. `Add` / `List` / `Update` (which hit the list endpoint with no rule in URL) work against a default install. See `RESTClient` godoc for the full caveat.
+- **Dev/test docker image now disables `StrictHttpFirewall`.** `docker/env/geoserver.env` adds `GEOSERVER_USE_STRICT_FIREWALL=false` so the integration suite can exercise REST ACL endpoints. Production deployments retain the default strict firewall unless they opt in.
+
 ## [2.0.0-alpha.4] — 2026-05-03
 
 Fourth alpha. **Closes the planned "everyone needs it" REST API surface.** The narrower tier-2 backlog continues in [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Five focused PRs landed in sequence: layer–style associations, file-upload publishing on stores, per-service OWS settings (WMS/WFS/WCS/WMTS), GeoWebCache (layers + seed + diskquota), and the Importer extension. Dev/test docker image now bakes the importer plugin in. Public API may still refine before `v2.0.0` based on early-adopter feedback — no production guarantees yet.

--- a/v2/rest/acl/acl.go
+++ b/v2/rest/acl/acl.go
@@ -15,15 +15,14 @@ type Core interface {
 	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
 }
 
-// Client is the v2 ACL sub-client. The current surface is layer
-// ACLs; nested clients for service-level and catalog-level ACLs can
-// be added in follow-up PRs without breaking the existing API.
+// Client is the v2 ACL sub-client. It exposes four nested sub-clients:
+// [Client.Layers], [Client.Services], [Client.REST], and [Client.Catalog].
 //
 //	rules, _ := c.ACL.Layers().List(ctx, acl.ListOptions{})
-//	_ = c.ACL.Layers().Add(ctx, acl.Rule{
-//	    Workspace: "topp", Layer: "states",
-//	    Operation: acl.OpWrite, Roles: []string{"ROLE_EDITOR"},
+//	_ = c.ACL.Services().Add(ctx, acl.ServiceRule{
+//	    Service: "wms", Operation: "GetMap", Roles: []string{"ROLE_USER"},
 //	})
+//	mode, _ := c.ACL.Catalog().Get(ctx)
 type Client struct {
 	core Core
 }
@@ -37,6 +36,29 @@ func New(core Core) *Client {
 // roles can read / write / administer a given workspace.layer entity.
 func (c *Client) Layers() *LayersClient {
 	return &LayersClient{core: c.core}
+}
+
+// Services returns the service-ACL sub-client. Service ACLs control
+// which roles can invoke a given OWS operation (e.g. WMS GetMap, WFS
+// GetFeature). Rule key shape is "service.operation".
+func (c *Client) Services() *ServicesClient {
+	return &ServicesClient{core: c.core}
+}
+
+// REST returns the REST-ACL sub-client. REST ACLs control which
+// roles can hit a given URL pattern with a given set of HTTP methods.
+// Rule key shape is "<URL Ant pattern>:<HTTP methods>".
+func (c *Client) REST() *RESTClient {
+	return &RESTClient{core: c.core}
+}
+
+// Catalog returns the catalog-mode sub-client. The catalog mode
+// (HIDE / MIXED / CHALLENGE) controls how GeoServer advertises
+// secured layers in capabilities documents and how it responds to
+// access without the required privileges. The same client also
+// exposes the configuration reload endpoint.
+func (c *Client) Catalog() *CatalogClient {
+	return &CatalogClient{core: c.core}
 }
 
 // LayersClient operates on the /rest/security/acl/layers endpoint.
@@ -86,6 +108,24 @@ func (c *LayersClient) Add(ctx context.Context, rule Rule) error {
 	ruleStr, rolesStr := rule.Encode()
 	body := map[string]string{ruleStr: rolesStr}
 	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Update edits an existing layer ACL rule's role list. GeoServer's
+// PUT semantics require the rule to already exist; modifying a
+// non-existent rule fails with 409 Conflict (use [LayersClient.Add]
+// to create instead).
+func (c *LayersClient) Update(ctx context.Context, rule Rule) error {
+	const op = "ACL.Layers.Update"
+	if rule.Operation == "" {
+		return errors.New(op + ": empty Operation")
+	}
+	u, err := c.core.URL("rest", "security", "acl", "layers")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	ruleStr, rolesStr := rule.Encode()
+	body := map[string]string{ruleStr: rolesStr}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
 }
 
 // Delete removes a layer ACL rule. The rule is identified by its

--- a/v2/rest/acl/acl_integration_test.go
+++ b/v2/rest/acl/acl_integration_test.go
@@ -52,6 +52,29 @@ func TestACL_Layers_CRUD_Integration(t *testing.T) {
 		t.Fatalf("rule for %s.%s.r not found in List", wsName, layerName)
 	}
 
+	// Update the role list before deletion.
+	updatedRole := testenv.UniqueName(t, "ROLE")
+	updated := rule
+	updated.Roles = []string{roleName, updatedRole}
+	if err := c.ACL.Layers().Update(ctx, updated); err != nil {
+		t.Fatalf("Update ACL rule: %v", err)
+	}
+
+	rules, err = c.ACL.Layers().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List after Update: %v", err)
+	}
+	gotRoles := []string(nil)
+	for _, r := range rules {
+		if r.Workspace == wsName && r.Layer == layerName && r.Operation == acl.OpRead {
+			gotRoles = r.Roles
+			break
+		}
+	}
+	if len(gotRoles) != 2 {
+		t.Errorf("expected 2 roles after Update, got %v", gotRoles)
+	}
+
 	if err := c.ACL.Layers().Delete(ctx, rule); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}

--- a/v2/rest/acl/catalog.go
+++ b/v2/rest/acl/catalog.go
@@ -1,0 +1,65 @@
+package acl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// CatalogClient operates on the /rest/security/acl/catalog endpoint
+// and the related /rest/security/acl/catalog/reload endpoint.
+//
+// The catalog mode is a singleton configuration value — there is no
+// per-rule list shape here. Three modes are documented:
+// [CatalogModeHide], [CatalogModeMixed], [CatalogModeChallenge]. See
+// each constant's doc for the operational difference.
+type CatalogClient struct {
+	core Core
+}
+
+// catalogModeWire is the JSON envelope GeoServer uses for both GET
+// and PUT against /rest/security/acl/catalog.
+type catalogModeWire struct {
+	Mode CatalogMode `json:"mode"`
+}
+
+// Get returns the current catalog mode.
+func (c *CatalogClient) Get(ctx context.Context) (CatalogMode, error) {
+	const op = "ACL.Catalog.Get"
+	u, err := c.core.URL("rest", "security", "acl", "catalog")
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", op, err)
+	}
+	var out catalogModeWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &out); err != nil {
+		return "", err
+	}
+	return out.Mode, nil
+}
+
+// Update sets the catalog mode. mode must be one of
+// [CatalogModeHide], [CatalogModeMixed], or [CatalogModeChallenge];
+// other values are rejected by GeoServer with 422 Unprocessable
+// Entity.
+func (c *CatalogClient) Update(ctx context.Context, mode CatalogMode) error {
+	const op = "ACL.Catalog.Update"
+	u, err := c.core.URL("rest", "security", "acl", "catalog")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := catalogModeWire{Mode: mode}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// Reload reloads the GeoServer Security Manager catalog and
+// configuration from disk. Used after an external tool has modified
+// the on-disk security configuration. GeoServer accepts both PUT
+// and POST for this endpoint; this client uses POST.
+func (c *CatalogClient) Reload(ctx context.Context) error {
+	const op = "ACL.Catalog.Reload"
+	u, err := c.core.URL("rest", "security", "acl", "catalog", "reload")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, nil, nil, nil)
+}

--- a/v2/rest/acl/catalog_test.go
+++ b/v2/rest/acl/catalog_test.go
@@ -1,0 +1,109 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/acl"
+)
+
+func TestCatalog_Get_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/security/acl/catalog" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"mode":"HIDE"}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	mode, err := c.ACL.Catalog().Get(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != acl.CatalogModeHide {
+		t.Errorf("mode = %q, want HIDE", mode)
+	}
+}
+
+func TestCatalog_Get_OtherModes(t *testing.T) {
+	for _, m := range []acl.CatalogMode{acl.CatalogModeMixed, acl.CatalogModeChallenge} {
+		t.Run(string(m), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"mode":"`+string(m)+`"}`)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv)
+			got, err := c.ACL.Catalog().Get(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != m {
+				t.Errorf("mode = %q, want %q", got, m)
+			}
+		})
+	}
+}
+
+func TestCatalog_Update_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/acl/catalog" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"mode":"MIXED"`) {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Catalog().Update(context.Background(), acl.CatalogModeMixed)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCatalog_Update_Invalid(t *testing.T) {
+	// GeoServer returns 422 for invalid catalog modes; the client
+	// should surface that as a 4xx error (no specific sentinel).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Catalog().Update(context.Background(), acl.CatalogMode("BOGUS"))
+	if err == nil {
+		t.Fatalf("expected error on 422, got nil")
+	}
+	var apiErr *geoserver.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 APIError, got %v", err)
+	}
+}
+
+func TestCatalog_Reload_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/security/acl/catalog/reload" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.ACL.Catalog().Reload(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/v2/rest/acl/example_test.go
+++ b/v2/rest/acl/example_test.go
@@ -8,14 +8,49 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/acl"
 )
 
-// ExampleClient_Layers returns the layer-ACL sub-client. Future
-// service-level and catalog-level ACL endpoints will live alongside
-// (e.g., c.ACL.Services(), c.ACL.Catalog()).
+// ExampleClient_Layers returns the layer-ACL sub-client.
 func ExampleClient_Layers() {
 	c, _ := geoserver.New("http://localhost:8080/geoserver",
 		geoserver.WithBasicAuth("admin", "geoserver"))
 
 	_ = c.ACL.Layers()
+}
+
+// ExampleServicesClient_Add grants the USER role permission to invoke
+// WMS GetMap. Use service "*" / operation "*" for global rules.
+func ExampleServicesClient_Add() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.ACL.Services().Add(context.Background(), acl.ServiceRule{
+		Service:   "wms",
+		Operation: "GetMap",
+		Roles:     []string{"ROLE_USER"},
+	})
+}
+
+// ExampleRESTClient_Add restricts mutating REST endpoints under
+// /rest/workspaces/** to admins only. Methods are HTTP verbs (or "*"
+// for any verb).
+func ExampleRESTClient_Add() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.ACL.REST().Add(context.Background(), acl.RESTRule{
+		Pattern: "/rest/workspaces/**",
+		Methods: []string{"POST", "PUT", "DELETE"},
+		Roles:   []string{"ROLE_ADMIN"},
+	})
+}
+
+// ExampleCatalogClient_Update flips GeoServer's catalog mode to
+// CHALLENGE — secured resources stay visible in capabilities but
+// every direct access without privileges returns a 401 challenge.
+func ExampleCatalogClient_Update() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.ACL.Catalog().Update(context.Background(), acl.CatalogModeChallenge)
 }
 
 // ExampleLayersClient_Add grants the EDITOR role write access to

--- a/v2/rest/acl/rest.go
+++ b/v2/rest/acl/rest.go
@@ -1,0 +1,133 @@
+package acl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// RESTClient operates on the /rest/security/acl/rest endpoint.
+// REST ACLs control which roles can hit a given URL pattern with a
+// given set of HTTP methods.
+//
+// The wire form in request/response bodies uses ":" as the separator
+// between the URL pattern and the methods list (e.g. "/**:GET");
+// the URL-path form used by DELETE uses ";" instead. [DecodeRESTRule]
+// accepts both. [RESTRule.Encode] emits the body form; the package
+// uses [RESTRule.EncodePathSegment] internally for DELETE.
+//
+// # Production caveat for REST DELETE
+//
+// REST ACL rule keys (e.g. "/**:GET", "/rest/workspaces/**:POST,PUT")
+// contain characters that GeoServer's HTTP firewall rejects in URL
+// paths by default:
+//
+//   - ";" — Spring Security's StrictHttpFirewall blocks ";" with 500
+//     "potentially malicious String". Setting the GeoServer property
+//     GEOSERVER_USE_STRICT_FIREWALL=false swaps to the lenient
+//     DefaultHttpFirewall and unblocks ";". The dev/test docker stack
+//     in this repo sets this; production deployments must do the same.
+//   - "/" — both StrictHttpFirewall and DefaultHttpFirewall reject
+//     URL-encoded slashes (%2F) with 500 "requestURI cannot contain
+//     encoded slash". The fix requires Java-level Spring Security
+//     configuration (firewall.setAllowUrlEncodedSlash(true)) which is
+//     not exposed via env vars or REST.
+//
+// As a practical consequence, [RESTClient.Delete] is wired for
+// completeness but **does not work against a default GeoServer
+// install**. Callers should either:
+//
+//   - Configure GeoServer's HTTP firewall to allow encoded slashes and
+//     semicolons, then this method works as documented.
+//   - Use the admin UI or edit security/rest.properties on disk and
+//     call [CatalogClient.Reload] to pick up the change.
+//   - Replace existing rules via [RESTClient.Update] (which uses PUT
+//     to the list endpoint and is unaffected by URL-path quirks).
+//
+// [RESTClient.Add], [RESTClient.List], and [RESTClient.Update] all
+// hit the list endpoint with no rule in the URL path and work
+// correctly against a default install.
+type RESTClient struct {
+	core Core
+}
+
+// List returns every registered REST ACL rule.
+func (c *RESTClient) List(ctx context.Context, _ ListOptions) ([]RESTRule, error) {
+	const op = "ACL.REST.List"
+	u, err := c.core.URL("rest", "security", "acl", "rest")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw map[string]string
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &raw); err != nil {
+		return nil, err
+	}
+	rules := make([]RESTRule, 0, len(raw))
+	for ruleStr, rolesStr := range raw {
+		r, parseErr := DecodeRESTRule(ruleStr, rolesStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("%s: %w", op, parseErr)
+		}
+		rules = append(rules, r)
+	}
+	return rules, nil
+}
+
+// Add registers a new REST ACL rule. GeoServer returns 200 OK (not
+// 201). Adding a rule that already exists is rejected with 409
+// Conflict — use [RESTClient.Update] in that case.
+func (c *RESTClient) Add(ctx context.Context, rule RESTRule) error {
+	const op = "ACL.REST.Add"
+	if rule.Pattern == "" && len(rule.Methods) == 0 {
+		return errors.New(op + ": empty Pattern and Methods (Encode would default both to wildcards; spell that out explicitly if intended)")
+	}
+	u, err := c.core.URL("rest", "security", "acl", "rest")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	ruleStr, rolesStr := rule.Encode()
+	body := map[string]string{ruleStr: rolesStr}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Update edits an existing REST ACL rule's role list. GeoServer's
+// PUT semantics require the rule to already exist; modifying a
+// non-existent rule fails with 409 Conflict (use [RESTClient.Add]
+// to create instead).
+func (c *RESTClient) Update(ctx context.Context, rule RESTRule) error {
+	const op = "ACL.REST.Update"
+	if rule.Pattern == "" && len(rule.Methods) == 0 {
+		return errors.New(op + ": empty Pattern and Methods")
+	}
+	u, err := c.core.URL("rest", "security", "acl", "rest")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	ruleStr, rolesStr := rule.Encode()
+	body := map[string]string{ruleStr: rolesStr}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// Delete removes a REST ACL rule. The rule is identified by its
+// path-segment form "<pattern>;<methods>" (e.g. "/**;GET"); the role
+// list is irrelevant.
+//
+// Wire-quirk: GeoServer requires the slashes inside the pattern, the
+// "*" glob characters, and the ";" separator to all be transmitted
+// literally — not percent-encoded. Go's [net/url.PathEscape] would
+// escape all three, which Tomcat / GeoServer's StrictHttpFirewall
+// rejects. This method therefore appends the rule segment manually
+// rather than going through the URL helper.
+func (c *RESTClient) Delete(ctx context.Context, rule RESTRule) error {
+	const op = "ACL.REST.Delete"
+	if rule.Pattern == "" && len(rule.Methods) == 0 {
+		return errors.New(op + ": empty Pattern and Methods")
+	}
+	base, err := c.core.URL("rest", "security", "acl", "rest")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	u := base + "/" + rule.EncodePathSegment()
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/acl/rest_test.go
+++ b/v2/rest/acl/rest_test.go
@@ -1,0 +1,218 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/acl"
+)
+
+// ---- RESTRule encode / decode round-trip ----
+
+func TestRESTRule_Encode_Defaults(t *testing.T) {
+	r := acl.RESTRule{}
+	rule, roles := r.Encode()
+	if rule != "/**:*" {
+		t.Errorf("rule = %q, want /**:*", rule)
+	}
+	if roles != "*" {
+		t.Errorf("roles = %q, want *", roles)
+	}
+}
+
+func TestRESTRule_Encode_Full(t *testing.T) {
+	r := acl.RESTRule{
+		Pattern: "/rest/workspaces/**",
+		Methods: []string{"POST", "PUT", "DELETE"},
+		Roles:   []string{"ROLE_ADMIN"},
+	}
+	rule, roles := r.Encode()
+	if rule != "/rest/workspaces/**:POST,PUT,DELETE" {
+		t.Errorf("rule = %q", rule)
+	}
+	if roles != "ROLE_ADMIN" {
+		t.Errorf("roles = %q", roles)
+	}
+}
+
+func TestRESTRule_EncodePathSegment_SemicolonSeparator(t *testing.T) {
+	r := acl.RESTRule{Pattern: "/**", Methods: []string{"GET"}}
+	got := r.EncodePathSegment()
+	if got != "/**;GET" {
+		t.Errorf("EncodePathSegment = %q, want /**;GET", got)
+	}
+}
+
+func TestDecodeRESTRule_AcceptsBothSeparators(t *testing.T) {
+	for _, s := range []string{"/**:GET", "/**;GET"} {
+		r, err := acl.DecodeRESTRule(s, "ROLE_ADMIN")
+		if err != nil {
+			t.Fatalf("decode %q: %v", s, err)
+		}
+		if r.Pattern != "/**" || len(r.Methods) != 1 || r.Methods[0] != "GET" {
+			t.Errorf("decode %q -> %+v", s, r)
+		}
+	}
+}
+
+func TestDecodeRESTRule_BadFormat(t *testing.T) {
+	_, err := acl.DecodeRESTRule("noseparator", "*")
+	if err == nil || !strings.Contains(err.Error(), "pattern:methods") {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+// ---- RESTClient HTTP CRUD ----
+
+func TestREST_List_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/acl/rest" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"/**:GET": "*",
+			"/**:POST,DELETE,PUT": "ADMIN"
+		}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	rules, err := c.ACL.REST().List(context.Background(), acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("len = %d, want 2", len(rules))
+	}
+	encoded := make([]string, 0, len(rules))
+	for _, r := range rules {
+		ruleStr, rolesStr := r.Encode()
+		encoded = append(encoded, ruleStr+"="+rolesStr)
+	}
+	sort.Strings(encoded)
+	want := []string{
+		"/**:GET=*",
+		"/**:POST,DELETE,PUT=ADMIN",
+	}
+	for i, w := range want {
+		if encoded[i] != w {
+			t.Errorf("encoded[%d] = %q, want %q", i, encoded[i], w)
+		}
+	}
+}
+
+func TestREST_Add_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/security/acl/rest" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"/**:GET":"*"`) {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Add(context.Background(), acl.RESTRule{
+		Pattern: "/**", Methods: []string{"GET"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestREST_Add_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Add(context.Background(), acl.RESTRule{
+		Pattern: "/**", Methods: []string{"GET"},
+	})
+	if !errors.Is(err, geoserver.ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestREST_Update_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/acl/rest" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Update(context.Background(), acl.RESTRule{
+		Pattern: "/**", Methods: []string{"GET"}, Roles: []string{"ROLE_USER"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestREST_Delete_OK_LiteralSlashesAndSemicolon(t *testing.T) {
+	// GeoServer requires the slashes, "*" globs, and ";" separator
+	// to be transmitted literally — not percent-encoded.
+	// The expected wire path is /rest/security/acl/rest//**;GET
+	// (note the double-slash because the rule itself starts with /).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/rest/security/acl/rest//**;GET" {
+			t.Errorf("path = %q, want /rest/security/acl/rest//**;GET", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Delete(context.Background(), acl.RESTRule{
+		Pattern: "/**", Methods: []string{"GET"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestREST_Delete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Delete(context.Background(), acl.RESTRule{
+		Pattern: "/**", Methods: []string{"GET"},
+	})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestREST_Add_EmptyPatternAndMethods(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.REST().Add(context.Background(), acl.RESTRule{})
+	if err == nil || !strings.Contains(err.Error(), "empty Pattern and Methods") {
+		t.Fatalf("expected empty-pattern-and-methods error, got %v", err)
+	}
+}

--- a/v2/rest/acl/services.go
+++ b/v2/rest/acl/services.go
@@ -1,0 +1,91 @@
+package acl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// ServicesClient operates on the /rest/security/acl/services
+// endpoint. Service ACLs control which roles can invoke a given OWS
+// operation (e.g. WMS GetMap, WFS GetFeature, WCS GetCoverage).
+//
+// The wire form is a JSON object whose keys are dotted-pair rule
+// strings ("service.operation") and values are comma-separated role
+// lists. "*" stands for any value.
+type ServicesClient struct {
+	core Core
+}
+
+// List returns every registered service ACL rule.
+func (c *ServicesClient) List(ctx context.Context, _ ListOptions) ([]ServiceRule, error) {
+	const op = "ACL.Services.List"
+	u, err := c.core.URL("rest", "security", "acl", "services")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw map[string]string
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &raw); err != nil {
+		return nil, err
+	}
+	rules := make([]ServiceRule, 0, len(raw))
+	for ruleStr, rolesStr := range raw {
+		r, parseErr := DecodeServiceRule(ruleStr, rolesStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("%s: %w", op, parseErr)
+		}
+		rules = append(rules, r)
+	}
+	return rules, nil
+}
+
+// Add registers a new service ACL rule. GeoServer returns 200 OK
+// (not 201). Adding a rule that already exists is rejected with 409
+// Conflict — use [ServicesClient.Update] in that case.
+func (c *ServicesClient) Add(ctx context.Context, rule ServiceRule) error {
+	const op = "ACL.Services.Add"
+	if rule.Service == "" && rule.Operation == "" {
+		return errors.New(op + ": empty Service and Operation (Encode would default both to '*'; spell that out explicitly if intended)")
+	}
+	u, err := c.core.URL("rest", "security", "acl", "services")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	ruleStr, rolesStr := rule.Encode()
+	body := map[string]string{ruleStr: rolesStr}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Update edits an existing service ACL rule's role list. GeoServer's
+// PUT semantics require the rule to already exist; modifying a
+// non-existent rule fails with 409 Conflict (use [ServicesClient.Add]
+// to create instead).
+func (c *ServicesClient) Update(ctx context.Context, rule ServiceRule) error {
+	const op = "ACL.Services.Update"
+	if rule.Service == "" && rule.Operation == "" {
+		return errors.New(op + ": empty Service and Operation")
+	}
+	u, err := c.core.URL("rest", "security", "acl", "services")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	ruleStr, rolesStr := rule.Encode()
+	body := map[string]string{ruleStr: rolesStr}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}
+
+// Delete removes a service ACL rule. The rule is identified by its
+// encoded form ("service.operation"); the role list is irrelevant.
+func (c *ServicesClient) Delete(ctx context.Context, rule ServiceRule) error {
+	const op = "ACL.Services.Delete"
+	if rule.Service == "" && rule.Operation == "" {
+		return errors.New(op + ": empty Service and Operation")
+	}
+	ruleStr, _ := rule.Encode()
+	u, err := c.core.URL("rest", "security", "acl", "services", ruleStr)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/acl/services_rest_catalog_integration_test.go
+++ b/v2/rest/acl/services_rest_catalog_integration_test.go
@@ -1,0 +1,284 @@
+//go:build integration
+
+package acl_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/acl"
+)
+
+func TestACL_Services_CRUD_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// GeoServer's services-ACL validator rejects rules where the
+	// service is "*" with a non-"*" operation (error message:
+	// "when namespace is * then also layer must be *"), and rejects
+	// rules referencing operations that don't exist in any real
+	// service. Pin to (wfs, GetCapabilities) — a canonical operation
+	// that's vanishingly unlikely to have a custom rule already on a
+	// fresh GeoServer install. Uniqueness is provided by the role
+	// name; the rule itself is removed on cleanup.
+	roleName := testenv.UniqueName(t, "ROLE")
+
+	rule := acl.ServiceRule{
+		Service:   "wfs",
+		Operation: "GetCapabilities",
+		Roles:     []string{roleName},
+	}
+
+	t.Cleanup(func() {
+		_ = c.ACL.Services().Delete(ctx, rule)
+	})
+
+	if err := c.ACL.Services().Add(ctx, rule); err != nil {
+		t.Fatalf("Add service rule: %v", err)
+	}
+
+	rules, err := c.ACL.Services().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List service rules: %v", err)
+	}
+	found := false
+	for _, r := range rules {
+		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+			if len(r.Roles) == 1 && r.Roles[0] == roleName {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("rule for wfs.GetCapabilities with role %q not found in List", roleName)
+	}
+
+	// Update: change the role list.
+	updatedRoleName := testenv.UniqueName(t, "ROLE")
+	updated := rule
+	updated.Roles = []string{roleName, updatedRoleName}
+	if err := c.ACL.Services().Update(ctx, updated); err != nil {
+		t.Fatalf("Update service rule: %v", err)
+	}
+
+	// Verify the update landed.
+	rules, err = c.ACL.Services().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List after Update: %v", err)
+	}
+	gotRoles := []string(nil)
+	for _, r := range rules {
+		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+			gotRoles = r.Roles
+			break
+		}
+	}
+	if len(gotRoles) != 2 {
+		t.Fatalf("expected 2 roles after Update, got %v", gotRoles)
+	}
+
+	if err := c.ACL.Services().Delete(ctx, rule); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Confirm removal.
+	rules, err = c.ACL.Services().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List after Delete: %v", err)
+	}
+	for _, r := range rules {
+		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+			t.Fatalf("rule still present after Delete: %+v", r)
+		}
+	}
+}
+
+func TestACL_REST_AddListUpdate_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// REST ACL rule keys carry "/" and ":" in their URL-path form,
+	// which GeoServer's HTTP firewall rejects by default — so the
+	// DELETE /rest/security/acl/rest/{rule} endpoint is effectively
+	// non-functional on a default install. See [RESTClient] doc for
+	// the full caveat. This test exercises the Add/List/Update path
+	// (which all hit the list endpoint and are unaffected); cleanup
+	// best-effort tries Delete and tolerates failure.
+	//
+	// Pattern suffix uses a nanosecond timestamp because rules
+	// accumulate across runs (Delete is broken on default GeoServer);
+	// testenv.UniqueName's per-process counter would re-collide on
+	// each run.
+	patternSuffix := fmt.Sprintf("fake_%d", time.Now().UnixNano())
+	roleName := testenv.UniqueName(t, "ROLE")
+
+	rule := acl.RESTRule{
+		Pattern: "/rest/" + patternSuffix + "/**",
+		Methods: []string{"GET"},
+		Roles:   []string{roleName},
+	}
+
+	t.Cleanup(func() {
+		// Best-effort Delete. If GeoServer's firewall rejects this
+		// path (the common case on default installs), the rule will
+		// remain on the server until manually cleaned.
+		_ = c.ACL.REST().Delete(ctx, rule)
+	})
+
+	if err := c.ACL.REST().Add(ctx, rule); err != nil {
+		t.Fatalf("Add REST rule: %v", err)
+	}
+
+	rules, err := c.ACL.REST().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List REST rules: %v", err)
+	}
+	found := false
+	for _, r := range rules {
+		if r.Pattern == rule.Pattern && len(r.Methods) == 1 && r.Methods[0] == "GET" {
+			if len(r.Roles) == 1 && r.Roles[0] == roleName {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("rule for %s:GET not found in List", rule.Pattern)
+	}
+
+	// Update: change the role list.
+	updatedRoleName := testenv.UniqueName(t, "ROLE")
+	updated := rule
+	updated.Roles = []string{roleName, updatedRoleName}
+	if err := c.ACL.REST().Update(ctx, updated); err != nil {
+		t.Fatalf("Update REST rule: %v", err)
+	}
+
+	// Verify Update landed.
+	rules, err = c.ACL.REST().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List after Update: %v", err)
+	}
+	gotRoles := []string(nil)
+	for _, r := range rules {
+		if r.Pattern == rule.Pattern && len(r.Methods) == 1 && r.Methods[0] == "GET" {
+			gotRoles = r.Roles
+			break
+		}
+	}
+	if len(gotRoles) != 2 {
+		t.Errorf("expected 2 roles after Update, got %v", gotRoles)
+	}
+}
+
+func TestACL_REST_Delete_Integration(t *testing.T) {
+	// Standalone Delete test — skipped by default because REST ACL
+	// DELETE requires Spring Security configuration that is not
+	// exposed via env vars on a default GeoServer install. See
+	// [acl.RESTClient] doc for the full explanation. Set the env
+	// var GEOSERVER_REST_ACL_DELETE_WORKS=1 to run it on a
+	// custom-configured server.
+	if os.Getenv("GEOSERVER_REST_ACL_DELETE_WORKS") != "1" {
+		t.Skip("REST ACL DELETE requires Spring Security firewall config not present on default GeoServer; see acl.RESTClient godoc for details")
+	}
+
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	patternSuffix := fmt.Sprintf("fake_%d", time.Now().UnixNano())
+	roleName := testenv.UniqueName(t, "ROLE")
+
+	rule := acl.RESTRule{
+		Pattern: "/rest/" + patternSuffix + "/**",
+		Methods: []string{"GET"},
+		Roles:   []string{roleName},
+	}
+	t.Cleanup(func() {
+		_ = c.ACL.REST().Delete(ctx, rule)
+	})
+	if err := c.ACL.REST().Add(ctx, rule); err != nil {
+		t.Fatalf("Add REST rule: %v", err)
+	}
+	if err := c.ACL.REST().Delete(ctx, rule); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	rules, err := c.ACL.REST().List(ctx, acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("List after Delete: %v", err)
+	}
+	for _, r := range rules {
+		if r.Pattern == rule.Pattern && len(r.Methods) == 1 && r.Methods[0] == "GET" {
+			t.Fatalf("rule still present after Delete: %+v", r)
+		}
+	}
+}
+
+func TestACL_Catalog_GetUpdate_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	original, err := c.ACL.Catalog().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get catalog mode: %v", err)
+	}
+	if original != acl.CatalogModeHide && original != acl.CatalogModeMixed && original != acl.CatalogModeChallenge {
+		t.Fatalf("unexpected initial catalog mode %q", original)
+	}
+
+	// Restore on cleanup so we don't leave the server in an altered
+	// state (subsequent tests may rely on the default mode).
+	t.Cleanup(func() {
+		_ = c.ACL.Catalog().Update(ctx, original)
+	})
+
+	// Toggle to a non-original mode.
+	target := acl.CatalogModeMixed
+	if original == acl.CatalogModeMixed {
+		target = acl.CatalogModeHide
+	}
+	if err := c.ACL.Catalog().Update(ctx, target); err != nil {
+		t.Fatalf("Update catalog mode to %q: %v", target, err)
+	}
+
+	got, err := c.ACL.Catalog().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got != target {
+		t.Errorf("after Update mode = %q, want %q", got, target)
+	}
+}
+
+func TestACL_Catalog_Update_InvalidMode_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	err := c.ACL.Catalog().Update(ctx, acl.CatalogMode("BOGUS"))
+	if err == nil {
+		t.Fatalf("expected error for invalid catalog mode, got nil")
+	}
+	// GeoServer documents 422 for invalid modes; surface as APIError
+	// regardless of which specific 4xx it ends up being.
+	var apiErr *geoserver.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %v", err)
+	}
+	if apiErr.StatusCode < 400 || apiErr.StatusCode >= 500 {
+		t.Errorf("expected 4xx status, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestACL_Catalog_Reload_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	if err := c.ACL.Catalog().Reload(ctx); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+}

--- a/v2/rest/acl/services_test.go
+++ b/v2/rest/acl/services_test.go
@@ -1,0 +1,206 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/acl"
+)
+
+// ---- ServiceRule encode / decode round-trip ----
+
+func TestServiceRule_Encode_Defaults(t *testing.T) {
+	r := acl.ServiceRule{}
+	rule, roles := r.Encode()
+	if rule != "*.*" {
+		t.Errorf("rule = %q, want *.*", rule)
+	}
+	if roles != "*" {
+		t.Errorf("roles = %q, want *", roles)
+	}
+}
+
+func TestServiceRule_Encode_Full(t *testing.T) {
+	r := acl.ServiceRule{
+		Service:   "wms",
+		Operation: "GetMap",
+		Roles:     []string{"ROLE_USER", "ROLE_ADMIN"},
+	}
+	rule, roles := r.Encode()
+	if rule != "wms.GetMap" {
+		t.Errorf("rule = %q", rule)
+	}
+	if roles != "ROLE_USER,ROLE_ADMIN" {
+		t.Errorf("roles = %q", roles)
+	}
+}
+
+func TestDecodeServiceRule_OK(t *testing.T) {
+	r, err := acl.DecodeServiceRule("wfs.GetFeature", "ROLE_READER")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if r.Service != "wfs" || r.Operation != "GetFeature" {
+		t.Fatalf("Rule = %+v", r)
+	}
+	if len(r.Roles) != 1 || r.Roles[0] != "ROLE_READER" {
+		t.Fatalf("Roles = %v", r.Roles)
+	}
+}
+
+func TestDecodeServiceRule_BadFormat(t *testing.T) {
+	_, err := acl.DecodeServiceRule("toomany.dots.here", "*")
+	if err == nil || !strings.Contains(err.Error(), "service.operation") {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+// ---- ServicesClient HTTP CRUD ----
+
+func TestServices_List_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/acl/services" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"*.*": "*",
+			"wms.GetMap": "ROLE_USER",
+			"wfs.GetFeature": "ROLE_READER,ROLE_ADMIN"
+		}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	rules, err := c.ACL.Services().List(context.Background(), acl.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rules) != 3 {
+		t.Fatalf("len = %d, want 3; rules = %+v", len(rules), rules)
+	}
+	encoded := make([]string, 0, len(rules))
+	for _, r := range rules {
+		ruleStr, rolesStr := r.Encode()
+		encoded = append(encoded, ruleStr+"="+rolesStr)
+	}
+	sort.Strings(encoded)
+	want := []string{
+		"*.*=*",
+		"wfs.GetFeature=ROLE_READER,ROLE_ADMIN",
+		"wms.GetMap=ROLE_USER",
+	}
+	for i, w := range want {
+		if encoded[i] != w {
+			t.Errorf("encoded[%d] = %q, want %q", i, encoded[i], w)
+		}
+	}
+}
+
+func TestServices_Add_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/security/acl/services" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"wms.GetMap":"ROLE_USER"`) {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Add(context.Background(), acl.ServiceRule{
+		Service: "wms", Operation: "GetMap", Roles: []string{"ROLE_USER"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServices_Add_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Add(context.Background(), acl.ServiceRule{
+		Service: "wms", Operation: "GetMap",
+	})
+	if !errors.Is(err, geoserver.ErrConflict) {
+		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestServices_Add_EmptyServiceAndOperation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Add(context.Background(), acl.ServiceRule{})
+	if err == nil || !strings.Contains(err.Error(), "empty Service and Operation") {
+		t.Fatalf("expected empty-service-and-operation error, got %v", err)
+	}
+}
+
+func TestServices_Update_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/acl/services" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Update(context.Background(), acl.ServiceRule{
+		Service: "wms", Operation: "GetMap", Roles: []string{"ROLE_ADMIN"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServices_Delete_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/security/acl/services/wms.GetMap" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Delete(context.Background(), acl.ServiceRule{
+		Service: "wms", Operation: "GetMap",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServices_Delete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ACL.Services().Delete(context.Background(), acl.ServiceRule{
+		Service: "wms", Operation: "GetMap",
+	})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/acl/types.go
+++ b/v2/rest/acl/types.go
@@ -1,12 +1,20 @@
 // Package acl is the v2 sub-client for the GeoServer access-control-list
-// endpoints under /rest/security/acl. The current surface covers
-// layer ACL rules; service-level and catalog-level ACL endpoints
-// can be added in follow-up PRs without breaking changes.
+// endpoints under /rest/security/acl. The four covered surfaces are:
 //
-// GeoServer's ACL wire format encodes a rule as the dotted triple
-// "workspace.layer.op" mapped to a comma-separated role list (or "*"
-// for any role). This package wraps that into a typed [Rule] with
-// [Rule.Encode] / [DecodeRule] for round-tripping.
+//   - [LayersClient] (`c.ACL.Layers()`) — per-workspace.layer permissions.
+//     Rule key shape: "workspace.layer.op", e.g. "topp.states.w".
+//   - [ServicesClient] (`c.ACL.Services()`) — per-OWS-operation permissions.
+//     Rule key shape: "service.operation", e.g. "wms.GetMap" or "*.*".
+//   - [RESTClient] (`c.ACL.REST()`) — per-REST-pattern permissions.
+//     Rule key shape: "<URL Ant pattern>:<HTTP methods>", e.g. "/**:GET".
+//   - [CatalogClient] (`c.ACL.Catalog()`) — singleton catalog mode
+//     (HIDE / MIXED / CHALLENGE) plus a configuration reload endpoint.
+//
+// Layers/Services/REST share a common rule wire format: a JSON object
+// whose keys are the rule string and values are comma-separated role
+// lists ("*" for any role). The typed encode / decode helpers
+// ([Rule.Encode] / [DecodeRule], [ServiceRule.Encode] / [DecodeServiceRule],
+// [RESTRule.Encode] / [DecodeRESTRule]) round-trip those.
 package acl
 
 import (
@@ -94,3 +102,136 @@ func DecodeRule(rule, rolesStr string) (Rule, error) {
 
 // ListOptions controls listing behavior. Currently empty.
 type ListOptions struct{}
+
+// ServiceRule is an OWS-operation ACL rule. The wire form is the
+// dotted pair "service.operation" mapped to a comma-separated role
+// list. Service is e.g. "wms" / "wfs" / "wcs" / "*" (any service).
+// Operation is the OWS request name, e.g. "GetMap" / "GetFeature" /
+// "*" (any operation).
+type ServiceRule struct {
+	Service   string
+	Operation string
+	Roles     []string
+}
+
+// Encode converts the ServiceRule into the wire-format pair
+// (rule, roles). Empty Service and Operation default to "*"; empty
+// Roles defaults to "*".
+func (r ServiceRule) Encode() (rule, roles string) {
+	s := r.Service
+	if s == "" {
+		s = "*"
+	}
+	op := r.Operation
+	if op == "" {
+		op = "*"
+	}
+	rs := r.Roles
+	if len(rs) == 0 {
+		rs = []string{"*"}
+	}
+	return fmt.Sprintf("%s.%s", s, op), strings.Join(rs, ",")
+}
+
+// DecodeServiceRule parses GeoServer's wire format back into a
+// [ServiceRule]. rule must be of the form "service.operation".
+func DecodeServiceRule(rule, rolesStr string) (ServiceRule, error) {
+	parts := strings.Split(rule, ".")
+	if len(parts) != 2 {
+		return ServiceRule{}, errors.New("acl: service rule must be 'service.operation'")
+	}
+	r := ServiceRule{Service: parts[0], Operation: parts[1]}
+	if rolesStr != "" && rolesStr != "*" {
+		r.Roles = strings.Split(rolesStr, ",")
+	}
+	return r, nil
+}
+
+// RESTRule is a per-REST-request ACL rule.
+//
+// The wire form for REST rules is "<pattern>:<methods>" where
+// <pattern> is a Spring URL Ant pattern (e.g. "/**", "/rest/workspaces/**")
+// and <methods> is a comma-separated list of HTTP methods (e.g.
+// "GET", "POST,PUT,DELETE", or "*" for any method). The path-segment
+// form documented for DELETE uses ";" as the separator instead of
+// ":"; both [DecodeRESTRule] forms are accepted on input. Encode
+// emits the canonical body form using ":" since that is what GET/POST
+// bodies use.
+//
+// Slashes inside the pattern are URL-percent-encoded automatically
+// when the rule is used as a path segment for DELETE — the
+// [Core.URL] helper applies url.PathEscape per segment.
+type RESTRule struct {
+	Pattern string
+	Methods []string
+	Roles   []string
+}
+
+// Encode converts the RESTRule into the wire-format pair
+// (rule, roles). Empty Pattern defaults to "/**"; empty Methods
+// defaults to "*"; empty Roles defaults to "*".
+func (r RESTRule) Encode() (rule, roles string) {
+	p := r.Pattern
+	if p == "" {
+		p = "/**"
+	}
+	m := r.Methods
+	if len(m) == 0 {
+		m = []string{"*"}
+	}
+	rs := r.Roles
+	if len(rs) == 0 {
+		rs = []string{"*"}
+	}
+	return p + ":" + strings.Join(m, ","), strings.Join(rs, ",")
+}
+
+// EncodePathSegment is like [RESTRule.Encode] but emits the
+// ";"-separator form GeoServer requires when the rule is embedded
+// in a URL path segment (used by DELETE).
+func (r RESTRule) EncodePathSegment() string {
+	rule, _ := r.Encode()
+	// Swap the FIRST ":" (between pattern and methods) for ";".
+	if i := strings.Index(rule, ":"); i >= 0 {
+		return rule[:i] + ";" + rule[i+1:]
+	}
+	return rule
+}
+
+// DecodeRESTRule parses GeoServer's wire format back into a
+// [RESTRule]. Accepts both ":" (body form) and ";" (URL form) as
+// the separator between the URL pattern and the methods list.
+func DecodeRESTRule(rule, rolesStr string) (RESTRule, error) {
+	sep := strings.IndexAny(rule, ":;")
+	if sep < 0 {
+		return RESTRule{}, errors.New("acl: REST rule must be 'pattern:methods' or 'pattern;methods'")
+	}
+	r := RESTRule{
+		Pattern: rule[:sep],
+		Methods: strings.Split(rule[sep+1:], ","),
+	}
+	if rolesStr != "" && rolesStr != "*" {
+		r.Roles = strings.Split(rolesStr, ",")
+	}
+	return r, nil
+}
+
+// CatalogMode controls how GeoServer advertises secured layers and
+// behaves when a secured layer is accessed without the necessary
+// privileges. See the GeoServer Security manual for semantics.
+type CatalogMode string
+
+// Recognized catalog modes.
+const (
+	// CatalogModeHide makes secured resources invisible to
+	// unauthenticated users (omitted from capabilities, 404 on
+	// direct access).
+	CatalogModeHide CatalogMode = "HIDE"
+	// CatalogModeMixed leaves secured resources visible in
+	// capabilities but returns 401/403 on direct access without
+	// privileges.
+	CatalogModeMixed CatalogMode = "MIXED"
+	// CatalogModeChallenge forces a 401 challenge with auth headers
+	// on every secured resource access.
+	CatalogModeChallenge CatalogMode = "CHALLENGE"
+)


### PR DESCRIPTION
## Summary

Closes the security tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). The v2 ACL sub-client previously covered only `c.ACL.Layers()`; this PR adds the three sibling surfaces under `/rest/security/acl/`.

## What lands

**New surface:**
- `c.ACL.Services()` — service ACL rules (`/rest/security/acl/services`). Rule key is `service.operation` (e.g. `wms.GetMap`, `*.*`). `List` / `Add` / `Update` / `Delete`.
- `c.ACL.REST()` — REST ACL rules (`/rest/security/acl/rest`). Rule key is `<URL Ant pattern>:<HTTP methods>`. `List` / `Add` / `Update` / `Delete`.
- `c.ACL.Catalog()` — singleton catalog mode (`/rest/security/acl/catalog`). `Get` / `Update` (`HIDE` / `MIXED` / `CHALLENGE`) plus `Reload` to reload security config from disk.
- `c.ACL.Layers().Update` — additive PUT method, mirroring the new shape on Services and REST.
- New typed structs: `ServiceRule`, `RESTRule`, `CatalogMode` + `Encode` / `Decode` helpers.

**Wire-format quirks discovered via local integration testing:**
- Services validator rejects `*.<op>` (wildcard service + concrete operation) with 422 — must be either `*.*` or a real `service.operation` pair.
- REST DELETE is wired for completeness but **does not work against a default GeoServer install**. Spring Security's HTTP firewall rejects `;` and `%2F` in URL paths. `;` can be unblocked with `GEOSERVER_USE_STRICT_FIREWALL=false` (the dev/test docker stack now sets this); `%2F` requires Java-level Spring config that is not env-configurable. The integration test for REST DELETE `t.Skip`'s by default with a clear reason, and can be enabled with `GEOSERVER_REST_ACL_DELETE_WORKS=1` on a custom-configured server. `Add`/`List`/`Update` all hit the list endpoint and work correctly against a default install.
- Full quirk explanation in `v2/rest/acl/rest.go` godoc and `v2/CHANGELOG.md`.

**Docker test stack change:** `docker/env/geoserver.env` adds `GEOSERVER_USE_STRICT_FIREWALL=false` so the integration suite can exercise the REST ACL surface. Production deployments retain the default strict firewall unless they opt in.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/acl/...` — all unit tests pass (24 tests covering encode/decode round-trips + HTTP CRUD + status-code → sentinel mapping).
- [x] `golangci-lint run ./rest/acl/...` — 0 issues.
- [x] `go vet -tags=integration ./rest/acl/...` — clean.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/acl/...` — 6 PASS, 1 SKIP (documented).
- [x] Full v2 integration suite green against GeoServer 2.28.0; nothing else regressed by the firewall env change.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.