### PR TITLE
feat(v2): add auth providers, auth filters, filter chains

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,12 +8,11 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **Auth providers + filter chains** — `/security/auth/providers`, `/security/filters`, `/security/usergroup/{name}` | Multi-IdP deployments | LDAP / OAuth / header-auth provider registration; reorder filter chains. |
-| 2 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
-| 3 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
-| 4 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 5 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 6 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
+| 2 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
+| 3 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
+| 4 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 5 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
@@ -21,6 +20,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **Resource API** — `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}`. Closed in beta.1.
 - **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Closed post-beta.1.
 - **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Closed post-beta.1.
+- **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Auth providers, auth filters, filter chains
+
+Closes the auth-providers + filter-chains tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Three new sub-clients on `c.Security` cover the security-pluggability surface for multi-IdP deployments.
+
+- **`c.Security.AuthProviders`** — `/security/authproviders`. `List` / `Get` / `Create` / `Update` / `Delete` plus `SetOrder` to replace the active provider order. Supports the four documented core fields (`ID`, `Name`, `ClassName`, `UserGroupServiceName`) plus a free-form `Extras map[string]interface{}` that carries provider-specific config (e.g. an LDAP provider's `serverURL`/`userFormat`, an OIDC provider's `clientId`/`clientSecret`). Custom `MarshalJSON` / `UnmarshalJSON` round-trip the extras flat alongside the typed fields.
+- **`c.Security.AuthFilters`** — `/security/authfilters`. `List` / `Get` / `Create` / `Update` / `Delete`. `AuthFilter` mirrors `AuthProvider`'s typed-core + `Extras` shape.
+- **`c.Security.FilterChains`** — `/security/filterchain`. `List` / `Get` / `Create` / `Update` / `Delete` plus `SetOrder`. Typed core covers the eleven `@`-prefixed JSON attributes (`@name`, `@class`, `@path`, `@disabled`, `@allowSessionCreation`, `@ssl`, `@matchHTTPMethod`, `@interceptorName`, `@exceptionTranslationName`, `@httpMethods`, `@roleFilterName`) plus the `filter` array of [AuthFilter] names.
+
+### Wire-format quirks (security: auth providers / filters)
+
+Discovered via local integration testing against live GeoServer 2.28.0 and confirmed by reading the upstream `restconfig` controllers:
+
+- **GET responses for individual auth providers / filters use a class-name-keyed envelope** — e.g. `{"o.g.s.config.AnonymousAuthenticationFilterConfig":{...}}` — instead of returning the entity flat. The SDK's `unwrapClassEnvelope` heuristic detects the single-key Java-FQN wrapper and unwraps transparently before flat-decoding.
+- **Auth providers' List endpoint returns either an array or a class-keyed map** — `{"authproviders":[...]}` (documented OpenAPI shape) or `{"authproviders":{"<className>":{...}}}` (single-element collapse). `List` accepts both.
+- **Auth filters' GET on a missing name returns `200 + {"null":""}`** instead of `404`. `AuthFilters.Get` detects the empty-Name result and synthesizes an `ErrNotFound`-bearing error so callers can use `errors.Is(err, geoserver.ErrNotFound)`. Auth providers and filter chains both correctly return 404.
+- **Filter chain `filter` field collapses to a scalar string** when there's exactly one filter. `FilterChain.UnmarshalJSON` accepts both shapes.
+- **Filter chain GET / Create / Update use a `{"filters":{...}}` body envelope** — note the field name is "filters" (plural) for a single chain entity. Required for both request and response bodies.
+
 ### Added — Templates (FTL) sub-client
 
 Closes the templates tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). FreeMarker (FTL) templates customize GetFeatureInfo HTML output, WMS HTML capabilities, and other text outputs; GeoServer scopes them at six nested levels and looks up most-specific to global at request time.

