### PR TITLE
feat(v2): add Templates (FTL) sub-client

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,19 +8,19 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **Templates** — `/templates`, `/workspaces/{ws}/templates`, `/workspaces/{ws}/featuretypes/{ft}/templates` | GetFeatureInfo / WMS HTML customizers | Per-workspace and per-feature-type FTL upload. |
-| 2 | **Auth providers + filter chains** — `/security/auth/providers`, `/security/filters`, `/security/usergroup/{name}` | Multi-IdP deployments | LDAP / OAuth / header-auth provider registration; reorder filter chains. |
-| 3 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
-| 4 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
-| 5 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 6 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 7 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **Auth providers + filter chains** — `/security/auth/providers`, `/security/filters`, `/security/usergroup/{name}` | Multi-IdP deployments | LDAP / OAuth / header-auth provider registration; reorder filter chains. |
+| 2 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
+| 3 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
+| 4 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
+| 5 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 6 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
 - **ACL services / REST / catalog rules** — `c.ACL.Services()` / `c.ACL.REST()` / `c.ACL.Catalog()`. Closed in beta.1.
 - **Resource API** — `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}`. Closed in beta.1.
 - **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Closed post-beta.1.
+- **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Templates (FTL) sub-client
+
+Closes the templates tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). FreeMarker (FTL) templates customize GetFeatureInfo HTML output, WMS HTML capabilities, and other text outputs; GeoServer scopes them at six nested levels and looks up most-specific to global at request time.
+
+- **`c.Templates`** is the global root. Fluent scoping narrows to `InWorkspace(ws)` → `InDatastore(ds)` → `InFeatureType(ft)`, or `InWorkspace(ws)` → `InCoverageStore(cs)` → `InCoverage(cov)`.
+- **`List(ctx)`** returns `[]TemplateRef` decoded from the class-name-wrapped envelope (`{"org.geoserver.rest.catalog.TemplateInfos":{"org.geoserver.rest.catalog.TemplateInfo":[...]}}`).
+- **`Get(ctx, name)`** streams the FTL body and returns it as a string.
+- **`Put(ctx, name, body io.Reader)`** / **`PutString(ctx, name, body string)`** write or overwrite a template (PUT with `Content-Type: text/plain`).
+- **`Delete(ctx, name)`** removes a template at this scope.
+- **`.ftl` suffix is auto-normalized.** `Get(ctx, "foo")` and `Get(ctx, "foo.ftl")` both target the same resource. List returns names with the suffix preserved.
+
 ### Added — Mosaic / structured-coverage granules
 
 Closes the mosaic-granules tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Read-side companion to the existing `c.CoverageStores.HarvestGranule` (which adds granules); the new surface lets callers list, inspect, and remove individual granules in image-mosaic / structured coverage stores.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/settings"
 	"github.com/hishamkaram/geoserver/v2/rest/styles"
 	"github.com/hishamkaram/geoserver/v2/rest/system"
+	"github.com/hishamkaram/geoserver/v2/rest/templates"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 
 	"github.com/hishamkaram/geoserver/v2/ows/wcs"
@@ -174,6 +175,14 @@ type Client struct {
 	// resources (FTL templates, SLD includes, icons), moving /
 	// copying files, and recursive deletion.
 	Resources *resources.Client
+
+	// Templates is the entry point for FreeMarker (FTL) templates
+	// that customize GetFeatureInfo HTML output, WMS HTML
+	// capabilities, and other text outputs. Six scope levels are
+	// supported — global, per workspace, per datastore, per feature
+	// type, per coverage store, per coverage — via fluent
+	// `c.Templates.InWorkspace(ws).In...()` chains.
+	Templates *templates.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -251,6 +260,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.GWC = gwc.New(adapter)
 	c.Imports = imports.New(adapter)
 	c.Resources = resources.New(adapter)
+	c.Templates = templates.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/templates/example_test.go
+++ b/v2/rest/templates/example_test.go
@@ -1,0 +1,58 @@
+package templates_test
+
+import (
+	"context"
+	"fmt"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	_ "github.com/hishamkaram/geoserver/v2/rest/templates"
+)
+
+// ExampleClient_PutString uploads an FTL template that customizes
+// WMS GetFeatureInfo HTML output for one feature type. The same
+// API works at every scope (global / workspace / datastore / feature
+// type / coverage store / coverage).
+func ExampleClient_PutString() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	template := `<table>
+<#list features as feature>
+  <tr><td>${feature.STATE_NAME.value}</td><td>${feature.PERSONS.value}</td></tr>
+</#list>
+</table>`
+
+	_ = c.Templates.InWorkspace("topp").
+		InDatastore("states_pg").
+		InFeatureType("states").
+		PutString(context.Background(), "content", template)
+}
+
+// ExampleClient_List enumerates the templates registered at a scope.
+// At every scope the wire shape is the same (a TemplateInfos
+// envelope with one TemplateInfo per template).
+func ExampleClient_List() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	list, err := c.Templates.InWorkspace("topp").List(context.Background())
+	if err != nil {
+		return
+	}
+	for _, ref := range list {
+		fmt.Println(ref.Name)
+	}
+}
+
+// ExampleClient_Delete removes a template at the most-specific
+// scope. GeoServer's runtime template lookup then falls back to
+// the next-broader scope (e.g. workspace, then global) automatically.
+func ExampleClient_Delete() {
+	c, _ := geoserver.New("http://localhost:8080/geoserver",
+		geoserver.WithBasicAuth("admin", "geoserver"))
+
+	_ = c.Templates.InWorkspace("topp").
+		InDatastore("states_pg").
+		InFeatureType("states").
+		Delete(context.Background(), "content")
+}

