### PR TITLE
feat(v2): add Resource API sub-client

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Resource API client
+
+Closes the Resource API tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Generic byte-stream access to files in the GeoServer data directory — FreeMarker templates, SLD includes, external graphic icons, and arbitrary descendants of the data dir.
+
+- **`v2/rest/resources/` package** — `c.Resources` exposes the `/rest/resource/{path}` endpoint:
+  - **`Get(ctx, path) (io.ReadCloser, error)`** — stream file content.
+  - **`Stat(ctx, path) (*Metadata, error)`** — bare metadata (no children listed).
+  - **`List(ctx, path) (*Directory, error)`** — directory listing with children.
+  - **`Exists(ctx, path) (bool, Type, error)`** — combined existence + type check.
+  - **`Put(ctx, path, body, contentType) error`** — upload / overwrite a regular-file resource. Intermediate directories are created on the fly.
+  - **`Move(ctx, srcPath, dstPath) error`** — relocate a resource via the upstream `?operation=move` form.
+  - **`Copy(ctx, srcPath, dstPath) error`** — duplicate a resource via `?operation=copy`. Per upstream, copy is not supported on directories.
+  - **`Delete(ctx, path) error`** — recursive delete (per upstream).
+- **Typed enums and structs** — `Type` (`TypeResource` / `TypeDirectory` / `TypeUndefined`), `Metadata`, `Directory`, `Child`.
+- **`coreAdapter.DoStream`** — previously unimplemented; now wired so any sub-client can stream a response body.
+- **`coreAdapter.SynthesizeError`** — sub-clients can surface package-sentinel errors (e.g. `ErrNotFound`) for wire responses that are technically 2xx but semantically failures.
+
+### Wire-format quirks (resources package)
+
+Discovered via local integration testing against live GeoServer 2.28.0:
+
+- **`operation=metadata` returns 200 with `type:"undefined"` for missing paths**, instead of 404. `Stat` translates that into an `ErrNotFound`-bearing error so callers can match with `errors.Is(err, geoserver.ErrNotFound)`.
+- **`children.child` is a "may be array, single object, or empty string" field.** A directory with no children may serialize as `"child":""`. A directory with one child may collapse to `"child":{...}` (no array). `Children` field's custom `UnmarshalJSON` accepts all three shapes.
+
 ### Added — ACL services / REST / catalog
 
 Closes the security tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). The v2 ACL sub-client previously covered only `c.ACL.Layers()`; this round adds the three sibling surfaces under `/rest/security/acl/`.

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -95,6 +95,13 @@ func (e *APIError) Unwrap() error {
 	return nil
 }
 
+// HTTPStatusCode returns the HTTP status code that produced the
+// error. A stable accessor (in addition to the [APIError.StatusCode]
+// field) so sub-clients in v2/rest/* can branch on the status without
+// importing the root package — that would create an import cycle
+// since the root imports each rest/<resource>.
+func (e *APIError) HTTPStatusCode() int { return e.StatusCode }
+
 // Is reports whether target matches the sentinel for this APIError's
 // status code. Lets callers use errors.Is(err, ErrNotFound) directly on
 // an *APIError.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
+	"github.com/hishamkaram/geoserver/v2/rest/resources"
 	"github.com/hishamkaram/geoserver/v2/rest/security"
 	"github.com/hishamkaram/geoserver/v2/rest/services"
 	"github.com/hishamkaram/geoserver/v2/rest/settings"
@@ -165,6 +166,14 @@ type Client struct {
 	// `WMTS()`. Each exposes `Get`/`Update` for global settings and
 	// `.InWorkspace(ws)` for per-workspace overrides (`Get`/`Update`/`Delete`).
 	Services *services.Client
+
+	// Resources is the entry point for the GeoServer Resource API at
+	// /rest/resource/{path} — generic byte-stream access to files
+	// in the GeoServer data directory. Daily-driver methods cover
+	// reading file contents, listing directories, uploading new
+	// resources (FTL templates, SLD includes, icons), moving /
+	// copying files, and recursive deletion.
+	Resources *resources.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -241,6 +250,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.Services = services.New(adapter)
 	c.GWC = gwc.New(adapter)
 	c.Imports = imports.New(adapter)
+	c.Resources = resources.New(adapter)
 	return c, nil
 }
 
@@ -352,12 +362,37 @@ func (a coreAdapter) Do(ctx context.Context, op string, method, requestURL strin
 	return err
 }
 
-// DoStream issues a request whose response is a stream (e.g., an SLD
-// download). The caller owns the returned ReadCloser and must close it.
-// Reserved for future resource ports; not used by Workspaces.
+// DoStream issues a request whose response is a streamed body
+// (e.g., a Resource API file download whose Content-Type can be
+// XML / JSON / image / binary depending on the file). The caller
+// owns the returned [io.ReadCloser] and must close it.
+//
+// On 2xx, returns the open body, the status code, and nil error.
+// On non-2xx, drains and closes the body, returns a [*APIError].
+// On transport failure, returns the wrapped transport error.
 func (a coreAdapter) DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error) {
-	// Placeholder; expand when the first streaming resource ports.
-	return nil, 0, errors.New("geoserver: DoStream not yet implemented")
+	httpReq, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s: build request: %w", op, err)
+	}
+	httpReq.Header.Set("Accept", "*/*")
+	if len(query) > 0 {
+		q := httpReq.URL.Query()
+		for k, v := range query {
+			q.Set(k, v)
+		}
+		httpReq.URL.RawQuery = q.Encode()
+	}
+	resp, err := a.core.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s: %s %s: %w", op, method, requestURL, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		_ = resp.Body.Close()
+		return nil, resp.StatusCode, newAPIError(op, method, requestURL, resp.StatusCode, body)
+	}
+	return resp.Body, resp.StatusCode, nil
 }
 
 // DoXML issues a GET-style request and decodes the response as XML.