--- a/v2/rest/security/auth_filter_chains_integration_test.go
+++ b/v2/rest/security/auth_filter_chains_integration_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package security_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/security"
+)
+
+// uniqueAuthName returns a name unique to this test run; security
+// CRUD endpoints don't always tolerate concurrent reuse and the
+// test stack persists state across runs without volume reset.
+func uniqueAuthName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
+// ---- AuthProviders ----
+
+func TestSecurity_AuthProviders_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	list, err := c.Security.AuthProviders.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Default GeoServer installs ship at minimum the "default"
+	// UsernamePassword provider.
+	found := false
+	for _, p := range list {
+		if p.Name == "default" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected default provider in list, got %+v", list)
+	}
+}
+
+func TestSecurity_AuthProviders_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	name := uniqueAuthName("v2_it_provider")
+	p := &security.AuthProvider{
+		Name:                 name,
+		ClassName:            "org.geoserver.security.auth.UsernamePasswordAuthenticationProvider",
+		UserGroupServiceName: "default",
+	}
+
+	t.Cleanup(func() {
+		_ = c.Security.AuthProviders.Delete(ctx, name)
+	})
+
+	if err := c.Security.AuthProviders.Create(ctx, p, security.CreateAuthProviderOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := c.Security.AuthProviders.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != name {
+		t.Errorf("Get Name = %q, want %q", got.Name, name)
+	}
+	if got.ClassName != p.ClassName {
+		t.Errorf("Get ClassName = %q", got.ClassName)
+	}
+
+	if err := c.Security.AuthProviders.Delete(ctx, name); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := c.Security.AuthProviders.Get(ctx, name); !errors.Is(err, geoserver.ErrNotFound) {
+		t.Errorf("Get after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestSecurity_AuthProviders_SetOrder_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Save current order, restore on cleanup.
+	originalList, err := c.Security.AuthProviders.List(ctx)
+	if err != nil {
+		t.Fatalf("List initial: %v", err)
+	}
+	originalOrder := make([]string, 0, len(originalList))
+	for _, p := range originalList {
+		originalOrder = append(originalOrder, p.Name)
+	}
+	t.Cleanup(func() {
+		if len(originalOrder) > 0 {
+			_ = c.Security.AuthProviders.SetOrder(ctx, originalOrder)
+		}
+	})
+
+	// Setting order to ["default"] is a no-op-ish action that
+	// exercises the endpoint without changing semantics on a vanilla
+	// install.
+	if err := c.Security.AuthProviders.SetOrder(ctx, []string{"default"}); err != nil {
+		t.Fatalf("SetOrder: %v", err)
+	}
+}
+
+// ---- AuthFilters ----
+
+func TestSecurity_AuthFilters_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	list, err := c.Security.AuthFilters.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	wantNames := map[string]bool{"anonymous": false, "basic": false}
+	for _, ref := range list {
+		if _, ok := wantNames[ref.Name]; ok {
+			wantNames[ref.Name] = true
+		}
+	}
+	for n, found := range wantNames {
+		if !found {
+			t.Errorf("expected filter %q in list, got %+v", n, list)
+		}
+	}
+}
+
+func TestSecurity_AuthFilters_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	f, err := c.Security.AuthFilters.Get(ctx, "anonymous")
+	if err != nil {
+		t.Fatalf("Get anonymous: %v", err)
+	}
+	if f.Name != "anonymous" {
+		t.Errorf("Name = %q", f.Name)
+	}
+	// Class should be the GeoServer anonymous filter.
+	if f.ClassName == "" {
+		t.Errorf("ClassName empty in %+v", f)
+	}
+}
+
+func TestSecurity_AuthFilters_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	_, err := c.Security.AuthFilters.Get(ctx, uniqueAuthName("v2_it_definitely_not_a_filter"))
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ---- FilterChains ----
+
+func TestSecurity_FilterChains_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	list, err := c.Security.FilterChains.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Default GeoServer ships with "web", "rest", "default" chains.
+	wantNames := map[string]bool{"web": false, "rest": false, "default": false}
+	for _, fc := range list {
+		if _, ok := wantNames[fc.Name]; ok {
+			wantNames[fc.Name] = true
+		}
+	}
+	for n, found := range wantNames {
+		if !found {
+			t.Errorf("expected chain %q in list, got chains: %+v", n, chainNames(list))
+		}
+	}
+}
+
+func TestSecurity_FilterChains_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	fc, err := c.Security.FilterChains.Get(ctx, "web")
+	if err != nil {
+		t.Fatalf("Get web: %v", err)
+	}
+	if fc.Name != "web" {
+		t.Errorf("Name = %q", fc.Name)
+	}
+	if fc.Path == "" || fc.ClassName == "" {
+		t.Errorf("Path/ClassName empty in %+v", fc)
+	}
+	if len(fc.Filters) == 0 {
+		t.Errorf("expected at least one filter in 'web' chain, got %+v", fc)
+	}
+}
+
+func TestSecurity_FilterChains_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	_, err := c.Security.FilterChains.Get(ctx, uniqueAuthName("v2_it_definitely_not_a_chain"))
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func chainNames(list []security.FilterChain) []string {
+	out := make([]string, len(list))
+	for i, fc := range list {
+		out[i] = fc.Name
+	}
+	return out
+}