--- a/v2/rest/templates/templates.go
+++ b/v2/rest/templates/templates.go
@@ -1,0 +1,187 @@
+package templates
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Client is the v2 templates sub-client. It is fluently scoped from
+// the global root via [Client.InWorkspace], [Client.InDatastore],
+// [Client.InFeatureType], [Client.InCoverageStore], [Client.InCoverage].
+type Client struct {
+	core Core
+
+	// scopePath is the URL prefix segments for this scope, NOT
+	// including "rest" or the trailing "templates". Concrete examples:
+	//   global       -> nil
+	//   workspace    -> ["workspaces", ws]
+	//   datastore    -> ["workspaces", ws, "datastores", ds]
+	//   featuretype  -> ["workspaces", ws, "datastores", ds, "featuretypes", ft]
+	//   coveragestore-> ["workspaces", ws, "coveragestores", cs]
+	//   coverage     -> ["workspaces", ws, "coveragestores", cs, "coverages", cov]
+	scopePath []string
+}
+
+// New constructs the templates sub-client at the global scope.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace narrows the scope to the named workspace's
+// /workspaces/{ws}/templates endpoint.
+func (c *Client) InWorkspace(workspace string) *Client {
+	return c.with("workspaces", workspace)
+}
+
+// InDatastore narrows further to /workspaces/{ws}/datastores/{ds}/templates.
+// Must be called on a workspace-scoped client (after [Client.InWorkspace]).
+// On other scopes the result is undefined; the SDK does not validate.
+func (c *Client) InDatastore(datastore string) *Client {
+	return c.with("datastores", datastore)
+}
+
+// InFeatureType narrows to
+// /workspaces/{ws}/datastores/{ds}/featuretypes/{ft}/templates.
+// Must be called on a datastore-scoped client.
+func (c *Client) InFeatureType(featureType string) *Client {
+	return c.with("featuretypes", featureType)
+}
+
+// InCoverageStore narrows to /workspaces/{ws}/coveragestores/{cs}/templates.
+// Must be called on a workspace-scoped client.
+func (c *Client) InCoverageStore(coverageStore string) *Client {
+	return c.with("coveragestores", coverageStore)
+}
+
+// InCoverage narrows to
+// /workspaces/{ws}/coveragestores/{cs}/coverages/{cov}/templates.
+// Must be called on a coverage-store-scoped client.
+func (c *Client) InCoverage(coverage string) *Client {
+	return c.with("coverages", coverage)
+}
+
+// with returns a copy of the client with extra path segments
+// appended. The original client is unchanged so chains can fork.
+func (c *Client) with(seg ...string) *Client {
+	next := make([]string, 0, len(c.scopePath)+len(seg))
+	next = append(next, c.scopePath...)
+	next = append(next, seg...)
+	return &Client{core: c.core, scopePath: next}
+}
+
+// listURL builds the URL for the scope's templates list endpoint.
+func (c *Client) listURL() (string, error) {
+	parts := make([]string, 0, 2+len(c.scopePath))
+	parts = append(parts, "rest")
+	parts = append(parts, c.scopePath...)
+	parts = append(parts, "templates")
+	return c.core.URL(parts...)
+}
+
+// templateURL builds the URL for one template within this scope.
+// name is normalized via [ensureFTL].
+func (c *Client) templateURL(name string) (string, error) {
+	parts := make([]string, 0, 3+len(c.scopePath))
+	parts = append(parts, "rest")
+	parts = append(parts, c.scopePath...)
+	parts = append(parts, "templates", ensureFTL(name))
+	return c.core.URL(parts...)
+}
+
+// List returns every template registered at this scope.
+func (c *Client) List(ctx context.Context) ([]TemplateRef, error) {
+	const op = "Templates.List"
+	u, err := c.listURL()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	// Append .json so GeoServer returns the typed JSON envelope
+	// instead of the default HTML page.
+	u += ".json"
+	var raw templatesWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &raw); err != nil {
+		return nil, err
+	}
+	return raw.Infos.Info, nil
+}
+
+// Get returns the body of one template at this scope as a string.
+// FTL templates are typically small text files; bodies larger than
+// a few hundred KB are unusual.
+//
+// Returns [ErrNotFound]-wrapped error if the template does not exist
+// at this scope. Note that GeoServer's template lookup walks from
+// most-specific to global at request time — this method ONLY checks
+// the exact scope, so a "not found" here doesn't mean the template
+// is unavailable to the layer at all.
+func (c *Client) Get(ctx context.Context, name string) (string, error) {
+	const op = "Templates.Get"
+	if name == "" {
+		return "", errors.New(op + ": empty name")
+	}
+	u, err := c.templateURL(name)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", op, err)
+	}
+	body, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = body.Close() }()
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return "", fmt.Errorf("%s: read body: %w", op, err)
+	}
+	return string(b), nil
+}
+
+// Put creates or overwrites a template at this scope. body is
+// the FTL source bytes; contentType defaults to "text/plain".
+//
+// GeoServer returns 201 Created for new templates and 200 OK for
+// overwrites; this method treats both as success.
+func (c *Client) Put(ctx context.Context, name string, body io.Reader) error {
+	const op = "Templates.Put"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if body == nil {
+		body = strings.NewReader("")
+	}
+	u, err := c.templateURL(name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, body, "text/plain", "*/*", nil)
+}
+
+// PutString is a convenience wrapper around [Client.Put] for the
+// common case of a string-literal FTL body.
+func (c *Client) PutString(ctx context.Context, name, body string) error {
+	return c.Put(ctx, name, strings.NewReader(body))
+}
+
+// Delete removes a template at this scope.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	const op = "Templates.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.templateURL(name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/templates/templates_integration_test.go
+++ b/v2/rest/templates/templates_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package templates_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+)
+
+// Templates ride on /workspaces/{ws}/... etc., so the test scope
+// uses the always-present "topp" workspace and the always-present
+// "nurc/mosaic/mosaic" coverage. Naming with a nanosecond timestamp
+// avoids collisions across runs (the test suite tries to clean up
+// but skipped/aborted runs may leave templates behind).
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
+func TestTemplates_Global_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	name := uniqueName("v2_it_global")
+	body := "Hello from " + name + "\n"
+
+	t.Cleanup(func() { _ = c.Templates.Delete(ctx, name) })
+
+	if err := c.Templates.PutString(ctx, name, body); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := c.Templates.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != body {
+		t.Errorf("Get = %q, want %q", got, body)
+	}
+
+	// List should include the new template.
+	list, err := c.Templates.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := name + ".ftl"
+	found := false
+	for _, ref := range list {
+		if ref.Name == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("template %q not in List", want)
+	}
+
+	if err := c.Templates.Delete(ctx, name); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := c.Templates.Get(ctx, name); !errors.Is(err, geoserver.ErrNotFound) {
+		t.Errorf("Get after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestTemplates_Workspace_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	scope := c.Templates.InWorkspace("topp")
+	name := uniqueName("v2_it_ws")
+	body := "ws scope " + name
+
+	t.Cleanup(func() { _ = scope.Delete(ctx, name) })
+
+	if err := scope.PutString(ctx, name, body); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := scope.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != body {
+		t.Errorf("Get = %q", got)
+	}
+	if err := scope.Delete(ctx, name); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestTemplates_Coverage_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	scope := c.Templates.InWorkspace("nurc").
+		InCoverageStore("mosaic").
+		InCoverage("mosaic")
+	name := uniqueName("v2_it_cov")
+	body := "coverage scope " + name
+
+	t.Cleanup(func() { _ = scope.Delete(ctx, name) })
+
+	if err := scope.PutString(ctx, name, body); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if got, err := scope.Get(ctx, name); err != nil {
+		t.Fatalf("Get: %v", err)
+	} else if got != body {
+		t.Errorf("Get = %q", got)
+	}
+	// Confirm the new template is listed at the coverage scope.
+	list, err := scope.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := name + ".ftl"
+	found := false
+	for _, ref := range list {
+		if ref.Name == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("template %q not listed; saw %v", want, list)
+	}
+}
+
+func TestTemplates_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+	_, err := c.Templates.Get(ctx, uniqueName("v2_it_definitely_not_a_template"))
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestTemplates_AcceptsNameWithFTLSuffix_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+	name := uniqueName("v2_it_suffix") + ".ftl"
+
+	t.Cleanup(func() { _ = c.Templates.Delete(ctx, name) })
+	if err := c.Templates.PutString(ctx, name, "x"); err != nil {
+		t.Fatalf("Put with .ftl suffix: %v", err)
+	}
+	if got, err := c.Templates.Get(ctx, strings.TrimSuffix(name, ".ftl")); err != nil {
+		t.Fatalf("Get without .ftl suffix: %v", err)
+	} else if got != "x" {
+		t.Errorf("body = %q", got)
+	}
+}

