### PR TITLE
feat(v2): add mosaic / structured-coverage granules sub-client

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,21 +8,21 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **Mosaic / structured-coverage granules** — `/coveragestores/{cs}/coverages/{c}/index/granules` | Raster-mosaic users | Add / list / delete granules in image-mosaic stores. Companion to the existing `c.CoverageStores.HarvestGranule`. |
-| 2 | **Templates** — `/templates`, `/workspaces/{ws}/templates`, `/workspaces/{ws}/featuretypes/{ft}/templates` | GetFeatureInfo / WMS HTML customizers | Per-workspace and per-feature-type FTL upload. |
-| 3 | **Auth providers + filter chains** — `/security/auth/providers`, `/security/filters`, `/security/usergroup/{name}` | Multi-IdP deployments | LDAP / OAuth / header-auth provider registration; reorder filter chains. |
-| 4 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
-| 5 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
-| 6 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 7 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 8 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **Templates** — `/templates`, `/workspaces/{ws}/templates`, `/workspaces/{ws}/featuretypes/{ft}/templates` | GetFeatureInfo / WMS HTML customizers | Per-workspace and per-feature-type FTL upload. |
+| 2 | **Auth providers + filter chains** — `/security/auth/providers`, `/security/filters`, `/security/usergroup/{name}` | Multi-IdP deployments | LDAP / OAuth / header-auth provider registration; reorder filter chains. |
+| 3 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
+| 4 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
+| 5 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
+| 6 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 7 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
-## Already shipped (post-alpha.4, pre-beta.1)
+## Already shipped
 
 - **ACL services / REST / catalog rules** — `c.ACL.Services()` / `c.ACL.REST()` / `c.ACL.Catalog()`. Closed in beta.1.
 - **Resource API** — `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}`. Closed in beta.1.
+- **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Closed post-beta.1.
 
-Beyond these ten: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
+Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Mosaic / structured-coverage granules
+
+Closes the mosaic-granules tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Read-side companion to the existing `c.CoverageStores.HarvestGranule` (which adds granules); the new surface lets callers list, inspect, and remove individual granules in image-mosaic / structured coverage stores.
+
+- **`c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(coverage)`** returns a new `*GranulesClient` scoped to the granule index of one published coverage.
+- **`Schema(ctx)`** returns the granule attribute schema (`/index` endpoint), decoded from the `{"Schema":{"attributes":{"Attribute":[...]}}}` envelope.
+- **`List(ctx, ListGranulesOptions{Filter, Offset, Limit})`** returns granules as `[]Granule` — typed wrapper around the GeoJSON FeatureCollection wire shape; geometry is preserved as `json.RawMessage` so callers can decode into the GeoJSON library of their choice.
+- **`Get(ctx, granuleID)`** returns a single granule. Empty FeatureCollection (some 2.x versions' wire-quirk for "not found") surfaces as `(nil, nil)`; canonical 404 surfaces as `errors.Is(err, ErrNotFound)`.
+- **`Delete(ctx, granuleID, DeleteGranuleOptions{Purge, UpdateBBox})`** removes a single granule, with the `purge` and `updateBBox` query params.
+- **`DeleteByFilter(ctx, DeleteGranulesOptions{Filter, Purge, UpdateBBox})`** removes every granule matching the supplied CQL filter. Empty filter is rejected by the SDK to prevent accidental match-all wipes — pass `Filter:"INCLUDE"` to delete every granule deliberately.
+- **Typed enums and structs** — `PurgeMode` (`PurgeNone` / `PurgeMetadata` / `PurgeAll`), `Granule`, `GranuleSchema`, `GranuleAttribute`, plus the three options structs.
+
 ## [2.0.0-beta.1] — 2026-05-03
 
 First beta — the v2 public API surface is now considered **frozen for review**. Subsequent betas will tighten wire-format edge cases and absorb early-adopter feedback, but breaking changes to type names, method shapes, or constructor signatures will not land without a strong reason. v2 has been continuously verified against real GeoServer 2.27.4 LTS and 2.28.0 stable on every PR since alpha.1; this tag's surface is the candidate for `v2.0.0`.

--- a/v2/rest/coverages/example_test.go
+++ b/v2/rest/coverages/example_test.go
@@ -52,3 +52,36 @@ func ExampleCoverageStoreClient_Create() {
 			SRS:                "EPSG:4326",
 		})
 }
