### PR TITLE
feat(v2): add URL checks (SSRF allow-list)

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,11 +8,10 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **URL checks** — `/urlchecks` | SSRF-conscious deployments | Allow / deny lists for external URL references in styles, mosaics, and remote stores. |
-| 2 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
-| 3 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 4 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 5 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
+| 2 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
+| 3 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 4 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
@@ -21,6 +20,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Closed post-beta.1.
 - **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Closed post-beta.1.
 - **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Closed post-beta.1.
+- **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — URL checks (SSRF allow-list)
+
+Closes the URL-checks tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). URL External Access Checks are allow/deny lists for external URLs that GeoServer is permitted to fetch (SLD external graphics, image-mosaic remote rasters, cascaded WMS sources). SSRF-conscious deployments use them to constrain off-server URL fetching.
+
+- **`c.URLChecks`** at `/rest/urlchecks` — `List` / `Get` / `Create` / `Update` / `Delete`. Typed core: `Name`, `Description`, `Enabled`, `Regex`.
+- **Wire-quirk: POST/PUT bodies require the `regexUrlCheck` class-name envelope.** Flat JSON is rejected with 500. The `URLCheck.MarshalJSON` always wraps; `URLCheck.UnmarshalJSON` accepts both wrapped and flat (so callers don't need to special-case GET responses).
+- **Wire-quirk: empty list comes back as `{"urlChecks":""}`** (bare string instead of object) — same empty-collection pattern as styles, datastores, etc. `List` returns `nil` on the empty form.
+
 ### Added — Auth providers, auth filters, filter chains
 
 Closes the auth-providers + filter-chains tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Three new sub-clients on `c.Security` cover the security-pluggability surface for multi-IdP deployments.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/styles"
 	"github.com/hishamkaram/geoserver/v2/rest/system"
 	"github.com/hishamkaram/geoserver/v2/rest/templates"
+	"github.com/hishamkaram/geoserver/v2/rest/urlchecks"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 
 	"github.com/hishamkaram/geoserver/v2/ows/wcs"
@@ -183,6 +184,13 @@ type Client struct {
 	// type, per coverage store, per coverage — via fluent
 	// `c.Templates.InWorkspace(ws).In...()` chains.
 	Templates *templates.Client
+
+	// URLChecks is the entry point for URL External Access Checks
+	// at /rest/urlchecks. Allow/deny lists for external URL
+	// references in styles, mosaics, and remote stores. Used by
+	// SSRF-conscious deployments to constrain which off-server
+	// URLs GeoServer is permitted to fetch.
+	URLChecks *urlchecks.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -261,6 +269,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.Imports = imports.New(adapter)
 	c.Resources = resources.New(adapter)
 	c.Templates = templates.New(adapter)
+	c.URLChecks = urlchecks.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/urlchecks/urlchecks.go
+++ b/v2/rest/urlchecks/urlchecks.go
@@ -1,0 +1,175 @@
+// Package urlchecks is the v2 sub-client for the GeoServer URL
+// External Access Checks endpoint at /rest/urlchecks. URL checks are
+// allow/deny lists for external URLs that GeoServer is permitted to
+// fetch — e.g. SLD external graphics, image-mosaic remote rasters,
+// cascaded WMS sources. Each check is a regex that incoming external
+// URLs are matched against; a request is allowed only when at least
+// one check matches.
+package urlchecks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// URLCheck is a single URL access rule.
+type URLCheck struct {
+	// Name is the catalog name of the check (required, unique).
+	Name string `json:"name,omitempty"`
+	// Description is human-readable text shown in the admin UI.
+	Description string `json:"description,omitempty"`
+	// Enabled toggles the check on or off without removing it.
+	Enabled bool `json:"enabled,omitempty"`
+	// Regex is the regular expression external URLs must match
+	// (required). Standard Java regex syntax.
+	Regex string `json:"regex,omitempty"`
+}
+
+// MarshalJSON wraps the URLCheck in GeoServer's required class-name
+// envelope (`{"regexUrlCheck":{...}}`) for POST/PUT bodies. Sending
+// a flat object is rejected by the server with 500.
+func (u URLCheck) MarshalJSON() ([]byte, error) {
+	type alias URLCheck
+	return json.Marshal(map[string]alias{"regexUrlCheck": alias(u)})
+}
+
+// UnmarshalJSON accepts the wrapped form
+// (`{"regexUrlCheck":{...}}`) GeoServer returns on GET, falling
+// back to a bare object if the wrapper is absent.
+func (u *URLCheck) UnmarshalJSON(b []byte) error {
+	type alias URLCheck
+	// Try wrapped form first.
+	var wrapped struct {
+		RegexURLCheck *alias `json:"regexUrlCheck"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.RegexURLCheck != nil {
+		*u = URLCheck(*wrapped.RegexURLCheck)
+		return nil
+	}
+	// Fallback: flat decode.
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*u = URLCheck(flat)
+	return nil
+}
+
+// URLCheckRef is one entry in the URL-checks listing.
+type URLCheckRef struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+// Client is the v2 URL-checks sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the URL-checks sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// urlChecksListWire decodes the list-shape envelope. The empty
+// collection comes back as `{"urlChecks":""}` (bare string instead
+// of object) — same wire-quirk pattern as styles, datastores, etc.
+type urlChecksListWire struct {
+	URLChecks json.RawMessage `json:"urlChecks"`
+}
+
+// List returns every configured URL check.
+func (c *Client) List(ctx context.Context) ([]URLCheckRef, error) {
+	const op = "URLChecks.List"
+	u, err := c.core.URL("rest", "urlchecks")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap urlChecksListWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.URLChecks) == 0 || wrap.URLChecks[0] == '"' {
+		// Empty-collection wire shape: bare string.
+		return nil, nil
+	}
+	var inner struct {
+		URLCheck []URLCheckRef `json:"urlCheck"`
+	}
+	if err := json.Unmarshal(wrap.URLChecks, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.URLCheck, nil
+}
+
+// Get returns one URL check by name.
+func (c *Client) Get(ctx context.Context, name string) (*URLCheck, error) {
+	const op = "URLChecks.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "urlchecks", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var check URLCheck
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &check); err != nil {
+		return nil, err
+	}
+	return &check, nil
+}
+
+// Create registers a new URL check. Name and Regex are required.
+func (c *Client) Create(ctx context.Context, check *URLCheck) error {
+	const op = "URLChecks.Create"
+	if check == nil {
+		return errors.New(op + ": nil check")
+	}
+	if check.Name == "" || check.Regex == "" {
+		return errors.New(op + ": Name and Regex are required")
+	}
+	u, err := c.core.URL("rest", "urlchecks")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, check, nil, nil)
+}
+
+// Update replaces the URL check at name with the supplied body.
+// Per the upstream API, only changed fields need to be present.
+func (c *Client) Update(ctx context.Context, name string, check *URLCheck) error {
+	const op = "URLChecks.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if check == nil {
+		return errors.New(op + ": nil check")
+	}
+	u, err := c.core.URL("rest", "urlchecks", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, check, nil, nil)
+}
+
+// Delete removes the named URL check.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	const op = "URLChecks.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "urlchecks", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/urlchecks/urlchecks_integration_test.go
+++ b/v2/rest/urlchecks/urlchecks_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package urlchecks_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/urlchecks"
+)
+
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
+func TestURLChecks_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	name := uniqueName("v2_it_check")
+	chk := &urlchecks.URLCheck{
+		Name:        name,
+		Description: "v2 integration test",
+		Enabled:     true,
+		Regex:       "^https://test.example/" + name + "/.*$",
+	}
+
+	t.Cleanup(func() { _ = c.URLChecks.Delete(ctx, name) })
+
+	if err := c.URLChecks.Create(ctx, chk); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := c.URLChecks.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != name || got.Regex != chk.Regex || got.Enabled != true {
+		t.Errorf("Get returned %+v, want %+v", got, chk)
+	}
+
+	// List should include the new check.
+	list, err := c.URLChecks.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, ref := range list {
+		if ref.Name == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("check %q not in list (%d entries)", name, len(list))
+	}
+
+	// Update — flip enabled.
+	if err := c.URLChecks.Update(ctx, name, &urlchecks.URLCheck{Enabled: false, Regex: chk.Regex, Name: name}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err = c.URLChecks.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got.Enabled {
+		t.Errorf("expected Enabled=false after Update, got %+v", got)
+	}
+
+	// Delete.
+	if err := c.URLChecks.Delete(ctx, name); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := c.URLChecks.Get(ctx, name); !errors.Is(err, geoserver.ErrNotFound) {
+		t.Errorf("Get after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestURLChecks_List_EmptyOnFreshInstall_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Default install has no URL checks. The wire response is
+	// {"urlChecks":""} which the SDK normalizes to a nil slice.
+	list, err := c.URLChecks.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// We don't assert the exact count — earlier integration tests
+	// may have left checks behind on a shared dev stack — but List
+	// must not error on the empty wire shape.
+	_ = list
+}

--- a/v2/rest/urlchecks/urlchecks_test.go
+++ b/v2/rest/urlchecks/urlchecks_test.go
@@ -1,0 +1,185 @@
+package urlchecks_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/urlchecks"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_Empty_StringWireShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"urlChecks":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.URLChecks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty list for {urlChecks:\"\"}, got %d", len(list))
+	}
+}
+
+func TestList_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/urlchecks" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"urlChecks":{"urlCheck":[
+			{"name":"icons","href":"http://srv/rest/urlchecks/icons.json"},
+			{"name":"safeWFS","href":"http://srv/rest/urlchecks/safeWFS.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.URLChecks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d", len(list))
+	}
+	if list[0].Name != "icons" || list[1].Name != "safeWFS" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_WrappedShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"regexUrlCheck":{"name":"icons","description":"External graphic icons","enabled":true,"regex":"^https://styles.example/.*$"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	chk, err := c.URLChecks.Get(context.Background(), "icons")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if chk.Name != "icons" || chk.Description != "External graphic icons" || !chk.Enabled || chk.Regex == "" {
+		t.Errorf("check = %+v", chk)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.URLChecks.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreate_BodyIsRegexUrlCheckEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/urlchecks" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		// Body MUST be wrapped — flat JSON is rejected by the server.
+		for _, want := range []string{`"regexUrlCheck":{`, `"name":"icons"`, `"regex":"^https://`, `"enabled":true`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.URLChecks.Create(context.Background(), &urlchecks.URLCheck{
+		Name: "icons", Regex: "^https://example/.*$", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestCreate_RequiresFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	for _, in := range []*urlchecks.URLCheck{nil, {}, {Name: "x"}, {Regex: "y"}} {
+		err := c.URLChecks.Create(context.Background(), in)
+		if err == nil {
+			t.Errorf("expected error for input %+v", in)
+		}
+	}
+}
+
+func TestUpdate_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/urlchecks/icons" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.URLChecks.Update(context.Background(), "icons", &urlchecks.URLCheck{Enabled: true})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+func TestDelete_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/urlchecks/icons" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.URLChecks.Delete(context.Background(), "icons"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.URLChecks.Delete(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the URL-checks tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). URL External Access Checks are allow/deny lists for external URLs that GeoServer is permitted to fetch — SLD external graphics, image-mosaic remote rasters, cascaded WMS sources. SSRF-conscious deployments use them to constrain off-server URL fetching.

## What lands

- `c.URLChecks` at `/rest/urlchecks` — `List` / `Get` / `Create` / `Update` / `Delete`. Typed core: `Name`, `Description`, `Enabled`, `Regex`.

## Wire-format quirks (discovered via live integration testing)

- POST/PUT bodies require the `{"regexUrlCheck":{...}}` class-name envelope. Flat JSON is rejected with 500. `URLCheck.MarshalJSON` always wraps; `URLCheck.UnmarshalJSON` accepts both wrapped and flat (so callers don't need to special-case GET).
- Empty list comes back as `{"urlChecks":""}` (bare string instead of object) — same empty-collection pattern as styles, datastores, etc. `List` returns nil on the empty form.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/urlchecks/...` — unit tests pass (CRUD + envelope wrap/unwrap + empty-string list shape + 404 mapping).
- [x] `golangci-lint run ./rest/urlchecks/...` — 0 issues.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/urlchecks/...` — 2 PASS (full RoundTrip CRUD + empty-list).
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.