--- a/v2/rest/templates/templates_test.go
+++ b/v2/rest/templates/templates_test.go
@@ -1,0 +1,256 @@
+package templates_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// ---- List shapes ----
+
+func TestList_Global_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/templates.json" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"org.geoserver.rest.catalog.TemplateInfos":{"org.geoserver.rest.catalog.TemplateInfo":[
+			{"name":"a.ftl","href":"http://srv/rest/templates/a.ftl.json"},
+			{"name":"b.ftl","href":"http://srv/rest/templates/b.ftl.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.Templates.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 || list[0].Name != "a.ftl" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestList_Workspace_PathOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/templates.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"org.geoserver.rest.catalog.TemplateInfos":{"org.geoserver.rest.catalog.TemplateInfo":[]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Templates.InWorkspace("topp").List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestList_FeatureType_PathOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/rest/workspaces/topp/datastores/states_pg/featuretypes/states/templates.json"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"org.geoserver.rest.catalog.TemplateInfos":{"org.geoserver.rest.catalog.TemplateInfo":[]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Templates.InWorkspace("topp").
+		InDatastore("states_pg").
+		InFeatureType("states").
+		List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestList_Coverage_PathOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/rest/workspaces/nurc/coveragestores/mosaic/coverages/mosaic/templates.json"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"org.geoserver.rest.catalog.TemplateInfos":{}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Templates.InWorkspace("nurc").
+		InCoverageStore("mosaic").
+		InCoverage("mosaic").
+		List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+// ---- Get / Put / Delete ----
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/templates/header.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "<#-- header -->\nHello")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	body, err := c.Templates.Get(context.Background(), "header")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !strings.Contains(body, "Hello") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestGet_NameWithFTLNotDoubled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Caller passed "header.ftl"; URL must NOT be header.ftl.ftl.
+		if r.URL.Path != "/rest/templates/header.ftl" {
+			t.Errorf("path = %q (suffix doubled?)", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "x")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Templates.Get(context.Background(), "header.ftl")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Templates.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestPut_Created(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/templates/foo.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "text/plain" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "hello" {
+			t.Errorf("body = %q", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Templates.PutString(context.Background(), "foo", "hello"); err != nil {
+		t.Fatalf("PutString: %v", err)
+	}
+}
+
+func TestPut_OverwriteOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Templates.PutString(context.Background(), "foo", "hello"); err != nil {
+		t.Fatalf("PutString: %v", err)
+	}
+}
+
+func TestPut_EmptyNameRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Templates.PutString(context.Background(), "", "x")
+	if err == nil || !strings.Contains(err.Error(), "empty name") {
+		t.Fatalf("expected empty-name error, got %v", err)
+	}
+}
+
+func TestDelete_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/templates/foo.ftl" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Templates.Delete(context.Background(), "foo"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Templates.Delete(context.Background(), "foo")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ---- Workspace-scoped CRUD path verification ----
+
+func TestPut_Workspace_PathOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/templates/content.ftl" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Templates.InWorkspace("topp").PutString(context.Background(), "content", "x")
+	if err != nil {
+		t.Fatalf("PutString: %v", err)
+	}
+}

--- a/v2/rest/templates/types.go
+++ b/v2/rest/templates/types.go
@@ -1,0 +1,69 @@
+// Package templates is the v2 sub-client for the GeoServer
+// /rest/.../templates endpoint family. Templates are FreeMarker
+// (FTL) files that customize GetFeatureInfo HTML output, WMS
+// HTML capabilities, and other text outputs.
+//
+// GeoServer scopes templates at six nested levels — global, per
+// workspace, per datastore, per feature type, per coverage store,
+// and per coverage. Lookup walks from the most specific applicable
+// scope outward to global. The SDK exposes the chain via fluent
+// scoping starting from [Client]:
+//
+//	c.Templates                                                              // global
+//	c.Templates.InWorkspace(ws)                                              // workspace
+//	c.Templates.InWorkspace(ws).InDatastore(ds)                              // datastore
+//	c.Templates.InWorkspace(ws).InDatastore(ds).InFeatureType(ft)            // feature type
+//	c.Templates.InWorkspace(ws).InCoverageStore(cs)                          // coverage store
+//	c.Templates.InWorkspace(ws).InCoverageStore(cs).InCoverage(cov)          // coverage
+//
+// Each scope exposes the same four methods: [Client.List],
+// [Client.Get], [Client.Put], [Client.Delete].
+//
+// Template names: GeoServer stores templates with a ".ftl"
+// extension. The SDK accepts names with or without the suffix and
+// normalizes — `c.Templates.Get(ctx, "foo")` and
+// `c.Templates.Get(ctx, "foo.ftl")` both target the same resource.
+package templates
+
+import "strings"
+
+// TemplateRef is one entry in the templates listing for a scope.
+type TemplateRef struct {
+	// Name is the template's filename, including the ".ftl" suffix
+	// (e.g. "content.ftl", "header.ftl"). Pass either form
+	// (with or without ".ftl") back to [Client.Get],
+	// [Client.Put], or [Client.Delete] — the SDK normalizes.
+	Name string
+	// Href is the absolute URL GeoServer reports for the template
+	// (informational; the SDK builds its own URLs internally).
+	Href string
+}
+
+// templatesWire is the GeoServer JSON envelope for a templates
+// listing. Class-name wrapper keys are GeoServer's canonical wire
+// shape for non-catalog list endpoints (same family as GWC's
+// `org.geowebcache.diskquota.DiskQuotaConfig` etc.):
+//
+//	{"org.geoserver.rest.catalog.TemplateInfos":{
+//	   "org.geoserver.rest.catalog.TemplateInfo":[
+//	     {"name":"foo.ftl","href":"http://srv/.../foo.ftl.json"},
+//	     ...
+//	   ]
+//	 }}
+//
+// Empty list collapses to an empty object on the wire shape.
+type templatesWire struct {
+	Infos struct {
+		Info []TemplateRef `json:"org.geoserver.rest.catalog.TemplateInfo"`
+	} `json:"org.geoserver.rest.catalog.TemplateInfos"`
+}
+
+// ensureFTL appends ".ftl" if the user-supplied name doesn't already
+// have it. Empty input is returned unchanged so the caller sees a
+// dedicated "empty name" error rather than a surprise URL.
+func ensureFTL(name string) string {
+	if name == "" || strings.HasSuffix(name, ".ftl") {
+		return name
+	}
+	return name + ".ftl"
+}


### PR DESCRIPTION
## Summary

Closes the templates tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). FreeMarker (FTL) templates customize GetFeatureInfo HTML output, WMS HTML capabilities, and other text outputs. GeoServer scopes them at six nested levels and looks up most-specific to global at request time.