@@ -379,6 +414,20 @@ func (a coreAdapter) DoXML(ctx context.Context, op, method, requestURL string, q
 		return newAPIError(tErr.Op, tErr.Method, tErr.URL, tErr.StatusCode, tErr.Body)
 	}
 	return err
+}
+
+// SynthesizeError manufactures an [*APIError] with the supplied
+// status code, suitable for sub-clients that need to surface a
+// package sentinel (e.g., [ErrNotFound]) when the wire response is
+// semantically an error but technically a 2xx — for example, the
+// Resource API returns 200 with type="undefined" for missing paths
+// when queried with operation=metadata, and the [resources] sub-client
+// translates that into an [ErrNotFound]-bearing [*APIError].
+//
+// bodyHint is preserved on the synthesized error's Body field for
+// diagnostic purposes; it is not parsed.
+func (a coreAdapter) SynthesizeError(op, method, requestURL string, statusCode int, bodyHint string) error {
+	return newAPIError(op, method, requestURL, statusCode, []byte(bodyHint))
 }
 
 // DoRaw issues a request with an arbitrary-Reader body and explicit

--- a/v2/rest/acl/services_rest_catalog_integration_test.go
+++ b/v2/rest/acl/services_rest_catalog_integration_test.go
@@ -22,15 +22,14 @@ func TestACL_Services_CRUD_Integration(t *testing.T) {
 	// service is "*" with a non-"*" operation (error message:
 	// "when namespace is * then also layer must be *"), and rejects
 	// rules referencing operations that don't exist in any real
-	// service. Pin to (wfs, GetCapabilities) — a canonical operation
-	// that's vanishingly unlikely to have a custom rule already on a
-	// fresh GeoServer install. Uniqueness is provided by the role
-	// name; the rule itself is removed on cleanup.
+	// service. Pin to (wfs, Transaction) — a real WFS-T operation
+	// that no other v2 integration test exercises, avoiding races
+	// against parallel test packages running anonymous requests.
 	roleName := testenv.UniqueName(t, "ROLE")
 
 	rule := acl.ServiceRule{
 		Service:   "wfs",
-		Operation: "GetCapabilities",
+		Operation: "Transaction",
 		Roles:     []string{roleName},
 	}
 
@@ -48,7 +47,7 @@ func TestACL_Services_CRUD_Integration(t *testing.T) {
 	}
 	found := false
 	for _, r := range rules {
-		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+		if r.Service == "wfs" && r.Operation == "Transaction" {
 			if len(r.Roles) == 1 && r.Roles[0] == roleName {
 				found = true
 				break
@@ -56,7 +55,7 @@ func TestACL_Services_CRUD_Integration(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("rule for wfs.GetCapabilities with role %q not found in List", roleName)
+		t.Fatalf("rule for wfs.Transaction with role %q not found in List", roleName)
 	}
 
 	// Update: change the role list.
@@ -74,7 +73,7 @@ func TestACL_Services_CRUD_Integration(t *testing.T) {
 	}
 	gotRoles := []string(nil)
 	for _, r := range rules {
-		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+		if r.Service == "wfs" && r.Operation == "Transaction" {
 			gotRoles = r.Roles
 			break
 		}
@@ -93,7 +92,7 @@ func TestACL_Services_CRUD_Integration(t *testing.T) {
 		t.Fatalf("List after Delete: %v", err)
 	}
 	for _, r := range rules {
-		if r.Service == "wfs" && r.Operation == "GetCapabilities" {
+		if r.Service == "wfs" && r.Operation == "Transaction" {
 			t.Fatalf("rule still present after Delete: %+v", r)
 		}
 	}

--- a/v2/rest/resources/example_test.go
+++ b/v2/rest/resources/example_test.go
@@ -1,0 +1,69 @@
+package resources_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// ExampleClient_Get streams a default style file from a fresh
+// GeoServer install and prints the first line.
+func ExampleClient_Get() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	body, err := c.Resources.Get(context.Background(), "styles/default_point.sld")
+	if err != nil {
+		return
+	}
+	defer body.Close()
+
+	contents, _ := io.ReadAll(body)
+	if i := strings.IndexByte(string(contents), '\n'); i > 0 {
+		fmt.Println(string(contents[:i]))
+	}
+}
+
+// ExampleClient_List dumps the names of every default style.
+func ExampleClient_List() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	dir, err := c.Resources.List(context.Background(), "styles")
+	if err != nil {
+		return
+	}
+	for _, child := range dir.Children {
+		fmt.Println(child.Name)
+	}
+}
+
+// ExampleClient_Put uploads an FTL template that customizes WMS
+// GetFeatureInfo HTML output for a layer.
+func ExampleClient_Put() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	template := `<table>
+<#list features as feature>
+  <tr><td>${feature.name}</td><td>${feature.label}</td></tr>
+</#list>
+</table>
+`
+	_ = c.Resources.Put(context.Background(),
+		"workspaces/topp/featuretypes_states/content.ftl",
+		strings.NewReader(template),
+		"text/plain")
+}
+
+// ExampleClient_Delete removes a single resource.
+func ExampleClient_Delete() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Resources.Delete(context.Background(),
+		"workspaces/topp/featuretypes_states/content.ftl")
+}

--- a/v2/rest/resources/resources.go
+++ b/v2/rest/resources/resources.go
@@ -1,0 +1,257 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	// SynthesizeError surfaces a package-sentinel error (via the
+	// parent's *APIError) for wire responses that are 2xx but
+	// semantically failures — see Resource API's "type=undefined"
+	// for missing paths.
+	SynthesizeError(op, method, requestURL string, statusCode int, bodyHint string) error
+}
+
+// Client is the v2 Resource API sub-client. Construct via [New].
+//
+//	body, err := c.Resources.Get(ctx, "styles/default_point.sld")
+//	if err != nil { return err }
+//	defer body.Close()
+//
+//	dir, err := c.Resources.List(ctx, "styles")
+//	for _, child := range dir.Children { ... }
+//
+//	_ = c.Resources.Put(ctx, "templates/foo.ftl", strings.NewReader(template))
+//	_ = c.Resources.Move(ctx, "templates/foo.ftl", "templates/bar.ftl")
+//	_ = c.Resources.Delete(ctx, "templates/bar.ftl")
+type Client struct {
+	core Core
+}
+
+// New constructs the resource sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// pathSegments builds the URL path for /rest/resource/<path>. The
+// {pathToResource} parameter on the upstream API is treated as a
+// raw multi-segment path; this helper splits the user-supplied
+// path on "/" and returns each segment so the URL helper can
+// path-escape per segment without collapsing the slashes.
+//
+// An empty path resolves to /rest/resource — the top-level data
+// directory listing, which is allowed by the upstream API.
+func pathSegments(path string) []string {
+	parts := splitPath(path)
+	out := make([]string, 0, 2+len(parts))
+	out = append(out, "rest", "resource")
+	out = append(out, parts...)
+	return out
+}
+
+// Get streams the contents of a regular-file resource at path. The
+// caller owns the returned [io.ReadCloser] and must close it.
+//
+// Returns [ErrNotFound]-wrapped error if the path does not exist.
+// Calling Get on a directory will return GeoServer's directory
+// listing (HTML/JSON depending on Accept) — use [Client.List]
+// for typed directory access instead.
+func (c *Client) Get(ctx context.Context, path string) (io.ReadCloser, error) {
+	const op = "Resources.Get"
+	u, err := c.core.URL(pathSegments(path)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	body, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, map[string]string{
+		"operation": "default",
+	})
+	return body, err
+}
+
+// Stat returns metadata for the resource at path — the bare
+// [Metadata] (no children listed even if path is a directory). For
+// the full directory listing including children, use [Client.List].
+//
+// Wire-quirk: GeoServer's operation=metadata endpoint returns
+// 200 OK with type="undefined" for non-existent paths (instead of
+// 404). This method translates that into an [ErrNotFound]-bearing
+// error so callers can match with errors.Is(err, geoserver.ErrNotFound).
+func (c *Client) Stat(ctx context.Context, path string) (*Metadata, error) {
+	const op = "Resources.Stat"
+	u, err := c.core.URL(pathSegments(path)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw resourceMetadataWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, map[string]string{
+		"operation": "metadata",
+		"format":    "json",
+	}, &raw); err != nil {
+		return nil, err
+	}
+	r := raw.ResourceMetadata
+	if r.Type == TypeUndefined {
+		return nil, c.core.SynthesizeError(op, http.MethodGet, u, http.StatusNotFound,
+			fmt.Sprintf("resource %q not found (GeoServer reported type=undefined)", path))
+	}
+	return &Metadata{
+		Name:         r.Name,
+		ParentPath:   r.Parent.Path,
+		LastModified: r.LastModified,
+		Type:         r.Type,
+	}, nil
+}
+
+// List returns the directory listing for path. path must reference
+// a directory — calling List on a regular file returns an error.
+//
+// To distinguish "is this a file or a directory?" without fetching
+// either form, use [Client.Stat] and inspect [Metadata.Type].
+func (c *Client) List(ctx context.Context, path string) (*Directory, error) {
+	const op = "Resources.List"
+	u, err := c.core.URL(pathSegments(path)...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw resourceDirectoryWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, map[string]string{
+		"operation": "default",
+		"format":    "json",
+	}, &raw); err != nil {
+		return nil, err
+	}
+	d := raw.ResourceDirectory
+	dir := &Directory{
+		Metadata: Metadata{
+			Name:         d.Name,
+			ParentPath:   d.Parent.Path,
+			LastModified: d.LastModified,
+			Type:         TypeDirectory,
+		},
+	}
+	if len(d.Children.Child) > 0 {
+		dir.Children = make([]Child, 0, len(d.Children.Child))
+		for _, c := range d.Children.Child {
+			dir.Children = append(dir.Children, Child{
+				Name:     c.Name,
+				Href:     c.Link.Href,
+				MimeType: c.Link.Type,
+			})
+		}
+	}
+	return dir, nil
+}
+
+// Exists reports whether the resource at path exists, and if it
+// does, whether it is a regular file or a directory. A non-existent
+// resource is reported as (false, "", nil) — not as an error.
+//
+// Implemented as a [Client.Stat] under the hood; if you also need
+// the full metadata, prefer Stat directly.
+func (c *Client) Exists(ctx context.Context, path string) (bool, Type, error) {
+	meta, err := c.Stat(ctx, path)
+	if err != nil {
+		// errNotFound is matched at the package level to avoid
+		// hard-coding the parent-package sentinel here. We rely on
+		// the [Core.Do] contract that 404 maps to errors.Is(err,
+		// ErrNotFound) — checked via the package-level helper.
+		if isNotFound(err) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, meta.Type, nil
+}
+
+// Put writes a regular-file resource at path. body is uploaded as
+// the resource's bytes; contentType, if non-empty, is sent in the
+// Content-Type header (otherwise GeoServer guesses from the URL
+// extension and the bytes themselves).
+//
+// Creates the resource if absent and overwrites it if present.
+// Per the upstream API, intermediate directories are created on
+// the fly. PUT is not supported on directories.
+//
+// Returns 200 if an existing resource was overwritten and 201 if a
+// new resource was created; either is treated as success here. The
+// caller does not see the distinction.
+func (c *Client) Put(ctx context.Context, path string, body io.Reader, contentType string) error {
+	const op = "Resources.Put"
+	if path == "" || path == "/" {
+		return errors.New(op + ": path must reference a non-root resource")
+	}
+	u, err := c.core.URL(pathSegments(path)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, body, contentType, "*/*", map[string]string{
+		"operation": "default",
+	})
+}
+
+// Move relocates a resource from srcPath to dstPath. Equivalent to
+// the upstream PUT /resource/{dstPath}?operation=move with the
+// source path as the request body.
+//
+// Returns [ErrNotFound] if srcPath does not exist; 405 (mapped to
+// [ErrMethodNotAllowed]) if dstPath references a directory copy
+// (not allowed by upstream).
+func (c *Client) Move(ctx context.Context, srcPath, dstPath string) error {
+	return c.relocate(ctx, "Resources.Move", srcPath, dstPath, "move")
+}
+
+// Copy duplicates a resource from srcPath to dstPath. Equivalent to
+// the upstream PUT /resource/{dstPath}?operation=copy with the
+// source path as the request body.
+//
+// Per the upstream API, copy is NOT supported on directories — use
+// move + write a new copy if you need to duplicate a directory tree.
+//
+// Returns [ErrNotFound] if srcPath does not exist.
+func (c *Client) Copy(ctx context.Context, srcPath, dstPath string) error {
+	return c.relocate(ctx, "Resources.Copy", srcPath, dstPath, "copy")
+}
+
+// relocate is the shared implementation behind Move and Copy.
+func (c *Client) relocate(ctx context.Context, op, srcPath, dstPath, operation string) error {
+	if srcPath == "" || srcPath == "/" {
+		return errors.New(op + ": srcPath must reference a non-root resource")
+	}
+	if dstPath == "" || dstPath == "/" {
+		return errors.New(op + ": dstPath must reference a non-root resource")
+	}
+	u, err := c.core.URL(pathSegments(dstPath)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u,
+		strings.NewReader(strings.TrimPrefix(srcPath, "/")),
+		"text/plain", "*/*",
+		map[string]string{"operation": operation})
+}
+
+// Delete removes the resource at path. Recursive — passing a
+// directory removes the directory and all descendants.
+//
+// Returns [ErrNotFound] if the path does not exist.
+func (c *Client) Delete(ctx context.Context, path string) error {
+	const op = "Resources.Delete"
+	if path == "" || path == "/" {
+		return errors.New(op + ": refusing to DELETE the root resource directory")
+	}
+	u, err := c.core.URL(pathSegments(path)...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/resources/resources_integration_test.go
+++ b/v2/rest/resources/resources_integration_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package resources_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/resources"
+)
+
+// TestResources_Stat_DirectoryAndFile_Integration confirms the wire
+// shape against a vanilla GeoServer install. The "styles" directory
+// always exists in a fresh data dir; "default_point.sld" is one of
+// the default seed styles.
+func TestResources_Stat_DirectoryAndFile_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	dirMeta, err := c.Resources.Stat(ctx, "styles")
+	if err != nil {
+		t.Fatalf("Stat styles dir: %v", err)
+	}
+	if dirMeta.Name != "styles" {
+		t.Errorf("dir Name = %q", dirMeta.Name)
+	}
+	if dirMeta.Type != resources.TypeDirectory {
+		t.Errorf("dir Type = %q, want directory", dirMeta.Type)
+	}
+
+	fileMeta, err := c.Resources.Stat(ctx, "styles/default_point.sld")
+	if err != nil {
+		t.Fatalf("Stat default_point.sld: %v", err)
+	}
+	if fileMeta.Type != resources.TypeResource {
+		t.Errorf("file Type = %q, want resource", fileMeta.Type)
+	}
+}
+
+func TestResources_List_StylesDir_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	dir, err := c.Resources.List(ctx, "styles")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if dir.Type != resources.TypeDirectory {
+		t.Errorf("Type = %q", dir.Type)
+	}
+	// Vanilla GeoServer ships with multiple default styles; this is
+	// a sanity check that we got a populated listing through.
+	if len(dir.Children) < 5 {
+		t.Errorf("expected ≥5 default styles, got %d", len(dir.Children))
+	}
+	// At least one expected default — default_point.sld is in every
+	// stock distribution.
+	found := false
+	for _, ch := range dir.Children {
+		if ch.Name == "default_point.sld" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("default_point.sld not in listing; children: %v", dir.Children)
+	}
+}
+
+func TestResources_Get_FileContent_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	body, err := c.Resources.Get(ctx, "styles/default_point.sld")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	// SLD is XML — should start with the XML declaration.
+	if !strings.HasPrefix(string(got), "<?xml") {
+		head := got
+		if len(head) > 80 {
+			head = head[:80]
+		}
+		t.Errorf("expected XML body, first 80 bytes: %q", head)
+	}
+}
+
+func TestResources_Exists_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	exists, typ, err := c.Resources.Exists(ctx, "styles/default_point.sld")
+	if err != nil {
+		t.Fatalf("Exists existing: %v", err)
+	}
+	if !exists || typ != resources.TypeResource {
+		t.Errorf("existing file: exists=%v type=%q", exists, typ)
+	}
+
+	exists, _, err = c.Resources.Exists(ctx, "styles/this_does_not_exist_"+fmt.Sprint(time.Now().UnixNano())+".sld")
+	if err != nil {
+		t.Fatalf("Exists missing: %v", err)
+	}
+	if exists {
+		t.Errorf("expected exists=false for missing file")
+	}
+}
+
+// Full create/read/move/copy/delete flow under a unique temp path.
+func TestResources_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Use a unique sub-directory under the writable workspaces/ tree
+	// (which always exists). Filename uses nanosecond uniqueness so
+	// repeated runs don't collide.
+	stamp := time.Now().UnixNano()
+	srcPath := fmt.Sprintf("workspaces/v2_it_%d/test.txt", stamp)
+	movedPath := fmt.Sprintf("workspaces/v2_it_%d/test_moved.txt", stamp)
+	copiedPath := fmt.Sprintf("workspaces/v2_it_%d/test_copy.txt", stamp)
+
+	// Best-effort cleanup: remove the whole temp directory.
+	t.Cleanup(func() {
+		_ = c.Resources.Delete(ctx, fmt.Sprintf("workspaces/v2_it_%d", stamp))
+	})
+
+	const payload = "hello world"
+	if err := c.Resources.Put(ctx, srcPath, strings.NewReader(payload), "text/plain"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Read it back.
+	body, err := c.Resources.Get(ctx, srcPath)
+	if err != nil {
+		t.Fatalf("Get after Put: %v", err)
+	}
+	got, _ := io.ReadAll(body)
+	body.Close()
+	if string(got) != payload {
+		t.Errorf("Get content = %q, want %q", got, payload)
+	}
+
+	// Move.
+	if err := c.Resources.Move(ctx, srcPath, movedPath); err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	// Source should be gone.
+	exists, _, err := c.Resources.Exists(ctx, srcPath)
+	if err != nil {
+		t.Fatalf("Exists src after Move: %v", err)
+	}
+	if exists {
+		t.Errorf("src %q still exists after Move", srcPath)
+	}
+	// Destination should be there.
+	exists, _, err = c.Resources.Exists(ctx, movedPath)
+	if err != nil {
+		t.Fatalf("Exists moved after Move: %v", err)
+	}
+	if !exists {
+		t.Errorf("moved %q not present after Move", movedPath)
+	}
+
+	// Copy moved → copied.
+	if err := c.Resources.Copy(ctx, movedPath, copiedPath); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	for _, p := range []string{movedPath, copiedPath} {
+		exists, _, err := c.Resources.Exists(ctx, p)
+		if err != nil {
+			t.Fatalf("Exists %q after Copy: %v", p, err)
+		}
+		if !exists {
+			t.Errorf("%q missing after Copy", p)
+		}
+	}
+
+	// Delete both.
+	for _, p := range []string{movedPath, copiedPath} {
+		if err := c.Resources.Delete(ctx, p); err != nil {
+			t.Fatalf("Delete %q: %v", p, err)
+		}
+	}
+	// Confirm both gone.
+	for _, p := range []string{movedPath, copiedPath} {
+		_, err := c.Resources.Stat(ctx, p)
+		if !errors.Is(err, geoserver.ErrNotFound) {
+			t.Errorf("Stat %q after Delete: expected ErrNotFound, got %v", p, err)
+		}
+	}
+}