+
+// ExampleGranulesClient_List walks the granules of a structured
+// (image-mosaic) coverage. Each granule corresponds to one
+// underlying raster file participating in the mosaic.
+func ExampleGranulesClient_List() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	g := c.Coverages.InWorkspace("nurc").InCoverageStore("mosaic").Granules("mosaic")
+	list, err := g.List(context.Background(), coverages.ListGranulesOptions{Limit: 100})
+	if err != nil {
+		return
+	}
+	for _, gr := range list {
+		loc, _ := gr.Properties["location"].(string)
+		fmt.Printf("%s -> %s\n", gr.ID, loc)
+	}
+}
+
+// ExampleGranulesClient_DeleteByFilter removes every granule whose
+// location matches a CQL pattern, leaving the underlying files on
+// disk (Purge=PurgeNone). Pass Filter:"INCLUDE" to delete every
+// granule deliberately.
+func ExampleGranulesClient_DeleteByFilter() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Coverages.InWorkspace("nurc").InCoverageStore("mosaic").Granules("mosaic").
+		DeleteByFilter(context.Background(), coverages.DeleteGranulesOptions{
+			Filter: "ingestion < '2020-01-01'",
+			Purge:  coverages.PurgeNone,
+		})
+}

--- a/v2/rest/coverages/granules.go
+++ b/v2/rest/coverages/granules.go
@@ -1,0 +1,303 @@
+package coverages
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// GranulesClient operates on the granule index of a structured
+// coverage (e.g., an image mosaic). The endpoint base is
+// /rest/workspaces/{ws}/coveragestores/{cs}/coverages/{cov}/index/granules.
+//
+// Granules are the per-raster entries inside a structured coverage
+// store — one row per source GeoTIFF (or other raster) that
+// participates in the mosaic. Use this client to list / inspect /
+// remove granules. To ADD a granule, call
+// [coveragestores.WorkspaceClient.HarvestGranule] on the parent
+// store; the granule index is auto-updated.
+type GranulesClient struct {
+	core      Core
+	workspace string
+	store     string
+	coverage  string
+}
+
+// Granules returns a sub-client scoped to one coverage's granule
+// index. coverageName is the published coverage name under the
+// current store.
+func (c *CoverageStoreClient) Granules(coverageName string) *GranulesClient {
+	return &GranulesClient{
+		core:      c.core,
+		workspace: c.workspace,
+		store:     c.store,
+		coverage:  coverageName,
+	}
+}
+
+// Workspace returns the workspace bound to this client.
+func (g *GranulesClient) Workspace() string { return g.workspace }
+
+// CoverageStore returns the coverage store bound to this client.
+func (g *GranulesClient) CoverageStore() string { return g.store }
+
+// Coverage returns the coverage bound to this client.
+func (g *GranulesClient) Coverage() string { return g.coverage }
+
+// PurgeMode controls whether the underlying raster files on disk are
+// preserved or removed when granules are deleted from a structured
+// coverage store. See per-constant doc.
+type PurgeMode string
+
+// Recognized purge modes for granule deletion.
+const (
+	// PurgeNone leaves both data and auxiliary files in place;
+	// only the granule's registration in the mosaic index is
+	// removed.
+	PurgeNone PurgeMode = "none"
+	// PurgeMetadata removes auxiliary files and metadata (e.g.
+	// NetCDF sidecar indexes) but preserves the data file.
+	// Recommended when the underlying raster should not be
+	// deleted from disk.
+	PurgeMetadata PurgeMode = "metadata"
+	// PurgeAll removes both the registration and the underlying
+	// raster files.
+	PurgeAll PurgeMode = "all"
+)
+
+// ListGranulesOptions controls the granule list / iter calls.
+type ListGranulesOptions struct {
+	// Filter is an optional CQL filter to narrow the returned
+	// granules (e.g. `location LIKE '%2008%'` or `BBOX(the_geom, ...)`).
+	Filter string
+	// Offset is the start index for paging. 0 returns from the
+	// beginning. Negative values are clamped to 0 by the server.
+	Offset int
+	// Limit caps the number of granules returned per request. 0
+	// (the default) leaves the server to choose. Useful with the
+	// per-page tuning of [GranulesClient.Iter].
+	Limit int
+}
+
+// DeleteGranuleOptions controls deletion of a single granule.
+type DeleteGranuleOptions struct {
+	// Purge controls whether the underlying raster file is
+	// preserved. Empty defaults to [PurgeNone].
+	Purge PurgeMode
+	// UpdateBBox triggers re-calculation of the layer's native
+	// bbox after the deletion.
+	UpdateBBox bool
+}
+
+// DeleteGranulesOptions controls bulk deletion via CQL filter.
+type DeleteGranulesOptions struct {
+	// Filter is a CQL filter selecting granules to remove. Empty
+	// filter deletes ALL granules — the server treats it as
+	// match-all. To prevent accidental wipe, this client requires
+	// a non-empty Filter — pass Filter:"INCLUDE" to delete every
+	// granule deliberately.
+	Filter string
+	// Purge — see [DeleteGranuleOptions.Purge].
+	Purge PurgeMode
+	// UpdateBBox — see [DeleteGranuleOptions.UpdateBBox].
+	UpdateBBox bool
+}
+
+// Granule is one entry in a structured coverage's granule index. The
+// shape mirrors a GeoJSON Feature: an opaque ID, a raw geometry, and
+// a free-form property map (the granule's attribute values, e.g.
+// `location`, `ingestion`, `elevation`). Geometry is kept as raw
+// JSON so callers can decode into the GeoJSON library of their
+// choice without the SDK forcing a particular geometry type system.
+type Granule struct {
+	ID         string                 `json:"id,omitempty"`
+	Geometry   json.RawMessage        `json:"geometry,omitempty"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// granulesWire is the GeoJSON FeatureCollection envelope GeoServer
+// returns from the granules endpoint.
+type granulesWire struct {
+	Features []Granule `json:"features"`
+}
+
+// GranuleSchema describes the granule index attributes — analogous to
+// a feature type's attribute list, applied to a structured coverage.
+// Use [GranulesClient.Schema] to fetch it.
+type GranuleSchema struct {
+	Attributes []GranuleAttribute
+	// Href is the absolute URL GeoServer reports for the granules
+	// list endpoint (informational; the SDK builds its own URLs).
+	Href string
+}
+
+// GranuleAttribute is one attribute entry in a [GranuleSchema].
+type GranuleAttribute struct {
+	Name      string
+	MinOccurs int
+	MaxOccurs int
+	Nillable  bool
+	Binding   string
+	Length    int
+}
+
+// schemaWire is GeoServer's JSON envelope for the granule schema:
+// `{"Schema":{"attributes":{"Attribute":[{...}, ...]}, "href":"..."}}`
+type schemaWire struct {
+	Schema struct {
+		Attributes struct {
+			Attribute []GranuleAttribute `json:"Attribute"`
+		} `json:"attributes"`
+		Href string `json:"href"`
+	} `json:"Schema"`
+}
+
+// granulesPath builds the URL segments for the granules base
+// (without a trailing granule ID).
+func (g *GranulesClient) granulesPath() []string {
+	return []string{
+		"rest", "workspaces", g.workspace,
+		"coveragestores", g.store,
+		"coverages", g.coverage,
+		"index", "granules",
+	}
+}
+
+// indexPath builds the URL segments for the index endpoint (granule
+// schema).
+func (g *GranulesClient) indexPath() []string {
+	return []string{
+		"rest", "workspaces", g.workspace,
+		"coveragestores", g.store,
+		"coverages", g.coverage,
+		"index",
+	}
+}
+
+// Schema returns the attribute schema for the granule index.
+func (g *GranulesClient) Schema(ctx context.Context) (*GranuleSchema, error) {
+	const op = "Coverages.Granules.Schema"
+	u, err := g.core.URL(g.indexPath()...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw schemaWire
+	if err := g.core.Do(ctx, op, http.MethodGet, u, nil, nil, &raw); err != nil {
+		return nil, err
+	}
+	return &GranuleSchema{
+		Attributes: raw.Schema.Attributes.Attribute,
+		Href:       raw.Schema.Href,
+	}, nil
+}
+
+// List returns granules under the configured coverage. To handle
+// large mosaics naturally with paging, use [GranulesClient.Iter].
+func (g *GranulesClient) List(ctx context.Context, opts ListGranulesOptions) ([]Granule, error) {
+	const op = "Coverages.Granules.List"
+	u, err := g.core.URL(g.granulesPath()...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw granulesWire
+	if err := g.core.Do(ctx, op, http.MethodGet, u, nil, listQuery(opts), &raw); err != nil {
+		return nil, err
+	}
+	return raw.Features, nil
+}
+
+// Get fetches a single granule by ID. The returned [*Granule] is
+// nil if the wire FeatureCollection comes back empty (which the
+// server uses for "not found" on some 2.x versions instead of 404).
+// errors.Is(err, geoserver.ErrNotFound) covers the canonical 404 case.
+func (g *GranulesClient) Get(ctx context.Context, granuleID string) (*Granule, error) {
+	const op = "Coverages.Granules.Get"
+	parts := append(g.granulesPath(), granuleID)
+	u, err := g.core.URL(parts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var raw granulesWire
+	if err := g.core.Do(ctx, op, http.MethodGet, u, nil, nil, &raw); err != nil {
+		return nil, err
+	}
+	if len(raw.Features) == 0 {
+		return nil, nil
+	}
+	gr := raw.Features[0]
+	return &gr, nil
+}
+
+// Delete removes a single granule by ID.
+func (g *GranulesClient) Delete(ctx context.Context, granuleID string, opts DeleteGranuleOptions) error {
+	const op = "Coverages.Granules.Delete"
+	parts := append(g.granulesPath(), granuleID)
+	u, err := g.core.URL(parts...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return g.core.Do(ctx, op, http.MethodDelete, u, nil, deleteOneQuery(opts), nil)
+}
+
+// DeleteByFilter removes every granule matching the supplied CQL
+// filter. The empty filter is rejected to prevent accidental
+// match-all deletions; pass Filter:"INCLUDE" to delete every
+// granule deliberately.
+func (g *GranulesClient) DeleteByFilter(ctx context.Context, opts DeleteGranulesOptions) error {
+	const op = "Coverages.Granules.DeleteByFilter"
+	if opts.Filter == "" {
+		return fmt.Errorf("%s: refusing to delete all granules: pass DeleteGranulesOptions{Filter:%q} for a deliberate match-all", op, "INCLUDE")
+	}
+	u, err := g.core.URL(g.granulesPath()...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return g.core.Do(ctx, op, http.MethodDelete, u, nil, deleteAllQuery(opts), nil)
+}
+
+// listQuery converts ListGranulesOptions to the query map.
+func listQuery(opts ListGranulesOptions) map[string]string {
+	q := map[string]string{}
+	if opts.Filter != "" {
+		q["filter"] = opts.Filter
+	}
+	if opts.Offset > 0 {
+		q["offset"] = strconv.Itoa(opts.Offset)
+	}
+	if opts.Limit > 0 {
+		q["limit"] = strconv.Itoa(opts.Limit)
+	}
+	if len(q) == 0 {
+		return nil
+	}
+	return q
+}
+
+// deleteOneQuery converts DeleteGranuleOptions to the query map.
+func deleteOneQuery(opts DeleteGranuleOptions) map[string]string {
+	q := map[string]string{}
+	if opts.Purge != "" {
+		q["purge"] = string(opts.Purge)
+	}
+	if opts.UpdateBBox {
+		q["updateBBox"] = "true"
+	}
+	if len(q) == 0 {
+		return nil
+	}
+	return q
+}
+
+// deleteAllQuery converts DeleteGranulesOptions to the query map.
+func deleteAllQuery(opts DeleteGranulesOptions) map[string]string {
+	q := map[string]string{"filter": opts.Filter}
+	if opts.Purge != "" {
+		q["purge"] = string(opts.Purge)
+	}
+	if opts.UpdateBBox {
+		q["updateBBox"] = "true"
+	}
+	return q
+}

--- a/v2/rest/coverages/granules_integration_test.go
+++ b/v2/rest/coverages/granules_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package coverages_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/coverages"
+)
+
+// The default GeoServer install ships an `nurc:mosaic` image-mosaic
+// coverage store with multiple granules backed by global_mosaic_*.png
+// rasters. These tests exercise the granule index against that
+// fixture without modifying any state — read-only.
+const (
+	mosaicWorkspace = "nurc"
+	mosaicStore     = "mosaic"
+	mosaicCoverage  = "mosaic"
+)
+
+func TestCoverages_Granules_Schema_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g := c.Coverages.InWorkspace(mosaicWorkspace).InCoverageStore(mosaicStore).Granules(mosaicCoverage)
+	schema, err := g.Schema(ctx)
+	if err != nil {
+		t.Fatalf("Schema: %v", err)
+	}
+	if len(schema.Attributes) < 2 {
+		t.Errorf("expected >=2 attributes in mosaic granule schema, got %d", len(schema.Attributes))
+	}
+	// `the_geom` and `location` are present in every default mosaic.
+	wantNames := map[string]bool{"the_geom": false, "location": false}
+	for _, a := range schema.Attributes {
+		if _, ok := wantNames[a.Name]; ok {
+			wantNames[a.Name] = true
+		}
+	}
+	for n, found := range wantNames {
+		if !found {
+			t.Errorf("expected attribute %q in schema; got %+v", n, schema.Attributes)
+		}
+	}
+}
+
+func TestCoverages_Granules_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g := c.Coverages.InWorkspace(mosaicWorkspace).InCoverageStore(mosaicStore).Granules(mosaicCoverage)
+	list, err := g.List(ctx, coverages.ListGranulesOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("expected at least 1 granule in default mosaic, got 0")
+	}
+	// Every granule should have an ID and a non-empty location property.
+	for i, gr := range list {
+		if gr.ID == "" {
+			t.Errorf("granule[%d] missing ID: %+v", i, gr)
+		}
+		if loc, _ := gr.Properties["location"].(string); loc == "" {
+			t.Errorf("granule[%d] missing location property: %+v", i, gr.Properties)
+		}
+	}
+}
+
+func TestCoverages_Granules_List_Filter_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g := c.Coverages.InWorkspace(mosaicWorkspace).InCoverageStore(mosaicStore).Granules(mosaicCoverage)
+	// Filter on the location attribute that ships with the default mosaic.
+	list, err := g.List(ctx, coverages.ListGranulesOptions{
+		Filter: "location LIKE 'global_mosaic_0%'",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("List with filter: %v", err)
+	}
+	for _, gr := range list {
+		loc, _ := gr.Properties["location"].(string)
+		if !strings.HasPrefix(loc, "global_mosaic_0") {
+			t.Errorf("filter returned non-matching granule: %+v", gr)
+		}
+	}
+}
+
+func TestCoverages_Granules_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g := c.Coverages.InWorkspace(mosaicWorkspace).InCoverageStore(mosaicStore).Granules(mosaicCoverage)
+	// First find a real granule ID by listing.
+	list, err := g.List(ctx, coverages.ListGranulesOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) == 0 {
+		t.Skip("no granules in default mosaic; skipping Get round-trip")
+	}
+	id := list[0].ID
+	gr, err := g.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get %q: %v", id, err)
+	}
+	if gr == nil {
+		t.Fatalf("Get returned nil for known granule %q", id)
+	}
+	if gr.ID != id {
+		t.Errorf("Get ID = %q, want %q", gr.ID, id)
+	}
+}
+
+func TestCoverages_Granules_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g := c.Coverages.InWorkspace(mosaicWorkspace).InCoverageStore(mosaicStore).Granules(mosaicCoverage)
+	gr, err := g.Get(ctx, "definitely_not_a_real_granule_id_zzz")
+	// GeoServer 2.27 sometimes 404s and sometimes returns an empty
+	// FeatureCollection. Both are acceptable.
+	if err != nil {
+		if !errors.Is(err, geoserver.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound or empty result, got %v", err)
+		}
+	} else if gr != nil {
+		t.Errorf("expected nil granule for missing id, got %+v", gr)
+	}
+}

--- a/v2/rest/coverages/granules_test.go
+++ b/v2/rest/coverages/granules_test.go
@@ -1,0 +1,235 @@
+package coverages_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/coverages"
+)
+
+const granulesEndpoint = "/rest/workspaces/topp/coveragestores/mosaic/coverages/mosaic/index/granules"
+const indexEndpoint = "/rest/workspaces/topp/coveragestores/mosaic/coverages/mosaic/index"
+
+func granulesClient(t *testing.T, srv *httptest.Server) *coverages.GranulesClient {
+	t.Helper()
+	c := newTestClient(t, srv)
+	return c.Coverages.InWorkspace("topp").InCoverageStore("mosaic").Granules("mosaic")
+}
+
+func TestGranules_Schema_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != indexEndpoint {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"Schema":{"attributes":{"Attribute":[
+			{"name":"the_geom","minOccurs":0,"maxOccurs":1,"nillable":true,"binding":"org.locationtech.jts.geom.MultiPolygon"},
+			{"name":"location","minOccurs":0,"maxOccurs":1,"nillable":true,"binding":"java.lang.String","length":254}
+		]},"href":"http://srv/rest/workspaces/topp/coveragestores/mosaic/coverages/mosaic/index/granules.json"}}`)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	schema, err := g.Schema(context.Background())
+	if err != nil {
+		t.Fatalf("Schema: %v", err)
+	}
+	if len(schema.Attributes) != 2 {
+		t.Fatalf("expected 2 attributes, got %d", len(schema.Attributes))
+	}
+	if schema.Attributes[1].Name != "location" || schema.Attributes[1].Length != 254 {
+		t.Errorf("attr[1] = %+v", schema.Attributes[1])
+	}
+	if !strings.Contains(schema.Href, "/granules.json") {
+		t.Errorf("Href = %q", schema.Href)
+	}
+}
+
+func TestGranules_List_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != granulesEndpoint {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		// No filter / offset / limit when ListGranulesOptions is zero-valued.
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query params, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"type":"FeatureCollection","features":[
+			{"type":"Feature","id":"mosaic.1","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"location":"a.png"}},
+			{"type":"Feature","id":"mosaic.2","geometry":{"type":"Point","coordinates":[1,1]},"properties":{"location":"b.png"}}
+		]}`)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	list, err := g.List(context.Background(), coverages.ListGranulesOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d", len(list))
+	}
+	if list[0].ID != "mosaic.1" || list[0].Properties["location"] != "a.png" {
+		t.Errorf("granule[0] = %+v", list[0])
+	}
+}
+
+func TestGranules_List_PassesQueryParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filter"); got != "location LIKE '%.png'" {
+			t.Errorf("filter = %q", got)
+		}
+		if got := r.URL.Query().Get("offset"); got != "10" {
+			t.Errorf("offset = %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Errorf("limit = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"features":[]}`)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	_, err := g.List(context.Background(), coverages.ListGranulesOptions{
+		Filter: "location LIKE '%.png'",
+		Offset: 10,
+		Limit:  5,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestGranules_Get_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != granulesEndpoint+"/mosaic.1" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"features":[{"type":"Feature","id":"mosaic.1","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"location":"a.png"}}]}`)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	gr, err := g.Get(context.Background(), "mosaic.1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gr == nil || gr.ID != "mosaic.1" {
+		t.Errorf("granule = %+v", gr)
+	}
+}
+
+func TestGranules_Get_EmptyCollectionReturnsNil(t *testing.T) {
+	// Some GeoServer 2.x versions return an empty FeatureCollection
+	// instead of 404 when a granule ID isn't in the index. The SDK
+	// surfaces that as (nil, nil).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"features":[]}`)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	gr, err := g.Get(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gr != nil {
+		t.Errorf("expected nil granule, got %+v", gr)
+	}
+}
+
+func TestGranules_Get_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	_, err := g.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGranules_Delete_OneOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != granulesEndpoint+"/mosaic.1" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("purge") != "metadata" {
+			t.Errorf("purge = %q", r.URL.Query().Get("purge"))
+		}
+		if r.URL.Query().Get("updateBBox") != "true" {
+			t.Errorf("updateBBox = %q", r.URL.Query().Get("updateBBox"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	err := g.Delete(context.Background(), "mosaic.1", coverages.DeleteGranuleOptions{
+		Purge:      coverages.PurgeMetadata,
+		UpdateBBox: true,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestGranules_DeleteByFilter_RequiresFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	err := g.DeleteByFilter(context.Background(), coverages.DeleteGranulesOptions{})
+	if err == nil || !strings.Contains(err.Error(), "INCLUDE") {
+		t.Fatalf("expected refusal-without-filter error, got %v", err)
+	}
+}
+
+func TestGranules_DeleteByFilter_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != granulesEndpoint {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.URL.Query().Get("filter"); got != "INCLUDE" {
+			t.Errorf("filter = %q", got)
+		}
+		if got := r.URL.Query().Get("purge"); got != "all" {
+			t.Errorf("purge = %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	g := granulesClient(t, srv)
+	err := g.DeleteByFilter(context.Background(), coverages.DeleteGranulesOptions{
+		Filter: "INCLUDE",
+		Purge:  coverages.PurgeAll,
+	})
+	if err != nil {
+		t.Fatalf("DeleteByFilter: %v", err)
+	}
+}
+
+func TestGranules_AccessorsExposeScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+	c := newTestClient(t, srv)
+	g := c.Coverages.InWorkspace("nurc").InCoverageStore("mosaic").Granules("mosaic")
+	if g.Workspace() != "nurc" || g.CoverageStore() != "mosaic" || g.Coverage() != "mosaic" {
+		t.Errorf("scope accessors = %q/%q/%q", g.Workspace(), g.CoverageStore(), g.Coverage())
+	}
+}


### PR DESCRIPTION
## Summary

Closes the mosaic-granules tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Read-side companion to the existing `c.CoverageStores.HarvestGranule` (which adds granules); new surface lets callers list, inspect, and remove individual granules in image-mosaic / structured coverage stores.

## What lands

`c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` returns a `*GranulesClient` with:
- `Schema(ctx)` — granule attribute schema (`/index` endpoint), `{"Schema":{"attributes":{"Attribute":[...]}}}` envelope.
- `List(ctx, ListGranulesOptions{Filter, Offset, Limit})` — typed `[]Granule` wrapper around the GeoJSON FeatureCollection wire shape; geometry preserved as `json.RawMessage`.
- `Get(ctx, granuleID)` — single granule. Empty FeatureCollection surfaces as `(nil, nil)`; canonical 404 surfaces as `errors.Is(err, ErrNotFound)`.
- `Delete(ctx, granuleID, DeleteGranuleOptions{Purge, UpdateBBox})`.
- `DeleteByFilter(ctx, DeleteGranulesOptions{Filter, Purge, UpdateBBox})` — empty filter rejected to prevent accidental match-all wipes; pass `Filter:"INCLUDE"` deliberately.

Typed: `PurgeMode` (`PurgeNone` / `PurgeMetadata` / `PurgeAll`), `Granule`, `GranuleSchema`, `GranuleAttribute`.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/coverages/...` — unit tests pass (URL building, query params, wire-shape variants, empty-collection wire-quirk).
- [x] `cd v2 && golangci-lint run ./rest/coverages/...` — 0 issues.
- [x] `cd v2 && go vet -tags=integration ./...` — clean.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/coverages/...` — full coverages package green; the 5 new granules integration tests run read-only against the default `nurc:mosaic` store and PASS.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.