## What lands

- `c.Templates` is the global root.
- Fluent scoping: `InWorkspace(ws)`, `InDatastore(ds)`, `InFeatureType(ft)`, `InCoverageStore(cs)`, `InCoverage(cov)`. Same four methods at every scope.
- `List(ctx)` — typed `[]TemplateRef` from the class-name-wrapped envelope (`{"org.geoserver.rest.catalog.TemplateInfos":{"...TemplateInfo":[...]}}`).
- `Get(ctx, name)` — streamed FTL body returned as a string.
- `Put(ctx, name, body io.Reader)` / `PutString(ctx, name, body string)` write or overwrite (PUT with `Content-Type: text/plain`).
- `Delete(ctx, name)` removes a template at this scope.
- **`.ftl` suffix is auto-normalized**: `Get(ctx, "foo")` and `Get(ctx, "foo.ftl")` both target the same resource. List returns names with the suffix preserved.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/templates/...` — unit tests pass (URL building at 4 scope depths + suffix normalization + Get/Put/Delete + 404 mapping).
- [x] `golangci-lint run ./rest/templates/...` — 0 issues.
- [x] `go vet -tags=integration ./...` — clean.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/templates/...` — 5 PASS (global / workspace / coverage round-trips + 404 + .ftl-suffix tolerance).
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.