--- a/v2/rest/security/auth_filter_chains_test.go
+++ b/v2/rest/security/auth_filter_chains_test.go
@@ -1,0 +1,306 @@
+package security_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/security"
+)
+
+// ---- AuthProviders ----
+
+func TestAuthProviders_List_ArrayShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/authproviders" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"authproviders":[
+			{"id":"1","name":"default","className":"o.g.s.auth.UPAP","userGroupServiceName":"default"},
+			{"id":"2","name":"corp","className":"o.g.s.auth.LDAPAP","userGroupServiceName":"default","serverURL":"ldaps://corp"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.Security.AuthProviders.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d", len(list))
+	}
+	if list[1].Name != "corp" || list[1].Extras["serverURL"] != "ldaps://corp" {
+		t.Errorf("provider[1] = %+v / extras=%+v", list[1], list[1].Extras)
+	}
+}
+
+func TestAuthProviders_List_ClassKeyedMapShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"authproviders":{"o.g.s.config.UsernamePasswordAuthenticationProviderConfig":{"id":"1","name":"default","className":"o.g.s.auth.UPAP","userGroupServiceName":"default"}}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.Security.AuthProviders.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "default" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestAuthProviders_Roundtrip_FlatJSONWithExtras(t *testing.T) {
+	// Verify Marshal/Unmarshal round-trip preserves provider-specific
+	// extras alongside typed core fields.
+	src := security.AuthProvider{
+		Name: "corp", ClassName: "X", UserGroupServiceName: "default",
+		Extras: map[string]interface{}{
+			"serverURL":  "ldaps://corp",
+			"userFormat": "uid={0}",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		// Body is the flat JSON; assert all four keys are emitted.
+		s := string(body)
+		for _, want := range []string{`"name":"corp"`, `"className":"X"`, `"userGroupServiceName":"default"`, `"serverURL":"ldaps://corp"`, `"userFormat":"uid={0}"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Security.AuthProviders.Create(context.Background(), &src, security.CreateAuthProviderOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestAuthProviders_Get_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Security.AuthProviders.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestAuthProviders_SetOrder_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/authproviders/order" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"order":["a","b"]`) {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Security.AuthProviders.SetOrder(context.Background(), []string{"a", "b"}); err != nil {
+		t.Fatalf("SetOrder: %v", err)
+	}
+}
+
+func TestAuthProviders_SetOrder_EmptyRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Security.AuthProviders.SetOrder(context.Background(), nil); err == nil {
+		t.Fatal("expected empty-list error")
+	}
+}
+
+// ---- AuthFilters ----
+
+func TestAuthFilters_List_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"authfilters":{"authfilter":[
+			{"name":"anonymous","href":"http://srv/rest/security/authfilters/anonymous.json"},
+			{"name":"basic","href":"http://srv/rest/security/authfilters/basic.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.Security.AuthFilters.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 || list[0].Name != "anonymous" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestAuthFilters_Get_FlatExtras(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"my-oidc","className":"o.g.s.f.OIDCFilter","clientId":"id123","clientSecret":"sek"}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	f, err := c.Security.AuthFilters.Get(context.Background(), "my-oidc")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if f.Name != "my-oidc" || f.Extras["clientId"] != "id123" {
+		t.Errorf("filter = %+v", f)
+	}
+}
+
+func TestAuthFilters_Get_NullWireQuirkMapsToNotFound(t *testing.T) {
+	// GeoServer wire-quirk: missing auth filter returns 200 with
+	// {"null":""} body instead of 404. SDK translates to ErrNotFound.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"null":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Security.AuthFilters.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for null wire shape, got %v", err)
+	}
+}
+
+func TestAuthFilters_Get_ClassEnvelopeUnwrap(t *testing.T) {
+	// GeoServer wraps single auth filter in class-name-keyed envelope.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"o.g.s.config.AnonymousAuthenticationFilterConfig":{"id":"x","name":"anonymous","className":"o.g.s.f.GeoServerAnonymousAuthenticationFilter"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	f, err := c.Security.AuthFilters.Get(context.Background(), "anonymous")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if f.Name != "anonymous" || f.ClassName != "o.g.s.f.GeoServerAnonymousAuthenticationFilter" {
+		t.Errorf("filter = %+v", f)
+	}
+}
+
+// ---- FilterChains ----
+
+func TestFilterChains_List_AttributeStyleOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/filterchain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"filterchain":{"filters":[
+			{"@name":"web","@class":"o.g.s.HtmlLoginFilterChain","@path":"/web/**","@disabled":false,"@allowSessionCreation":true,"@ssl":false,"@matchHTTPMethod":false,"filter":["rememberme","form","anonymous"]},
+			{"@name":"webLogin","@class":"o.g.s.ConstantFilterChain","@path":"/j_spring/","@disabled":false,"@allowSessionCreation":true,"@ssl":false,"@matchHTTPMethod":false,"filter":"form"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.Security.FilterChains.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d", len(list))
+	}
+	if list[0].Name != "web" || len(list[0].Filters) != 3 {
+		t.Errorf("chain[0] = %+v", list[0])
+	}
+	// Single-string filter collapse.
+	if list[1].Name != "webLogin" || len(list[1].Filters) != 1 || list[1].Filters[0] != "form" {
+		t.Errorf("chain[1] single-filter collapse = %+v", list[1])
+	}
+}
+
+func TestFilterChains_Get_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/filterchain/web.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"filters":{"@name":"web","@class":"o.g.s.HtmlLoginFilterChain","@path":"/web/**","filter":["form","anonymous"]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	fc, err := c.Security.FilterChains.Get(context.Background(), "web")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fc.Name != "web" || fc.Path != "/web/**" || len(fc.Filters) != 2 {
+		t.Errorf("chain = %+v", fc)
+	}
+}
+
+func TestFilterChains_Create_BodyShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/security/filterchain" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		// Body must be the {"filters":{...}} envelope with @-attrs.
+		for _, want := range []string{`"filters":{`, `"@name":"new"`, `"@path":"/x/**"`, `"@class":"o.g.s.X"`, `"filter":["a","b"]`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Security.FilterChains.Create(context.Background(), &security.FilterChain{
+		Name:      "new",
+		ClassName: "o.g.s.X",
+		Path:      "/x/**",
+		Filters:   []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestFilterChains_SetOrder_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/filterchain/order" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"order":["web","rest","default"]`) {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Security.FilterChains.SetOrder(context.Background(), []string{"web", "rest", "default"})
+	if err != nil {
+		t.Fatalf("SetOrder: %v", err)
+	}
+}

--- a/v2/rest/security/authfilters.go
+++ b/v2/rest/security/authfilters.go
@@ -1,0 +1,187 @@
+package security
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// AuthFilter describes one authentication filter — a single auth
+// step (anonymous, basic, form, rememberme, oidc, …) that filter
+// chains compose into per-URL auth pipelines.
+//
+// Like [AuthProvider], the wire shape is heterogeneous: the Java
+// filter class drives extra fields. The SDK normalizes the typed
+// core (Name, ClassName) and keeps the rest in [AuthFilter.Extras].
+type AuthFilter struct {
+	// Name is the catalog name of the filter (e.g. "anonymous",
+	// "basic", "form").
+	Name string `json:"name,omitempty"`
+
+	// ClassName is the FQN of the GeoServer Java class implementing
+	// the filter (e.g.
+	// "org.geoserver.security.filter.GeoServerAnonymousAuthenticationFilter").
+	ClassName string `json:"className,omitempty"`
+
+	// Extras carries the filter-specific config not represented in
+	// the typed fields (e.g. an OIDC filter's clientId/clientSecret).
+	Extras map[string]interface{} `json:"-"`
+}
+
+// MarshalJSON serializes the filter as a flat object — typed fields
+// + Extras. Conflicts resolved in favor of typed fields.
+func (f AuthFilter) MarshalJSON() ([]byte, error) {
+	out := map[string]interface{}{}
+	for k, v := range f.Extras {
+		out[k] = v
+	}
+	if f.Name != "" {
+		out["name"] = f.Name
+	}
+	if f.ClassName != "" {
+		out["className"] = f.ClassName
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON parses either a flat filter object or GeoServer's
+// class-name-keyed envelope (e.g.
+// `{"o.g.s.config.AnonymousAuthenticationFilterConfig":{...}}`).
+// Typed fields land in the typed slots and everything else
+// accumulates in Extras.
+func (f *AuthFilter) UnmarshalJSON(b []byte) error {
+	if inner, ok := unwrapClassEnvelope(b); ok {
+		b = inner
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	for k, v := range raw {
+		switch k {
+		case "name":
+			_ = json.Unmarshal(v, &f.Name)
+		case "className":
+			_ = json.Unmarshal(v, &f.ClassName)
+		default:
+			if f.Extras == nil {
+				f.Extras = map[string]interface{}{}
+			}
+			var anyVal interface{}
+			if err := json.Unmarshal(v, &anyVal); err == nil {
+				f.Extras[k] = anyVal
+			}
+		}
+	}
+	return nil
+}
+
+// AuthFilterRef is one entry in the auth-filters listing.
+type AuthFilterRef struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+// AuthFiltersClient operates on /rest/security/authfilters.
+type AuthFiltersClient struct {
+	core Core
+}
+
+// authFiltersListWire decodes the list-shape envelope:
+// `{"authfilters":{"authfilter":[{name, href}, ...]}}`.
+type authFiltersListWire struct {
+	AuthFilters struct {
+		AuthFilter []AuthFilterRef `json:"authfilter"`
+	} `json:"authfilters"`
+}
+
+// List returns every configured auth filter (just names + hrefs;
+// fetch detail via [AuthFiltersClient.Get]).
+func (c *AuthFiltersClient) List(ctx context.Context) ([]AuthFilterRef, error) {
+	const op = "Security.AuthFilters.List"
+	u, err := c.core.URL("rest", "security", "authfilters")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap authFiltersListWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	return wrap.AuthFilters.AuthFilter, nil
+}
+
+// Get returns one filter by name.
+//
+// Wire-quirk: GeoServer's auth-filters endpoint returns `200 OK`
+// with body `{"null":""}` for filter names that don't exist instead
+// of `404 Not Found`. This method detects the empty-result wire
+// shape (Name field comes back blank after a successful response)
+// and surfaces it as an [ErrNotFound]-bearing error so callers can
+// match with errors.Is(err, geoserver.ErrNotFound).
+func (c *AuthFiltersClient) Get(ctx context.Context, name string) (*AuthFilter, error) {
+	const op = "Security.AuthFilters.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "authfilters", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var f AuthFilter
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &f); err != nil {
+		return nil, err
+	}
+	if f.Name == "" {
+		return nil, c.core.SynthesizeError(op, http.MethodGet, u, http.StatusNotFound,
+			fmt.Sprintf("auth filter %q not found (GeoServer returned empty/null body)", name))
+	}
+	return &f, nil
+}
+
+// Create registers a new filter. Name and ClassName are required.
+func (c *AuthFiltersClient) Create(ctx context.Context, f *AuthFilter) error {
+	const op = "Security.AuthFilters.Create"
+	if f == nil {
+		return errors.New(op + ": nil filter")
+	}
+	if f.Name == "" || f.ClassName == "" {
+		return errors.New(op + ": Name and ClassName are required")
+	}
+	u, err := c.core.URL("rest", "security", "authfilters")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, f, nil, nil)
+}
+
+// Update replaces the filter at name with the supplied body.
+func (c *AuthFiltersClient) Update(ctx context.Context, name string, f *AuthFilter) error {
+	const op = "Security.AuthFilters.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if f == nil {
+		return errors.New(op + ": nil filter")
+	}
+	u, err := c.core.URL("rest", "security", "authfilters", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, f, nil, nil)
+}
+
+// Delete removes the named filter. Filters referenced by an active
+// filter chain cannot be deleted (server returns 4xx).
+func (c *AuthFiltersClient) Delete(ctx context.Context, name string) error {
+	const op = "Security.AuthFilters.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "authfilters", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/security/authproviders.go
+++ b/v2/rest/security/authproviders.go
@@ -1,0 +1,301 @@
+package security
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// AuthProvider describes one authentication provider — the bridge
+// between GeoServer's catalog auth and an external identity backend
+// (UsernamePassword, LDAP, OAuth/OIDC, header-auth, etc.).
+//
+// The wire shape is heterogeneous: every concrete provider type
+// declares its own java config class as the JSON envelope key (e.g.
+// "org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig"
+// for a UsernamePassword provider) and its own provider-specific
+// fields alongside the common core fields. This SDK normalizes the
+// core fields into typed properties and keeps any extras in the
+// [AuthProvider.Extras] free-form map. Round-tripping a fetched
+// provider back unchanged is supported.
+type AuthProvider struct {
+	// ID is server-generated; ignore on creates.
+	ID string `json:"id,omitempty"`
+
+	// Name is the provider's catalog name (e.g. "default",
+	// "corporateLdap"). Required on create.
+	Name string `json:"name,omitempty"`
+
+	// ClassName is the FQN of the GeoServer Java class that
+	// implements this provider's auth flow (e.g.
+	// "org.geoserver.security.auth.UsernamePasswordAuthenticationProvider").
+	// Required on create.
+	ClassName string `json:"className,omitempty"`
+
+	// UserGroupServiceName names the user/group service this
+	// provider authenticates against (typically "default").
+	// Required on create.
+	UserGroupServiceName string `json:"userGroupServiceName,omitempty"`
+
+	// Extras is provider-specific configuration that doesn't fit
+	// the typed core fields — for example an LDAP provider's
+	// `serverURL`, `userFormat`, or an OIDC provider's
+	// `clientId`/`clientSecret`. Any key not in the typed list
+	// above is preserved here on read and re-emitted on write.
+	Extras map[string]interface{} `json:"-"`
+}
+
+// MarshalJSON serializes the provider as a flat object: typed core
+// fields plus all entries from [AuthProvider.Extras]. Conflicts (an
+// Extras key matching a typed field) are resolved in favor of the
+// typed field.
+func (p AuthProvider) MarshalJSON() ([]byte, error) {
+	out := map[string]interface{}{}
+	for k, v := range p.Extras {
+		out[k] = v
+	}
+	if p.ID != "" {
+		out["id"] = p.ID
+	}
+	if p.Name != "" {
+		out["name"] = p.Name
+	}
+	if p.ClassName != "" {
+		out["className"] = p.ClassName
+	}
+	if p.UserGroupServiceName != "" {
+		out["userGroupServiceName"] = p.UserGroupServiceName
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON parses either a flat provider object or GeoServer's
+// class-name-keyed envelope (e.g.
+// `{"o.g.s.config.UsernamePasswordAuthenticationProviderConfig":{...}}`).
+// Typed core fields land in the typed slots and everything else
+// accumulates in [AuthProvider.Extras].
+func (p *AuthProvider) UnmarshalJSON(b []byte) error {
+	if inner, ok := unwrapClassEnvelope(b); ok {
+		b = inner
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	for k, v := range raw {
+		switch k {
+		case "id":
+			_ = json.Unmarshal(v, &p.ID)
+		case "name":
+			_ = json.Unmarshal(v, &p.Name)
+		case "className":
+			_ = json.Unmarshal(v, &p.ClassName)
+		case "userGroupServiceName":
+			_ = json.Unmarshal(v, &p.UserGroupServiceName)
+		default:
+			if p.Extras == nil {
+				p.Extras = map[string]interface{}{}
+			}
+			var anyVal interface{}
+			if err := json.Unmarshal(v, &anyVal); err == nil {
+				p.Extras[k] = anyVal
+			}
+		}
+	}
+	return nil
+}
+
+// unwrapClassEnvelope detects GeoServer's
+// `{"<JavaClassFQN>": {...}}` single-key envelope and returns the
+// inner JSON object so a flat-decoder path can finish parsing.
+// Heuristic: exactly one top-level key, the key looks like a Java
+// FQN (contains a dot), and the value is a JSON object.
+func unwrapClassEnvelope(b []byte) ([]byte, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, false
+	}
+	if len(raw) != 1 {
+		return nil, false
+	}
+	for k, v := range raw {
+		if !strings.Contains(k, ".") {
+			return nil, false
+		}
+		// Strip leading whitespace before checking the first byte.
+		trimmed := v
+		for len(trimmed) > 0 {
+			c := trimmed[0]
+			if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+				break
+			}
+			trimmed = trimmed[1:]
+		}
+		if len(trimmed) == 0 || trimmed[0] != '{' {
+			return nil, false
+		}
+		return v, true
+	}
+	return nil, false
+}
+
+// AuthProvidersClient operates on /rest/security/authproviders.
+type AuthProvidersClient struct {
+	core Core
+}
+
+// CreateAuthProviderOptions controls Create behavior.
+type CreateAuthProviderOptions struct {
+	// Position is the 0-based insert index in the active order. Zero
+	// (the default) appends at the end.
+	Position int
+}
+
+// UpdateAuthProviderOptions controls Update behavior.
+type UpdateAuthProviderOptions struct {
+	// Position, if non-nil, moves the provider to this 0-based
+	// index in the active order while updating its body.
+	Position *int
+}
+
+// authProvidersListWire decodes the list-shape envelope. GeoServer
+// returns one of two shapes depending on number of providers:
+//
+//   - `{"authproviders":[{...}, {...}]}` — array (documented OpenAPI form)
+//   - `{"authproviders":{"<className>":{...}}}` — single-element collapse
+//     keyed by the concrete provider class. We accept both.
+type authProvidersListWire struct {
+	AuthProviders json.RawMessage `json:"authproviders"`
+}
+
+// authProviderOrderWire is the body shape for SetOrder.
+type authProviderOrderWire struct {
+	Order []string `json:"order"`
+}
+
+// List returns every configured auth provider, in active order.
+func (c *AuthProvidersClient) List(ctx context.Context) ([]AuthProvider, error) {
+	const op = "Security.AuthProviders.List"
+	u, err := c.core.URL("rest", "security", "authproviders")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap authProvidersListWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.AuthProviders) == 0 || string(wrap.AuthProviders) == "null" {
+		return nil, nil
+	}
+	// Try array first.
+	if wrap.AuthProviders[0] == '[' {
+		var arr []AuthProvider
+		if err := json.Unmarshal(wrap.AuthProviders, &arr); err != nil {
+			return nil, fmt.Errorf("%s: decode array: %w", op, err)
+		}
+		return arr, nil
+	}
+	// Otherwise treat as object keyed by class name.
+	var byClass map[string]AuthProvider
+	if err := json.Unmarshal(wrap.AuthProviders, &byClass); err != nil {
+		return nil, fmt.Errorf("%s: decode map: %w", op, err)
+	}
+	out := make([]AuthProvider, 0, len(byClass))
+	for _, p := range byClass {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// Get returns one provider by name.
+func (c *AuthProvidersClient) Get(ctx context.Context, name string) (*AuthProvider, error) {
+	const op = "Security.AuthProviders.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "authproviders", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var p AuthProvider
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// Create registers a new provider. Required fields on the input:
+// Name, ClassName, UserGroupServiceName.
+func (c *AuthProvidersClient) Create(ctx context.Context, p *AuthProvider, opts CreateAuthProviderOptions) error {
+	const op = "Security.AuthProviders.Create"
+	if p == nil {
+		return errors.New(op + ": nil provider")
+	}
+	if p.Name == "" || p.ClassName == "" || p.UserGroupServiceName == "" {
+		return errors.New(op + ": Name, ClassName, and UserGroupServiceName are required")
+	}
+	u, err := c.core.URL("rest", "security", "authproviders")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Position > 0 {
+		query = map[string]string{"position": strconv.Itoa(opts.Position)}
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, p, query, nil)
+}
+
+// Update replaces the provider's body and optionally moves it in the
+// active order.
+func (c *AuthProvidersClient) Update(ctx context.Context, name string, p *AuthProvider, opts UpdateAuthProviderOptions) error {
+	const op = "Security.AuthProviders.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if p == nil {
+		return errors.New(op + ": nil provider")
+	}
+	u, err := c.core.URL("rest", "security", "authproviders", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Position != nil {
+		query = map[string]string{"position": strconv.Itoa(*opts.Position)}
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, p, query, nil)
+}
+
+// Delete removes the named provider. Removing a provider also
+// removes it from the active order.
+func (c *AuthProvidersClient) Delete(ctx context.Context, name string) error {
+	const op = "Security.AuthProviders.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "authproviders", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}
+
+// SetOrder replaces the active provider order. Names not in the
+// list become inactive (they remain configured but are not consulted
+// during auth). Empty list is rejected by GeoServer.
+func (c *AuthProvidersClient) SetOrder(ctx context.Context, names []string) error {
+	const op = "Security.AuthProviders.SetOrder"
+	if len(names) == 0 {
+		return errors.New(op + ": names list must be non-empty")
+	}
+	u, err := c.core.URL("rest", "security", "authproviders", "order")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := authProviderOrderWire{Order: names}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}

--- a/v2/rest/security/filterchains.go
+++ b/v2/rest/security/filterchains.go
@@ -1,0 +1,203 @@
+package security
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// FilterChain binds a set of URL patterns to an ordered list of
+// authentication filters. Requests matching the chain's URL pattern
+// run through its filters in order.
+//
+// On the JSON wire, GeoServer emits filter-chain attributes as
+// "@"-prefixed keys (XML-attribute style). The SDK normalizes those
+// into typed fields and round-trips identically.
+type FilterChain struct {
+	Name                     string `json:"@name,omitempty"`
+	ClassName                string `json:"@class,omitempty"`
+	Path                     string `json:"@path,omitempty"`
+	Disabled                 bool   `json:"@disabled,omitempty"`
+	AllowSessionCreation     bool   `json:"@allowSessionCreation,omitempty"`
+	SSL                      bool   `json:"@ssl,omitempty"`
+	MatchHTTPMethod          bool   `json:"@matchHTTPMethod,omitempty"`
+	InterceptorName          string `json:"@interceptorName,omitempty"`
+	ExceptionTranslationName string `json:"@exceptionTranslationName,omitempty"`
+	HTTPMethods              string `json:"@httpMethods,omitempty"`
+	RoleFilterName           string `json:"@roleFilterName,omitempty"`
+
+	// Filters is the ordered list of [AuthFilter] names that
+	// requests matching this chain run through. On the wire,
+	// GeoServer collapses single-element arrays to a scalar
+	// string — handled transparently by the custom unmarshal.
+	Filters []string `json:"filter,omitempty"`
+}
+
+// UnmarshalJSON tolerates the single-element collapse on the
+// `filter` field: GeoServer returns it as a JSON array when there
+// are 2+ filters and as a bare string when there's exactly 1.
+func (fc *FilterChain) UnmarshalJSON(b []byte) error {
+	type alias FilterChain
+	var raw struct {
+		alias
+		Filters json.RawMessage `json:"filter"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	*fc = FilterChain(raw.alias)
+	if len(raw.Filters) == 0 || string(raw.Filters) == "null" {
+		return nil
+	}
+	switch raw.Filters[0] {
+	case '[':
+		return json.Unmarshal(raw.Filters, &fc.Filters)
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw.Filters, &s); err != nil {
+			return err
+		}
+		fc.Filters = []string{s}
+		return nil
+	default:
+		return fmt.Errorf("security: unexpected JSON shape for filter: %s", raw.Filters)
+	}
+}
+
+// FilterChainsClient operates on /rest/security/filterchain.
+type FilterChainsClient struct {
+	core Core
+}
+
+// UpdateFilterChainOptions controls Update behavior.
+type UpdateFilterChainOptions struct {
+	// Position, if non-nil, moves the chain to this 0-based index
+	// in the chain ordering while updating its body.
+	Position *int
+}
+
+// filterChainsListWire decodes the list shape:
+// `{"filterchain":{"filters":[{...}, ...]}}`.
+type filterChainsListWire struct {
+	FilterChain struct {
+		Filters []FilterChain `json:"filters"`
+	} `json:"filterchain"`
+}
+
+// filterChainSingleWire is the per-chain shape for Get / Create / Update:
+// `{"filters":{...}}` (note the field name is "filters" — GeoServer's
+// REST controller chose the same plural element name as in the list,
+// even though it's a single chain here).
+type filterChainSingleWire struct {
+	Filters FilterChain `json:"filters"`
+}
+
+// filterChainOrderWire is the body for SetOrder.
+type filterChainOrderWire struct {
+	Order []string `json:"order"`
+}
+
+// List returns every configured filter chain in active order.
+func (c *FilterChainsClient) List(ctx context.Context) ([]FilterChain, error) {
+	const op = "Security.FilterChains.List"
+	u, err := c.core.URL("rest", "security", "filterchain")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	// Append .json so GeoServer skips its default HTML rendering.
+	u += ".json"
+	var wrap filterChainsListWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	return wrap.FilterChain.Filters, nil
+}
+
+// Get returns one filter chain by name.
+func (c *FilterChainsClient) Get(ctx context.Context, name string) (*FilterChain, error) {
+	const op = "Security.FilterChains.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "filterchain", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	u += ".json"
+	var wrap filterChainSingleWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	return &wrap.Filters, nil
+}
+
+// Create registers a new filter chain.
+func (c *FilterChainsClient) Create(ctx context.Context, fc *FilterChain) error {
+	const op = "Security.FilterChains.Create"
+	if fc == nil {
+		return errors.New(op + ": nil chain")
+	}
+	if fc.Name == "" || fc.ClassName == "" || fc.Path == "" {
+		return errors.New(op + ": Name, ClassName, and Path are required")
+	}
+	u, err := c.core.URL("rest", "security", "filterchain")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := filterChainSingleWire{Filters: *fc}
+	return c.core.Do(ctx, op, http.MethodPost, u, body, nil, nil)
+}
+
+// Update replaces the chain at name with the supplied body and
+// optionally moves it in the ordering.
+func (c *FilterChainsClient) Update(ctx context.Context, name string, fc *FilterChain, opts UpdateFilterChainOptions) error {
+	const op = "Security.FilterChains.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if fc == nil {
+		return errors.New(op + ": nil chain")
+	}
+	u, err := c.core.URL("rest", "security", "filterchain", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Position != nil {
+		query = map[string]string{"position": strconv.Itoa(*opts.Position)}
+	}
+	body := filterChainSingleWire{Filters: *fc}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, query, nil)
+}
+
+// Delete removes the named filter chain.
+func (c *FilterChainsClient) Delete(ctx context.Context, name string) error {
+	const op = "Security.FilterChains.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "security", "filterchain", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}
+
+// SetOrder replaces the chain ordering. Names not in the list keep
+// their current configuration but are not consulted at request time
+// until re-added.
+func (c *FilterChainsClient) SetOrder(ctx context.Context, names []string) error {
+	const op = "Security.FilterChains.SetOrder"
+	if len(names) == 0 {
+		return errors.New(op + ": names list must be non-empty")
+	}
+	u, err := c.core.URL("rest", "security", "filterchain", "order")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := filterChainOrderWire{Order: names}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}

--- a/v2/rest/security/security.go
+++ b/v2/rest/security/security.go
@@ -13,9 +13,14 @@ type Core interface {
 	URL(parts ...string) (string, error)
 	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
 	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+	// SynthesizeError surfaces a package-sentinel error (via the
+	// parent's *APIError) for wire responses that are 2xx but
+	// semantically failures — e.g. auth filters' `{"null":""}`
+	// "not found" wire shape.
+	SynthesizeError(op, method, requestURL string, statusCode int, bodyHint string) error
 }
 
-// Client is the v2 security sub-client. It carries three nested
+// Client is the v2 security sub-client. It carries six nested
 // surfaces:
 //
 //	c.Security.Users()                       // default user/group service
@@ -23,6 +28,9 @@ type Core interface {
 //	c.Security.Groups()
 //	c.Security.GroupsInService("custom-jdbc")
 //	c.Security.Roles                         // always global, no service scope
+//	c.Security.AuthProviders                 // /security/authproviders
+//	c.Security.AuthFilters                   // /security/authfilters
+//	c.Security.FilterChains                  // /security/filterchain
 type Client struct {
 	core Core
 
@@ -30,13 +38,34 @@ type Client struct {
 	// assignment. Roles are global — not scoped to a user/group
 	// service — so this is a single client, not a method.
 	Roles *RolesClient
+
+	// AuthProviders is the entry point for authentication-provider
+	// CRUD plus active-order management at /security/authproviders.
+	// Providers are how GeoServer delegates authentication to backends
+	// (UsernamePassword, LDAP, OAuth/OIDC, header-auth, etc.).
+	AuthProviders *AuthProvidersClient
+
+	// AuthFilters is the entry point for authentication-filter CRUD at
+	// /security/authfilters. Filters are individual auth steps
+	// (anonymous, basic, form, rememberme, oidc-test, …) that are
+	// composed into [FilterChainsClient] entries.
+	AuthFilters *AuthFiltersClient
+
+	// FilterChains is the entry point for security filter-chain CRUD
+	// plus chain-order management at /security/filterchain. A filter
+	// chain binds a URL pattern (e.g. "/web/**") to an ordered list
+	// of [AuthFiltersClient] filter names.
+	FilterChains *FilterChainsClient
 }
 
 // New constructs the security sub-client.
 func New(core Core) *Client {
 	return &Client{
-		core:  core,
-		Roles: &RolesClient{core: core},
+		core:          core,
+		Roles:         &RolesClient{core: core},
+		AuthProviders: &AuthProvidersClient{core: core},
+		AuthFilters:   &AuthFiltersClient{core: core},
+		FilterChains:  &FilterChainsClient{core: core},
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the auth-providers + filter-chains tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Three new sub-clients on `c.Security` cover the security-pluggability surface for multi-IdP deployments.

## What lands

**`c.Security.AuthProviders`** — `/security/authproviders` — `List` / `Get` / `Create` / `Update` / `Delete` + `SetOrder`. `AuthProvider` has typed core (`ID`, `Name`, `ClassName`, `UserGroupServiceName`) plus a free-form `Extras map[string]interface{}` for provider-specific fields (LDAP `serverURL`, OIDC `clientId`/`clientSecret`, etc.). Custom Marshal/Unmarshal round-trips extras flat alongside typed.

**`c.Security.AuthFilters`** — `/security/authfilters` — `List` / `Get` / `Create` / `Update` / `Delete`. `AuthFilter` mirrors `AuthProvider`'s typed-core + Extras shape.

**`c.Security.FilterChains`** — `/security/filterchain` — `List` / `Get` / `Create` / `Update` / `Delete` + `SetOrder`. `FilterChain` typed core covers 11 `@`-prefixed JSON attributes (`@name`, `@class`, `@path`, `@disabled`, …) plus a `filter[]` list of [AuthFilter] names. Tolerates the single-filter wire-collapse.

## Wire-format quirks (discovered via live integration testing)

- GET on individual auth provider/filter wraps the body in a class-name-keyed envelope (`{"o.g.s.config.AnonymousAuthenticationFilterConfig":{...}}`); `unwrapClassEnvelope` detects single-key Java-FQN wrappers and unwraps transparently.
- `AuthProviders.List` accepts both array shape (`{"authproviders":[...]}`) and class-keyed-map shape (`{"authproviders":{"<class>":{...}}}`).
- `AuthFilters.Get` returns `200 + {"null":""}` for missing entries instead of `404`; SDK detects empty-Name response and synthesizes `ErrNotFound` via `core.SynthesizeError` (added to security.Core interface).
- `FilterChain.UnmarshalJSON` tolerates the single-element collapse on the `filter` field.
- Filter chain GET / POST / PUT use a `{"filters":{...}}` envelope — note: field name is "filters" (plural) for a single chain entity, matching GeoServer's `FilterChainItemXml` schema.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/security/...` — 12+ unit tests pass (CRUD, wire shapes, class-envelope unwrap, single-filter collapse, null-shape detection).
- [x] `golangci-lint run ./rest/security/...` — 0 issues.
- [x] `go vet -tags=integration ./...` — clean.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/security/...` — 9 new integration PASS against the default GeoServer fixture (default provider, anonymous/basic/form/rememberme filters, web/rest/default chains).
- [x] Full v2 integration suite green; nothing else regressed.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.