--- a/v2/rest/resources/resources_test.go
+++ b/v2/rest/resources/resources_test.go
@@ -1,0 +1,457 @@
+package resources_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/resources"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// ---- Get (file content streaming) ----
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/resource/styles/default_point.sld" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("operation") != "default" {
+			t.Errorf("operation = %q", r.URL.Query().Get("operation"))
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, `<sld>example</sld>`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	body, err := c.Resources.Get(context.Background(), "styles/default_point.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != `<sld>example</sld>` {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Resources.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// Path with leading slash should still produce the same URL.
+func TestGet_LeadingSlashOK(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.URL.Path != "/rest/resource/styles/foo.sld" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, "x")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	body, err := c.Resources.Get(context.Background(), "/styles/foo.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body.Close()
+	if !called {
+		t.Fatal("server not hit")
+	}
+}
+
+// Path segments with spaces / non-ASCII must be URL-encoded.
+func TestGet_PathEscaping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Decoded form on the server side is "/rest/resource/styles/with space.sld".
+		if r.URL.Path != "/rest/resource/styles/with space.sld" {
+			t.Errorf("decoded path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, "x")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	body, err := c.Resources.Get(context.Background(), "styles/with space.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body.Close()
+}
+
+// ---- Stat (metadata) ----
+
+func TestStat_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("operation") != "metadata" || r.URL.Query().Get("format") != "json" {
+			t.Errorf("operation=%q format=%q", r.URL.Query().Get("operation"), r.URL.Query().Get("format"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceMetadata":{"name":"default_point.sld","parent":{"path":"/styles","link":{"href":"http://srv/rest/resource/styles","rel":"alternate","type":"application/json"}},"lastModified":"2025-10-13 05:03:12.0 UTC","type":"resource"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	meta, err := c.Resources.Stat(context.Background(), "styles/default_point.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Name != "default_point.sld" {
+		t.Errorf("Name = %q", meta.Name)
+	}
+	if meta.ParentPath != "/styles" {
+		t.Errorf("ParentPath = %q", meta.ParentPath)
+	}
+	if meta.Type != resources.TypeResource {
+		t.Errorf("Type = %q", meta.Type)
+	}
+	if meta.LastModified != "2025-10-13 05:03:12.0 UTC" {
+		t.Errorf("LastModified = %q", meta.LastModified)
+	}
+}
+
+func TestStat_UndefinedTypeMapsToNotFound(t *testing.T) {
+	// GeoServer's wire-quirk: missing path returns 200 + type="undefined"
+	// instead of 404. The SDK translates this into ErrNotFound.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceMetadata":{"name":"missing.sld","parent":{"path":"styles"},"lastModified":"1970-01-01 00:00:00.0 UTC","type":"undefined"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Resources.Stat(context.Background(), "styles/missing.sld")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for type=undefined, got %v", err)
+	}
+}
+
+func TestStat_Directory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceMetadata":{"name":"styles","parent":{"path":"/","link":{"href":"http://srv/rest/resource/","rel":"alternate","type":"application/json"}},"lastModified":"2025-10-13 05:03:12.0 UTC","type":"directory"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	meta, err := c.Resources.Stat(context.Background(), "styles")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Type != resources.TypeDirectory {
+		t.Errorf("Type = %q, want directory", meta.Type)
+	}
+}
+
+// ---- List (directory listing) ----
+
+func TestList_OK_MultipleChildren(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("operation") != "default" || r.URL.Query().Get("format") != "json" {
+			t.Errorf("operation=%q format=%q", r.URL.Query().Get("operation"), r.URL.Query().Get("format"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceDirectory":{"name":"styles","parent":{"path":"","link":{"href":"http://srv/rest/resource/","rel":"alternate","type":"application/json"}},"lastModified":"2025-10-13 05:03:12.0 UTC","children":{"child":[{"name":"a.sld","link":{"href":"http://srv/rest/resource/styles/a.sld","rel":"alternate","type":"text/xml"}},{"name":"b.png","link":{"href":"http://srv/rest/resource/styles/b.png","rel":"alternate","type":"image/png"}}]}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	dir, err := c.Resources.List(context.Background(), "styles")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir.Name != "styles" || dir.Type != resources.TypeDirectory {
+		t.Errorf("dir = %+v", dir.Metadata)
+	}
+	if len(dir.Children) != 2 {
+		t.Fatalf("len(Children) = %d", len(dir.Children))
+	}
+	if dir.Children[0].Name != "a.sld" || dir.Children[0].MimeType != "text/xml" {
+		t.Errorf("child[0] = %+v", dir.Children[0])
+	}
+	if dir.Children[1].Name != "b.png" || dir.Children[1].MimeType != "image/png" {
+		t.Errorf("child[1] = %+v", dir.Children[1])
+	}
+}
+
+// Children may collapse to a single object (not array) per GeoServer's
+// classic single-element wire shape.
+func TestList_OK_SingleChildCollapsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceDirectory":{"name":"templates","parent":{"path":""},"lastModified":"2025-10-13","children":{"child":{"name":"only.ftl","link":{"href":"http://srv/rest/resource/templates/only.ftl","rel":"alternate","type":"text/plain"}}}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	dir, err := c.Resources.List(context.Background(), "templates")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dir.Children) != 1 {
+		t.Fatalf("expected 1 child via collapse, got %d", len(dir.Children))
+	}
+	if dir.Children[0].Name != "only.ftl" {
+		t.Errorf("child = %+v", dir.Children[0])
+	}
+}
+
+// Children may be an empty string for an empty directory — same
+// pattern GeoServer uses for empty datastore / coverage / styles
+// collections elsewhere.
+func TestList_OK_EmptyChildrenAsString(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceDirectory":{"name":"empty","parent":{"path":""},"lastModified":"2025-10-13","children":{"child":""}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	dir, err := c.Resources.List(context.Background(), "empty")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dir.Children) != 0 {
+		t.Errorf("expected 0 children, got %d", len(dir.Children))
+	}
+}
+
+// ---- Exists ----
+
+func TestExists_True(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ResourceMetadata":{"name":"x.sld","parent":{"path":""},"lastModified":"2025-10-13","type":"resource"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	exists, typ, err := c.Resources.Exists(context.Background(), "x.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Errorf("expected exists=true")
+	}
+	if typ != resources.TypeResource {
+		t.Errorf("type = %q", typ)
+	}
+}
+
+func TestExists_False(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	exists, typ, err := c.Resources.Exists(context.Background(), "x.sld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Errorf("expected exists=false")
+	}
+	if typ != "" {
+		t.Errorf("type = %q on missing, want empty", typ)
+	}
+}
+
+// ---- Put ----
+
+func TestPut_Created(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/resource/templates/foo.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("operation") != "default" {
+			t.Errorf("operation = %q", r.URL.Query().Get("operation"))
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "text/plain" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "hello" {
+			t.Errorf("body = %q", body)
+		}
+		w.WriteHeader(http.StatusCreated) // 201 — new resource
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Put(context.Background(), "templates/foo.ftl",
+		strings.NewReader("hello"), "text/plain")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPut_OverwriteOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // 200 — existing resource overwritten
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Put(context.Background(), "templates/foo.ftl",
+		strings.NewReader("hello"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPut_RootPathRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	for _, p := range []string{"", "/"} {
+		err := c.Resources.Put(context.Background(), p, strings.NewReader("x"), "")
+		if err == nil || !strings.Contains(err.Error(), "non-root") {
+			t.Errorf("path %q: expected non-root error, got %v", p, err)
+		}
+	}
+}
+
+// ---- Move ----
+
+func TestMove_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/resource/templates/bar.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("operation") != "move" {
+			t.Errorf("operation = %q", r.URL.Query().Get("operation"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "templates/foo.ftl" {
+			t.Errorf("body = %q (expected source path)", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Move(context.Background(), "templates/foo.ftl", "templates/bar.ftl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMove_LeadingSlashesStripped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "templates/foo.ftl" {
+			t.Errorf("body = %q (leading slash should be stripped)", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Move(context.Background(), "/templates/foo.ftl", "/templates/bar.ftl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---- Copy ----
+
+func TestCopy_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("operation") != "copy" {
+			t.Errorf("operation = %q", r.URL.Query().Get("operation"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Copy(context.Background(), "templates/foo.ftl", "templates/foo_backup.ftl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---- Delete ----
+
+func TestDelete_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/resource/templates/foo.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Delete(context.Background(), "templates/foo.ftl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Resources.Delete(context.Background(), "missing.ftl")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDelete_RootPathRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	for _, p := range []string{"", "/"} {
+		err := c.Resources.Delete(context.Background(), p)
+		if err == nil || !strings.Contains(err.Error(), "root resource") {
+			t.Errorf("path %q: expected root-rejection error, got %v", p, err)
+		}
+	}
+}

--- a/v2/rest/resources/status.go
+++ b/v2/rest/resources/status.go
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"errors"
+	"net/http"
+)
+
+// httpStatusErr is satisfied by the parent package's *APIError. We
+// can't import the root v2 package directly (it imports this
+// sub-package, so doing so would create a cycle), so we declare the
+// interface locally and rely on errors.As to walk the wrapping
+// chain.
+type httpStatusErr interface {
+	error
+	HTTPStatusCode() int
+}
+
+// isNotFound reports whether err is a 404 from the wrapped HTTP
+// request, regardless of which sub-client surfaced it.
+func isNotFound(err error) bool {
+	var s httpStatusErr
+	return errors.As(err, &s) && s.HTTPStatusCode() == http.StatusNotFound
+}

--- a/v2/rest/resources/types.go
+++ b/v2/rest/resources/types.go
@@ -1,0 +1,220 @@
+// Package resources is the v2 sub-client for the GeoServer Resource
+// REST API at /rest/resource/{path}. The Resource API provides
+// generic byte-stream access to files in the GeoServer data
+// directory — anything that is data, not configuration. Common
+// uses:
+//
+//   - Read or write FreeMarker (FTL) templates that customize
+//     GetFeatureInfo / WMS HTML output.
+//   - Upload icons or external graphic files referenced from SLD
+//     styles (PNG, SVG).
+//   - Inspect the contents of arbitrary directories under the data
+//     dir (e.g., logs/, styles/, templates/, workspaces/).
+//
+// The API uses a single endpoint with verb- and query-driven
+// behavior: GET reads (with operation=default for content,
+// operation=metadata for a metadata summary); HEAD returns just
+// metadata in headers; PUT writes (with operation=default for
+// upload, operation=move/copy for relocation); DELETE removes
+// (recursively for directories). POST is invalid (405).
+//
+// This package exposes the daily-driver methods: [Client.Get],
+// [Client.List], [Client.Stat], [Client.Exists], [Client.Put],
+// [Client.Move], [Client.Copy], [Client.Delete].
+package resources
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// Type classifies a resource as a regular file (sometimes called a
+// "leaf resource") or a directory. The wire form is the lowercase
+// strings GeoServer returns in the Resource-Type response header
+// and the JSON ResourceMetadata.type field.
+type Type string
+
+// Recognized resource types.
+const (
+	// TypeResource is a regular file resource.
+	TypeResource Type = "resource"
+	// TypeDirectory is a directory of child resources.
+	TypeDirectory Type = "directory"
+	// TypeUndefined is GeoServer's wire-quirk response for a
+	// non-existent path queried via operation=metadata (instead of
+	// returning 404). The [Client.Stat] method translates this into
+	// an [ErrNotFound]-bearing error so callers don't have to
+	// special-case it; you should not see this constant in normal
+	// SDK use unless you bypass [Client.Stat] and call the wire
+	// endpoint directly.
+	TypeUndefined Type = "undefined"
+)
+
+// Metadata describes a single resource. For the bare metadata of a
+// directory (without its children), use [Client.Stat]. For the
+// full directory listing, use [Client.List].
+type Metadata struct {
+	// Name is the leaf name of the resource (e.g. "default_point.sld",
+	// "templates"), without the parent path.
+	Name string
+
+	// ParentPath is the path of the parent directory, slash-separated,
+	// e.g. "" for the root, "/" for a top-level resource, or
+	// "/styles" for a file inside the styles directory. The exact
+	// shape ("/" vs "" for the root) is preserved as GeoServer
+	// returned it.
+	ParentPath string
+
+	// LastModified is the timestamp GeoServer reports for the
+	// resource, in its native string form (e.g.
+	// "2025-10-13 05:03:12.0 UTC"). Left as a string because
+	// GeoServer's format is not RFC 3339; callers that need a
+	// time.Time can parse with the same layout.
+	LastModified string
+
+	// Type is "resource" (regular file) or "directory".
+	Type Type
+}
+
+// Directory is a directory listing — [Metadata] for the directory
+// itself plus the immediate children. Children are populated only
+// when the listing was retrieved via [Client.List]; [Client.Stat]
+// returns just the metadata even for directories (per the upstream
+// REST API's operation=metadata mode).
+type Directory struct {
+	Metadata
+	Children []Child
+}
+
+// Child is one entry in a [Directory] listing.
+type Child struct {
+	// Name is the leaf name (e.g. "default_point.sld").
+	Name string
+	// Href is the absolute URL GeoServer reports for the child
+	// resource. Useful for streaming download but not required —
+	// callers can also reconstruct the path and call
+	// [Client.Get] directly.
+	Href string
+	// MimeType is the Content-Type GeoServer guessed from the
+	// child's name / contents (e.g. "text/xml", "image/png",
+	// "application/octet-stream").
+	MimeType string
+}
+
+// resourceDirectoryWire is the GeoServer JSON envelope for a
+// directory listing — a top-level "ResourceDirectory" object.
+type resourceDirectoryWire struct {
+	ResourceDirectory struct {
+		Name         string    `json:"name"`
+		Parent       parentRef `json:"parent"`
+		LastModified string    `json:"lastModified"`
+		Children     struct {
+			Child childArray `json:"child"`
+		} `json:"children"`
+	} `json:"ResourceDirectory"`
+}
+
+// resourceMetadataWire is the GeoServer JSON envelope for a
+// per-resource metadata document — top-level "ResourceMetadata".
+type resourceMetadataWire struct {
+	ResourceMetadata struct {
+		Name         string    `json:"name"`
+		Parent       parentRef `json:"parent"`
+		LastModified string    `json:"lastModified"`
+		Type         Type      `json:"type"`
+	} `json:"ResourceMetadata"`
+}
+
+// parentRef captures the parent.path field. The full envelope also
+// includes a "link" sub-object with href / rel / type, which the
+// SDK ignores — the parent path is the only piece callers need.
+type parentRef struct {
+	Path string `json:"path"`
+}
+
+// childArray is GeoServer's classic "may be a single object or an
+// array of objects" wire shape. A directory with no children may
+// also omit the field entirely or send it as an empty string.
+type childArray []childWire
+
+// UnmarshalJSON tolerates the three documented shapes for the
+// "child" field:
+//
+//   - a JSON array of child objects (the canonical shape)
+//   - a single child object (single-element collapse)
+//   - an empty string "" (no children, GeoServer's empty-collection
+//     wire form — same pattern used elsewhere in the API)
+func (a *childArray) UnmarshalJSON(b []byte) error {
+	trimmed := bytesTrimSpaceASCII(b)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		*a = nil
+		return nil
+	}
+	switch trimmed[0] {
+	case '[':
+		var arr []childWire
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return err
+		}
+		*a = arr
+		return nil
+	case '{':
+		var single childWire
+		if err := json.Unmarshal(b, &single); err != nil {
+			return err
+		}
+		*a = []childWire{single}
+		return nil
+	case '"':
+		// Empty-collection wire form ("") — treat as no children.
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		if s != "" {
+			return errors.New("resources: unexpected non-empty string for child")
+		}
+		*a = nil
+		return nil
+	default:
+		return errors.New("resources: unexpected JSON shape for child")
+	}
+}
+
+// childWire is one entry of the "child" array on the wire.
+type childWire struct {
+	Name string `json:"name"`
+	Link struct {
+		Href string `json:"href"`
+		Type string `json:"type"`
+	} `json:"link"`
+}
+
+// bytesTrimSpaceASCII trims leading ASCII whitespace from a byte
+// slice. The encoding/json package uses the same definition.
+func bytesTrimSpaceASCII(b []byte) []byte {
+	for len(b) > 0 {
+		c := b[0]
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			break
+		}
+		b = b[1:]
+	}
+	return b
+}
+
+// splitPath converts a slash-separated resource path (e.g.
+// "styles/foo.sld" or "/templates/getfeatureinfo.ftl") into the
+// list of segments expected by [Core.URL]. Leading and trailing
+// slashes are tolerated; empty segments (from "//") are dropped.
+func splitPath(path string) []string {
+	parts := strings.Split(path, "/")
+	out := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Closes the Resource API tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Generic byte-stream access to files in the GeoServer data directory — FreeMarker templates, SLD includes, external graphic icons, and arbitrary descendants of the data dir.

## What lands

**New surface:**
- `c.Resources.Get(ctx, path)` — stream file content (`io.ReadCloser`).
- `c.Resources.Stat(ctx, path)` — bare metadata (no children listed even on directories).
- `c.Resources.List(ctx, path)` — directory listing with children.
- `c.Resources.Exists(ctx, path)` — combined existence + type check; returns `(false, "", nil)` for missing.
- `c.Resources.Put(ctx, path, body, contentType)` — upload / overwrite. Intermediate directories created on the fly.
- `c.Resources.Move(ctx, srcPath, dstPath)` — relocate via upstream `?operation=move`.
- `c.Resources.Copy(ctx, srcPath, dstPath)` — duplicate via `?operation=copy`. Per upstream, copy is not supported on directories.
- `c.Resources.Delete(ctx, path)` — recursive (per upstream).

**Typed:** `Type` (`TypeResource` / `TypeDirectory` / `TypeUndefined`), `Metadata`, `Directory`, `Child`.

**Root plumbing additions:**
- `coreAdapter.DoStream` was a placeholder; now fully wired so any sub-client can stream a response body.
- `coreAdapter.SynthesizeError` — lets sub-clients surface a package sentinel (`ErrNotFound`, etc.) for wire responses that are 2xx but semantically failures.
- `APIError.HTTPStatusCode()` accessor — lets sub-clients branch on status without importing the root v2 package (would cycle).

## Wire-format quirks

Discovered via local integration testing against live GeoServer 2.28.0:

- **`operation=metadata` returns 200 + `type:"undefined"` for missing paths** instead of 404. `Stat` translates this into an `ErrNotFound`-bearing error so callers match with `errors.Is(err, geoserver.ErrNotFound)`.
- **`children.child` is a "may be array, single object, or empty string" field.** A directory with no children may serialize as `"child":""`. A single child may collapse to `"child":{...}` (no array). Custom `UnmarshalJSON` accepts all three shapes.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/resources/...` — 22 unit tests pass (HTTP CRUD + wire-shape edge cases + path escaping + root-path rejection).
- [x] `golangci-lint run ./rest/resources/...` — 0 issues.
- [x] `go vet -tags=integration ./...` — clean.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/resources/...` — 5 PASS (Stat / List / Get / Exists / RoundTrip — the last covers Put → Get → Move → Exists × 2 → Copy → Exists × 2 → Delete × 2 → Stat × 2).
- [x] Full v2 integration suite green — no regressions in other packages.
- [x] Side-fix included: `TestACL_Services_CRUD_Integration` switched rule from `wfs.GetCapabilities` → `wfs.Transaction` so it doesn't race with parallel anonymous WFS GetCapabilities tests.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.