### PR TITLE
feat(v2): add cascaded WMS/WMTS stores and layers

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,10 +8,9 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **Cascaded WMS / WMTS stores** — `/wmsstores`, `/wmtsstores` | Federation / proxy setups | Re-publish a remote WMS / WMTS through your own server. |
-| 2 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 3 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 4 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
+| 2 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 3 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
@@ -21,6 +20,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Closed post-beta.1.
 - **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Closed post-beta.1.
 - **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Closed post-beta.1.
+- **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Cascaded WMS / WMTS stores and layers
+
+Closes the cascaded-WMS/WMTS tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Cascaded stores reference a remote WMS / WMTS server; cascaded layers re-publish that remote server's layers through the local GeoServer (federation / proxy setups).
+
+- **`c.WMSStores`** at `/rest/workspaces/{ws}/wmsstores` — workspace-scoped CRUD plus `Iter` for the (single-page) listing. `WMSStore` covers the daily-driver fields: `Name`, `Type`, `Enabled`, `CapabilitiesURL`, `User`/`Password`/`AuthKey`/`HeaderName`/`HeaderValue`, `MaxConnections`, `ReadTimeout`, `ConnectTimeout`, `UseHTTPConnPool`.
+- **`c.WMSLayers`** at `/rest/workspaces/{ws}/wmsstores/{store}/wmslayers` (canonical) and `/rest/workspaces/{ws}/wmslayers` (cross-store list) — 2-level scoped via `InWorkspace(ws).InStore(s)`. Daily-driver fields: `Name`, `NativeName`, `Title`, `Abstract`, `Keywords`, `NativeCRS`/`SRS`, bbox, `ProjectionPolicy`, `Enabled`, `ForcedRemoteStyle`, `PreferredFormat`, `MinScale`/`MaxScale`.
+- **`c.WMTSStores`** + **`c.WMTSLayers`** — parallel surface for cascaded WMTS.
+- **Wire shape:** all four packages MarshalJSON wrap in the documented per-type envelope (`{"wmsStore":{...}}` / `{"wmsLayer":{...}}` / `{"wmtsStore":{...}}` / `{"wmtsLayer":{...}}`); UnmarshalJSON accepts both wrapped and flat. List endpoints handle the empty-collection wire shape (`{"wmsStores":""}` etc.).
+
+Integration tests verify the empty-list and 404 paths against the live stack; full CRUD requires an upstream WMS/WMTS server to cascade FROM and isn't exercised in the test stack — the unit tests cover the wire-shape round-trip.
+
 ### Added — URL checks (SSRF allow-list)
 
 Closes the URL-checks tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). URL External Access Checks are allow/deny lists for external URLs that GeoServer is permitted to fetch (SLD external graphics, image-mosaic remote rasters, cascaded WMS sources). SSRF-conscious deployments use them to constrain off-server URL fetching.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -31,6 +31,10 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/system"
 	"github.com/hishamkaram/geoserver/v2/rest/templates"
 	"github.com/hishamkaram/geoserver/v2/rest/urlchecks"
+	"github.com/hishamkaram/geoserver/v2/rest/wmslayers"
+	"github.com/hishamkaram/geoserver/v2/rest/wmsstores"
+	"github.com/hishamkaram/geoserver/v2/rest/wmtslayers"
+	"github.com/hishamkaram/geoserver/v2/rest/wmtsstores"
 	"github.com/hishamkaram/geoserver/v2/rest/workspaces"
 
 	"github.com/hishamkaram/geoserver/v2/ows/wcs"
@@ -191,6 +195,27 @@ type Client struct {
 	// SSRF-conscious deployments to constrain which off-server
 	// URLs GeoServer is permitted to fetch.
 	URLChecks *urlchecks.Client
+
+	// WMSStores is the entry point for cascaded WMS stores —
+	// references to remote WMS servers re-published through this
+	// GeoServer instance. Workspace-scoped via
+	// `c.WMSStores.InWorkspace(ws)`.
+	WMSStores *wmsstores.Client
+
+	// WMSLayers is the entry point for cascaded WMS layers —
+	// individual remote WMS layers published locally. 2-level
+	// scoped: `c.WMSLayers.InWorkspace(ws).InStore(s)` for the
+	// canonical CRUD path, `c.WMSLayers.InWorkspace(ws)` for the
+	// workspace-wide list / get / delete.
+	WMSLayers *wmslayers.Client
+
+	// WMTSStores is the entry point for cascaded WMTS stores.
+	// Same scoping pattern as [Client.WMSStores].
+	WMTSStores *wmtsstores.Client
+
+	// WMTSLayers is the entry point for cascaded WMTS layers.
+	// Same scoping pattern as [Client.WMSLayers].
+	WMTSLayers *wmtslayers.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -270,6 +295,10 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.Resources = resources.New(adapter)
 	c.Templates = templates.New(adapter)
 	c.URLChecks = urlchecks.New(adapter)
+	c.WMSStores = wmsstores.New(adapter)
+	c.WMSLayers = wmslayers.New(adapter)
+	c.WMTSStores = wmtsstores.New(adapter)
+	c.WMTSLayers = wmtslayers.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/wmslayers/wmslayers.go
+++ b/v2/rest/wmslayers/wmslayers.go
@@ -1,0 +1,330 @@
+// Package wmslayers is the v2 sub-client for GeoServer's cascaded
+// WMS layers — published references to remote WMS server layers
+// served through the local GeoServer.
+//
+// Endpoints live at
+// /rest/workspaces/{ws}/wmsstores/{store}/wmslayers (canonical) and
+// /rest/workspaces/{ws}/wmslayers (workspace-scoped shortcut).
+package wmslayers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net/http"
+	"strconv"
+
+	"github.com/hishamkaram/geoserver/v2/internal/wire"
+)
+
+type (
+	// BoundingBox — see [wire.BoundingBox].
+	BoundingBox = wire.BoundingBox
+	// NativeBoundingBox — see [wire.NativeBoundingBox].
+	NativeBoundingBox = wire.NativeBoundingBox
+	// LatLonBoundingBox — see [wire.LatLonBoundingBox].
+	LatLonBoundingBox = wire.LatLonBoundingBox
+	// Keywords — see [wire.Keywords].
+	Keywords = wire.Keywords
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// StoreRef points at a WMS store (response-only).
+type StoreRef struct {
+	Name string `json:"name,omitempty"`
+}
+
+// WMSLayer is one cascaded WMS layer published by a [WMSStore].
+//
+// Required fields on Create: Name, NativeName.
+type WMSLayer struct {
+	Name              string             `json:"name,omitempty"`
+	NativeName        string             `json:"nativeName,omitempty"`
+	Title             string             `json:"title,omitempty"`
+	Abstract          string             `json:"abstract,omitempty"`
+	Description       string             `json:"description,omitempty"`
+	Keywords          *Keywords          `json:"keywords,omitempty"`
+	NativeCRS         string             `json:"nativeCRS,omitempty"`
+	SRS               string             `json:"srs,omitempty"`
+	NativeBoundingBox *NativeBoundingBox `json:"nativeBoundingBox,omitempty"`
+	LatLonBoundingBox *LatLonBoundingBox `json:"latLonBoundingBox,omitempty"`
+	ProjectionPolicy  string             `json:"projectionPolicy,omitempty"`
+	Enabled           bool               `json:"enabled,omitempty"`
+	Store             *StoreRef          `json:"store,omitempty"`
+	ForcedRemoteStyle string             `json:"forcedRemoteStyle,omitempty"`
+	PreferredFormat   string             `json:"preferredFormat,omitempty"`
+	MinScale          float64            `json:"minScale,omitempty"`
+	MaxScale          float64            `json:"maxScale,omitempty"`
+}
+
+// MarshalJSON wraps the layer in GeoServer's `{"wmsLayer":{...}}`
+// envelope used by POST/PUT.
+func (l WMSLayer) MarshalJSON() ([]byte, error) {
+	type alias WMSLayer
+	return json.Marshal(map[string]alias{"wmsLayer": alias(l)})
+}
+
+// UnmarshalJSON accepts both the wrapped form (`{"wmsLayer":{...}}`)
+// and a flat object.
+func (l *WMSLayer) UnmarshalJSON(b []byte) error {
+	type alias WMSLayer
+	var wrapped struct {
+		WMSLayer *alias `json:"wmsLayer"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.WMSLayer != nil {
+		*l = WMSLayer(*wrapped.WMSLayer)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*l = WMSLayer(flat)
+	return nil
+}
+
+// Ref is a `{name, href}` reference returned by list endpoints.
+type Ref struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+type listWire struct {
+	WMSLayers json.RawMessage `json:"wmsLayers"`
+}
+
+// Client is the cascaded WMS layers sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace narrows scope to one workspace.
+func (c *Client) InWorkspace(workspace string) *WorkspaceClient {
+	return &WorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// WorkspaceClient operates on /workspaces/{ws}/wmslayers — the
+// workspace-wide list across all WMS stores in the workspace.
+type WorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *WorkspaceClient) Workspace() string { return c.workspace }
+
+// InStore narrows further to one WMS store, exposing the canonical
+// /workspaces/{ws}/wmsstores/{store}/wmslayers path.
+func (c *WorkspaceClient) InStore(store string) *StoreClient {
+	return &StoreClient{core: c.core, workspace: c.workspace, store: store}
+}
+
+// ListOptions controls listing behavior.
+type ListOptions struct{}
+
+// DeleteOptions controls deletion behavior.
+type DeleteOptions struct {
+	Recurse bool
+}
+
+// CreateOptions controls listing behavior for creates.
+type CreateOptions struct{}
+
+// List returns every cascaded WMS layer in the workspace.
+func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMSLayers.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmslayers")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return c.decodeList(ctx, op, u)
+}
+
+// Get returns one workspace-scoped layer by name.
+func (c *WorkspaceClient) Get(ctx context.Context, name string) (*WMSLayer, error) {
+	const op = "WMSLayers.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmslayers", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var l WMSLayer
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// Delete removes a layer at the workspace scope.
+func (c *WorkspaceClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMSLayers.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}
+
+func (c *WorkspaceClient) decodeList(ctx context.Context, op, u string) ([]Ref, error) {
+	var wrap listWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMSLayers) == 0 || wrap.WMSLayers[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMSLayer []Ref `json:"wmsLayer"`
+	}
+	if err := json.Unmarshal(wrap.WMSLayers, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMSLayer, nil
+}
+
+// StoreClient is store-scoped CRUD —
+// /workspaces/{ws}/wmsstores/{store}/wmslayers — the canonical
+// surface for creating cascaded layers (Create requires a store
+// parent).
+type StoreClient struct {
+	core      Core
+	workspace string
+	store     string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *StoreClient) Workspace() string { return c.workspace }
+
+// Store returns the WMS store bound to this client.
+func (c *StoreClient) Store() string { return c.store }
+
+// List returns every cascaded WMS layer under this store.
+func (c *StoreClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMSLayers.Store.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", c.store, "wmslayers")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return decodeListAt(ctx, op, c.core, u)
+}
+
+// Iter is the range-over-func pagination helper. The wmslayers
+// endpoint doesn't paginate; this is a single-page Seq2.
+func (c *StoreClient) Iter(ctx context.Context, opts ListOptions) iter.Seq2[Ref, error] {
+	return func(yield func(Ref, error) bool) {
+		refs, err := c.List(ctx, opts)
+		if err != nil {
+			yield(Ref{}, err)
+			return
+		}
+		for _, r := range refs {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get returns one cascaded WMS layer under this store.
+func (c *StoreClient) Get(ctx context.Context, name string) (*WMSLayer, error) {
+	const op = "WMSLayers.Store.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", c.store, "wmslayers", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var l WMSLayer
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// Create publishes a cascaded WMS layer. Required: Name, NativeName.
+func (c *StoreClient) Create(ctx context.Context, layer *WMSLayer) error {
+	const op = "WMSLayers.Store.Create"
+	if layer == nil {
+		return errors.New(op + ": nil layer")
+	}
+	if layer.Name == "" || layer.NativeName == "" {
+		return errors.New(op + ": Name and NativeName are required")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", c.store, "wmslayers")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, layer, nil, nil)
+}
+
+// Update replaces the layer at name.
+func (c *StoreClient) Update(ctx context.Context, name string, layer *WMSLayer) error {
+	const op = "WMSLayers.Store.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if layer == nil {
+		return errors.New(op + ": nil layer")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", c.store, "wmslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, layer, nil, nil)
+}
+
+// Delete removes a layer.
+func (c *StoreClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMSLayers.Store.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", c.store, "wmslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}
+
+func decodeListAt(ctx context.Context, op string, core Core, u string) ([]Ref, error) {
+	var wrap listWire
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMSLayers) == 0 || wrap.WMSLayers[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMSLayer []Ref `json:"wmsLayer"`
+	}
+	if err := json.Unmarshal(wrap.WMSLayers, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMSLayer, nil
+}

--- a/v2/rest/wmslayers/wmslayers_test.go
+++ b/v2/rest/wmslayers/wmslayers_test.go
@@ -1,0 +1,125 @@
+package wmslayers_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/wmslayers"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_Workspace_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmslayers" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsLayers":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMSLayers.InWorkspace("topp").List(context.Background(), wmslayers.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty, got %d", len(list))
+	}
+}
+
+func TestList_Store_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmsstores/altgs/wmslayers" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsLayers":{"wmsLayer":[
+			{"name":"dem","href":"http://srv/rest/workspaces/topp/wmsstores/altgs/wmslayers/dem.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMSLayers.InWorkspace("topp").InStore("altgs").List(context.Background(), wmslayers.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "dem" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_Store_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsLayer":{"name":"dem","nativeName":"usgs:dem","srs":"EPSG:4326","enabled":true}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	l, err := c.WMSLayers.InWorkspace("topp").InStore("altgs").Get(context.Background(), "dem")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if l.Name != "dem" || l.NativeName != "usgs:dem" || l.SRS != "EPSG:4326" {
+		t.Errorf("layer = %+v", l)
+	}
+}
+
+func TestCreate_BodyWrapsInWMSLayerEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"wmsLayer":{`, `"name":"dem"`, `"nativeName":"usgs:dem"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.WMSLayers.InWorkspace("topp").InStore("altgs").Create(context.Background(), &wmslayers.WMSLayer{
+		Name:       "dem",
+		NativeName: "usgs:dem",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WMSLayers.InWorkspace("topp").InStore("altgs").Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/wmsstores/wmsstores.go
+++ b/v2/rest/wmsstores/wmsstores.go
@@ -1,0 +1,231 @@
+// Package wmsstores is the v2 sub-client for the GeoServer cascaded
+// WMS store endpoint at /rest/workspaces/{ws}/wmsstores. A WMS store
+// references a remote WMS server; cascaded layers under the store
+// re-publish that remote WMS through the local GeoServer.
+package wmsstores
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net/http"
+	"strconv"
+)
+
+// WorkspaceRef is the workspace pointer GeoServer carries back on a
+// store response.
+type WorkspaceRef struct {
+	Name string `json:"name,omitempty"`
+}
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// WMSStore is a cascaded WMS store. Required fields on Create:
+// Name, CapabilitiesURL.
+type WMSStore struct {
+	Name            string        `json:"name,omitempty"`
+	Type            string        `json:"type,omitempty"`
+	Enabled         bool          `json:"enabled,omitempty"`
+	Workspace       *WorkspaceRef `json:"workspace,omitempty"`
+	Default         bool          `json:"_default,omitempty"`
+	CapabilitiesURL string        `json:"capabilitiesURL,omitempty"`
+	User            string        `json:"user,omitempty"`
+	Password        string        `json:"password,omitempty"`
+	HeaderName      string        `json:"headerName,omitempty"`
+	HeaderValue     string        `json:"headerValue,omitempty"`
+	AuthKey         string        `json:"authKey,omitempty"`
+	MaxConnections  int           `json:"maxConnections,omitempty"`
+	ReadTimeout     int           `json:"readTimeout,omitempty"`
+	ConnectTimeout  int           `json:"connectTimeout,omitempty"`
+	UseHTTPConnPool bool          `json:"useHttpConnectionPooling,omitempty"`
+}
+
+// MarshalJSON wraps the store in GeoServer's `{"wmsStore":{...}}`
+// envelope expected by POST/PUT. The store body legitimately
+// includes upstream-WMS basic-auth credentials (Password, AuthKey)
+// — these are part of the documented GeoServer config schema, not
+// an exfiltration channel, so the gosec credential heuristic is
+// suppressed below.
+func (s WMSStore) MarshalJSON() ([]byte, error) {
+	type alias WMSStore
+	return json.Marshal(map[string]alias{"wmsStore": alias(s)}) //nolint:gosec // Password/AuthKey are required upstream-WMS credentials per GeoServer's wmsStore schema.
+}
+
+// UnmarshalJSON accepts both the wrapped form (`{"wmsStore":{...}}`)
+// and a flat object.
+func (s *WMSStore) UnmarshalJSON(b []byte) error {
+	type alias WMSStore
+	var wrapped struct {
+		WMSStore *alias `json:"wmsStore"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.WMSStore != nil {
+		*s = WMSStore(*wrapped.WMSStore)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*s = WMSStore(flat)
+	return nil
+}
+
+// Ref is a `{name, href}` reference returned by list endpoints.
+type Ref struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+// listWire decodes the list envelope shape:
+// `{"wmsStores":{"wmsStore":[{name, href}, ...]}}` or
+// `{"wmsStores":""}` (empty).
+type listWire struct {
+	WMSStores json.RawMessage `json:"wmsStores"`
+}
+
+// Client is the v2 cascaded WMS stores sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the WMS stores sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace narrows scope to one workspace's WMS stores.
+func (c *Client) InWorkspace(workspace string) *WorkspaceClient {
+	return &WorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// WorkspaceClient is workspace-scoped CRUD for WMS stores.
+type WorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *WorkspaceClient) Workspace() string { return c.workspace }
+
+// ListOptions controls listing behavior. Currently empty.
+type ListOptions struct{}
+
+// DeleteOptions controls deletion behavior.
+type DeleteOptions struct {
+	// Recurse removes any cascaded layers under the store along
+	// with the store itself.
+	Recurse bool
+}
+
+// List returns every cascaded WMS store in the workspace.
+func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMSStores.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap listWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMSStores) == 0 || wrap.WMSStores[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMSStore []Ref `json:"wmsStore"`
+	}
+	if err := json.Unmarshal(wrap.WMSStores, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMSStore, nil
+}
+
+// Iter yields refs as a range-over-func iterator. Single-page
+// fallback (the GeoServer wmsstores endpoint does not paginate).
+func (c *WorkspaceClient) Iter(ctx context.Context, opts ListOptions) iter.Seq2[Ref, error] {
+	return func(yield func(Ref, error) bool) {
+		refs, err := c.List(ctx, opts)
+		if err != nil {
+			yield(Ref{}, err)
+			return
+		}
+		for _, r := range refs {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get returns one store by name.
+func (c *WorkspaceClient) Get(ctx context.Context, name string) (*WMSStore, error) {
+	const op = "WMSStores.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var s WMSStore
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// Create registers a new store. Required fields: Name, CapabilitiesURL.
+func (c *WorkspaceClient) Create(ctx context.Context, store *WMSStore) error {
+	const op = "WMSStores.Create"
+	if store == nil {
+		return errors.New(op + ": nil store")
+	}
+	if store.Name == "" || store.CapabilitiesURL == "" {
+		return errors.New(op + ": Name and CapabilitiesURL are required")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, store, nil, nil)
+}
+
+// Update replaces the store at name.
+func (c *WorkspaceClient) Update(ctx context.Context, name string, store *WMSStore) error {
+	const op = "WMSStores.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if store == nil {
+		return errors.New(op + ": nil store")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, store, nil, nil)
+}
+
+// Delete removes a store. Set DeleteOptions.Recurse to also remove
+// any cascaded layers under it.
+func (c *WorkspaceClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMSStores.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmsstores", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}

--- a/v2/rest/wmsstores/wmsstores_integration_test.go
+++ b/v2/rest/wmsstores/wmsstores_integration_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package wmsstores_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/wmsstores"
+)
+
+// The default GeoServer install ships no cascaded WMS stores. The
+// list endpoint returns the empty-collection wire shape
+// {"wmsStores":""} which the SDK normalizes to a nil slice. We
+// can't exercise full CRUD without an upstream WMS to cascade FROM,
+// but verifying the empty-shape path against a real GeoServer is
+// already meaningful coverage.
+func TestWMSStores_List_EmptyOnFreshInstall_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	for _, ws := range []string{"topp", "nurc", "sf"} {
+		list, err := c.WMSStores.InWorkspace(ws).List(ctx, wmsstores.ListOptions{})
+		if err != nil {
+			t.Errorf("List in %s: %v", ws, err)
+		}
+		// Length is whatever — fresh install has 0; concurrent runs
+		// of other tests may leave stores behind. The key assertion
+		// is that the empty-string wire shape doesn't error.
+		_ = list
+	}
+}
+
+func TestWMSStores_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+	_, err := c.WMSStores.InWorkspace("topp").Get(ctx, "v2_it_definitely_not_a_store")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/wmsstores/wmsstores_test.go
+++ b/v2/rest/wmsstores/wmsstores_test.go
@@ -1,0 +1,151 @@
+package wmsstores_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/wmsstores"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_EmptyStringWireShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsStores":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMSStores.InWorkspace("topp").List(context.Background(), wmsstores.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty list, got %d entries", len(list))
+	}
+}
+
+func TestList_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmsstores" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsStores":{"wmsStore":[
+			{"name":"altgs","href":"http://srv/rest/workspaces/topp/wmsstores/altgs.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMSStores.InWorkspace("topp").List(context.Background(), wmsstores.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "altgs" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_OK_WrappedShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmsStore":{"name":"altgs","type":"WMS","enabled":true,"capabilitiesURL":"http://upstream/wms?request=GetCapabilities","maxConnections":6}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	s, err := c.WMSStores.InWorkspace("topp").Get(context.Background(), "altgs")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if s.Name != "altgs" || s.CapabilitiesURL == "" || s.MaxConnections != 6 {
+		t.Errorf("store = %+v", s)
+	}
+}
+
+func TestCreate_BodyWrapsInWMSStoreEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"wmsStore":{`, `"name":"new"`, `"capabilitiesURL":"http://upstream/wms"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.WMSStores.InWorkspace("topp").Create(context.Background(), &wmsstores.WMSStore{
+		Name:            "new",
+		CapabilitiesURL: "http://upstream/wms",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestCreate_RequiresFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	for _, in := range []*wmsstores.WMSStore{nil, {}, {Name: "x"}, {CapabilitiesURL: "y"}} {
+		if err := c.WMSStores.InWorkspace("topp").Create(context.Background(), in); err == nil {
+			t.Errorf("expected error for %+v", in)
+		}
+	}
+}
+
+func TestDelete_RecurseQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/workspaces/topp/wmsstores/altgs" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("recurse") != "true" {
+			t.Errorf("recurse = %q", r.URL.Query().Get("recurse"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.WMSStores.InWorkspace("topp").Delete(context.Background(), "altgs", wmsstores.DeleteOptions{Recurse: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WMSStores.InWorkspace("topp").Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/wmtslayers/wmtslayers.go
+++ b/v2/rest/wmtslayers/wmtslayers.go
@@ -1,0 +1,330 @@
+// Package wmtslayers is the v2 sub-client for GeoServer's cascaded
+// WMS layers — published references to remote WMS server layers
+// served through the local GeoServer.
+//
+// Endpoints live at
+// /rest/workspaces/{ws}/wmtsstores/{store}/wmtslayers (canonical) and
+// /rest/workspaces/{ws}/wmtslayers (workspace-scoped shortcut).
+package wmtslayers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net/http"
+	"strconv"
+
+	"github.com/hishamkaram/geoserver/v2/internal/wire"
+)
+
+type (
+	// BoundingBox — see [wire.BoundingBox].
+	BoundingBox = wire.BoundingBox
+	// NativeBoundingBox — see [wire.NativeBoundingBox].
+	NativeBoundingBox = wire.NativeBoundingBox
+	// LatLonBoundingBox — see [wire.LatLonBoundingBox].
+	LatLonBoundingBox = wire.LatLonBoundingBox
+	// Keywords — see [wire.Keywords].
+	Keywords = wire.Keywords
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// StoreRef points at a WMS store (response-only).
+type StoreRef struct {
+	Name string `json:"name,omitempty"`
+}
+
+// WMTSLayer is one cascaded WMTS layer published by a [WMTSStore].
+//
+// Required fields on Create: Name, NativeName.
+type WMTSLayer struct {
+	Name              string             `json:"name,omitempty"`
+	NativeName        string             `json:"nativeName,omitempty"`
+	Title             string             `json:"title,omitempty"`
+	Abstract          string             `json:"abstract,omitempty"`
+	Description       string             `json:"description,omitempty"`
+	Keywords          *Keywords          `json:"keywords,omitempty"`
+	NativeCRS         string             `json:"nativeCRS,omitempty"`
+	SRS               string             `json:"srs,omitempty"`
+	NativeBoundingBox *NativeBoundingBox `json:"nativeBoundingBox,omitempty"`
+	LatLonBoundingBox *LatLonBoundingBox `json:"latLonBoundingBox,omitempty"`
+	ProjectionPolicy  string             `json:"projectionPolicy,omitempty"`
+	Enabled           bool               `json:"enabled,omitempty"`
+	Store             *StoreRef          `json:"store,omitempty"`
+	ForcedRemoteStyle string             `json:"forcedRemoteStyle,omitempty"`
+	PreferredFormat   string             `json:"preferredFormat,omitempty"`
+	MinScale          float64            `json:"minScale,omitempty"`
+	MaxScale          float64            `json:"maxScale,omitempty"`
+}
+
+// MarshalJSON wraps the layer in GeoServer's `{"wmtsLayer":{...}}`
+// envelope used by POST/PUT.
+func (l WMTSLayer) MarshalJSON() ([]byte, error) {
+	type alias WMTSLayer
+	return json.Marshal(map[string]alias{"wmtsLayer": alias(l)})
+}
+
+// UnmarshalJSON accepts both the wrapped form (`{"wmtsLayer":{...}}`)
+// and a flat object.
+func (l *WMTSLayer) UnmarshalJSON(b []byte) error {
+	type alias WMTSLayer
+	var wrapped struct {
+		WMTSLayer *alias `json:"wmtsLayer"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.WMTSLayer != nil {
+		*l = WMTSLayer(*wrapped.WMTSLayer)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*l = WMTSLayer(flat)
+	return nil
+}
+
+// Ref is a `{name, href}` reference returned by list endpoints.
+type Ref struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+type listWire struct {
+	WMTSLayers json.RawMessage `json:"wmtsLayers"`
+}
+
+// Client is the cascaded WMTS layers sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace narrows scope to one workspace.
+func (c *Client) InWorkspace(workspace string) *WorkspaceClient {
+	return &WorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// WorkspaceClient operates on /workspaces/{ws}/wmtslayers — the
+// workspace-wide list across all WMS stores in the workspace.
+type WorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *WorkspaceClient) Workspace() string { return c.workspace }
+
+// InStore narrows further to one WMS store, exposing the canonical
+// /workspaces/{ws}/wmtsstores/{store}/wmtslayers path.
+func (c *WorkspaceClient) InStore(store string) *StoreClient {
+	return &StoreClient{core: c.core, workspace: c.workspace, store: store}
+}
+
+// ListOptions controls listing behavior.
+type ListOptions struct{}
+
+// DeleteOptions controls deletion behavior.
+type DeleteOptions struct {
+	Recurse bool
+}
+
+// CreateOptions controls listing behavior for creates.
+type CreateOptions struct{}
+
+// List returns every cascaded WMTS layer in the workspace.
+func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMTSLayers.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtslayers")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return c.decodeList(ctx, op, u)
+}
+
+// Get returns one workspace-scoped layer by name.
+func (c *WorkspaceClient) Get(ctx context.Context, name string) (*WMTSLayer, error) {
+	const op = "WMTSLayers.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtslayers", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var l WMTSLayer
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// Delete removes a layer at the workspace scope.
+func (c *WorkspaceClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMTSLayers.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}
+
+func (c *WorkspaceClient) decodeList(ctx context.Context, op, u string) ([]Ref, error) {
+	var wrap listWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMTSLayers) == 0 || wrap.WMTSLayers[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMTSLayer []Ref `json:"wmtsLayer"`
+	}
+	if err := json.Unmarshal(wrap.WMTSLayers, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMTSLayer, nil
+}
+
+// StoreClient is store-scoped CRUD —
+// /workspaces/{ws}/wmtsstores/{store}/wmtslayers — the canonical
+// surface for creating cascaded layers (Create requires a store
+// parent).
+type StoreClient struct {
+	core      Core
+	workspace string
+	store     string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *StoreClient) Workspace() string { return c.workspace }
+
+// Store returns the WMS store bound to this client.
+func (c *StoreClient) Store() string { return c.store }
+
+// List returns every cascaded WMTS layer under this store.
+func (c *StoreClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMTSLayers.Store.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", c.store, "wmtslayers")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return decodeListAt(ctx, op, c.core, u)
+}
+
+// Iter is the range-over-func pagination helper. The wmtslayers
+// endpoint doesn't paginate; this is a single-page Seq2.
+func (c *StoreClient) Iter(ctx context.Context, opts ListOptions) iter.Seq2[Ref, error] {
+	return func(yield func(Ref, error) bool) {
+		refs, err := c.List(ctx, opts)
+		if err != nil {
+			yield(Ref{}, err)
+			return
+		}
+		for _, r := range refs {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get returns one cascaded WMTS layer under this store.
+func (c *StoreClient) Get(ctx context.Context, name string) (*WMTSLayer, error) {
+	const op = "WMTSLayers.Store.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", c.store, "wmtslayers", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var l WMTSLayer
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// Create publishes a cascaded WMTS layer. Required: Name, NativeName.
+func (c *StoreClient) Create(ctx context.Context, layer *WMTSLayer) error {
+	const op = "WMTSLayers.Store.Create"
+	if layer == nil {
+		return errors.New(op + ": nil layer")
+	}
+	if layer.Name == "" || layer.NativeName == "" {
+		return errors.New(op + ": Name and NativeName are required")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", c.store, "wmtslayers")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, layer, nil, nil)
+}
+
+// Update replaces the layer at name.
+func (c *StoreClient) Update(ctx context.Context, name string, layer *WMTSLayer) error {
+	const op = "WMTSLayers.Store.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if layer == nil {
+		return errors.New(op + ": nil layer")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", c.store, "wmtslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, layer, nil, nil)
+}
+
+// Delete removes a layer.
+func (c *StoreClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMTSLayers.Store.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", c.store, "wmtslayers", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}
+
+func decodeListAt(ctx context.Context, op string, core Core, u string) ([]Ref, error) {
+	var wrap listWire
+	if err := core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMTSLayers) == 0 || wrap.WMTSLayers[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMTSLayer []Ref `json:"wmtsLayer"`
+	}
+	if err := json.Unmarshal(wrap.WMTSLayers, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMTSLayer, nil
+}

--- a/v2/rest/wmtslayers/wmtslayers_test.go
+++ b/v2/rest/wmtslayers/wmtslayers_test.go
@@ -1,0 +1,125 @@
+package wmtslayers_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/wmtslayers"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_Workspace_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmtslayers" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsLayers":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMTSLayers.InWorkspace("topp").List(context.Background(), wmtslayers.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty, got %d", len(list))
+	}
+}
+
+func TestList_Store_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmtsstores/altgs/wmtslayers" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsLayers":{"wmtsLayer":[
+			{"name":"dem","href":"http://srv/rest/workspaces/topp/wmtsstores/altgs/wmtslayers/dem.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMTSLayers.InWorkspace("topp").InStore("altgs").List(context.Background(), wmtslayers.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "dem" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_Store_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsLayer":{"name":"dem","nativeName":"usgs:dem","srs":"EPSG:4326","enabled":true}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	l, err := c.WMTSLayers.InWorkspace("topp").InStore("altgs").Get(context.Background(), "dem")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if l.Name != "dem" || l.NativeName != "usgs:dem" || l.SRS != "EPSG:4326" {
+		t.Errorf("layer = %+v", l)
+	}
+}
+
+func TestCreate_BodyWrapsInWMTSLayerEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"wmtsLayer":{`, `"name":"dem"`, `"nativeName":"usgs:dem"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.WMTSLayers.InWorkspace("topp").InStore("altgs").Create(context.Background(), &wmtslayers.WMTSLayer{
+		Name:       "dem",
+		NativeName: "usgs:dem",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WMTSLayers.InWorkspace("topp").InStore("altgs").Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/wmtsstores/wmtsstores.go
+++ b/v2/rest/wmtsstores/wmtsstores.go
@@ -1,0 +1,228 @@
+// Package wmtsstores is the v2 sub-client for the GeoServer cascaded
+// WMS store endpoint at /rest/workspaces/{ws}/wmtsstores. A WMS store
+// references a remote WMS server; cascaded layers under the store
+// re-publish that remote WMS through the local GeoServer.
+package wmtsstores
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net/http"
+	"strconv"
+)
+
+// WorkspaceRef is the workspace pointer GeoServer carries back on a
+// store response.
+type WorkspaceRef struct {
+	Name string `json:"name,omitempty"`
+}
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// WMTSStore is a cascaded WMTS store. Required fields on Create:
+// Name, CapabilitiesURL.
+type WMTSStore struct {
+	Name            string        `json:"name,omitempty"`
+	Type            string        `json:"type,omitempty"`
+	Enabled         bool          `json:"enabled,omitempty"`
+	Workspace       *WorkspaceRef `json:"workspace,omitempty"`
+	Default         bool          `json:"_default,omitempty"`
+	CapabilitiesURL string        `json:"capabilitiesURL,omitempty"`
+	User            string        `json:"user,omitempty"`
+	Password        string        `json:"password,omitempty"`
+	HeaderName      string        `json:"headerName,omitempty"`
+	HeaderValue     string        `json:"headerValue,omitempty"`
+	AuthKey         string        `json:"authKey,omitempty"`
+	MaxConnections  int           `json:"maxConnections,omitempty"`
+	ReadTimeout     int           `json:"readTimeout,omitempty"`
+	ConnectTimeout  int           `json:"connectTimeout,omitempty"`
+	UseHTTPConnPool bool          `json:"useHttpConnectionPooling,omitempty"`
+}
+
+// MarshalJSON wraps the store in GeoServer's `{"wmtsStore":{...}}`
+// envelope expected by POST/PUT. See [WMTSStore] doc for the
+// rationale on the Password / AuthKey gosec suppression.
+func (s WMTSStore) MarshalJSON() ([]byte, error) {
+	type alias WMTSStore
+	return json.Marshal(map[string]alias{"wmtsStore": alias(s)}) //nolint:gosec // Password/AuthKey are required upstream-WMTS credentials per GeoServer's wmtsStore schema.
+}
+
+// UnmarshalJSON accepts both the wrapped form (`{"wmtsStore":{...}}`)
+// and a flat object.
+func (s *WMTSStore) UnmarshalJSON(b []byte) error {
+	type alias WMTSStore
+	var wrapped struct {
+		WMTSStore *alias `json:"wmtsStore"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.WMTSStore != nil {
+		*s = WMTSStore(*wrapped.WMTSStore)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*s = WMTSStore(flat)
+	return nil
+}
+
+// Ref is a `{name, href}` reference returned by list endpoints.
+type Ref struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+// listWire decodes the list envelope shape:
+// `{"wmtsStores":{"wmtsStore":[{name, href}, ...]}}` or
+// `{"wmtsStores":""}` (empty).
+type listWire struct {
+	WMTSStores json.RawMessage `json:"wmtsStores"`
+}
+
+// Client is the v2 cascaded WMTS stores sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the WMS stores sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// InWorkspace narrows scope to one workspace's WMS stores.
+func (c *Client) InWorkspace(workspace string) *WorkspaceClient {
+	return &WorkspaceClient{core: c.core, workspace: workspace}
+}
+
+// WorkspaceClient is workspace-scoped CRUD for WMS stores.
+type WorkspaceClient struct {
+	core      Core
+	workspace string
+}
+
+// Workspace returns the workspace bound to this client.
+func (c *WorkspaceClient) Workspace() string { return c.workspace }
+
+// ListOptions controls listing behavior. Currently empty.
+type ListOptions struct{}
+
+// DeleteOptions controls deletion behavior.
+type DeleteOptions struct {
+	// Recurse removes any cascaded layers under the store along
+	// with the store itself.
+	Recurse bool
+}
+
+// List returns every cascaded WMTS store in the workspace.
+func (c *WorkspaceClient) List(ctx context.Context, _ ListOptions) ([]Ref, error) {
+	const op = "WMTSStores.List"
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap listWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.WMTSStores) == 0 || wrap.WMTSStores[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		WMTSStore []Ref `json:"wmtsStore"`
+	}
+	if err := json.Unmarshal(wrap.WMTSStores, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.WMTSStore, nil
+}
+
+// Iter yields refs as a range-over-func iterator. Single-page
+// fallback (the GeoServer wmtsstores endpoint does not paginate).
+func (c *WorkspaceClient) Iter(ctx context.Context, opts ListOptions) iter.Seq2[Ref, error] {
+	return func(yield func(Ref, error) bool) {
+		refs, err := c.List(ctx, opts)
+		if err != nil {
+			yield(Ref{}, err)
+			return
+		}
+		for _, r := range refs {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Get returns one store by name.
+func (c *WorkspaceClient) Get(ctx context.Context, name string) (*WMTSStore, error) {
+	const op = "WMTSStores.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var s WMTSStore
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// Create registers a new store. Required fields: Name, CapabilitiesURL.
+func (c *WorkspaceClient) Create(ctx context.Context, store *WMTSStore) error {
+	const op = "WMTSStores.Create"
+	if store == nil {
+		return errors.New(op + ": nil store")
+	}
+	if store.Name == "" || store.CapabilitiesURL == "" {
+		return errors.New(op + ": Name and CapabilitiesURL are required")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, store, nil, nil)
+}
+
+// Update replaces the store at name.
+func (c *WorkspaceClient) Update(ctx context.Context, name string, store *WMTSStore) error {
+	const op = "WMTSStores.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if store == nil {
+		return errors.New(op + ": nil store")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, store, nil, nil)
+}
+
+// Delete removes a store. Set DeleteOptions.Recurse to also remove
+// any cascaded layers under it.
+func (c *WorkspaceClient) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	const op = "WMTSStores.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "workspaces", c.workspace, "wmtsstores", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	var query map[string]string
+	if opts.Recurse {
+		query = map[string]string{"recurse": strconv.FormatBool(true)}
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, query, nil)
+}

--- a/v2/rest/wmtsstores/wmtsstores_integration_test.go
+++ b/v2/rest/wmtsstores/wmtsstores_integration_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package wmtsstores_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/wmtsstores"
+)
+
+// The default GeoServer install ships no cascaded WMS stores. The
+// list endpoint returns the empty-collection wire shape
+// {"wmtsStores":""} which the SDK normalizes to a nil slice. We
+// can't exercise full CRUD without an upstream WMS to cascade FROM,
+// but verifying the empty-shape path against a real GeoServer is
+// already meaningful coverage.
+func TestWMTSStores_List_EmptyOnFreshInstall_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	for _, ws := range []string{"topp", "nurc", "sf"} {
+		list, err := c.WMTSStores.InWorkspace(ws).List(ctx, wmtsstores.ListOptions{})
+		if err != nil {
+			t.Errorf("List in %s: %v", ws, err)
+		}
+		// Length is whatever — fresh install has 0; concurrent runs
+		// of other tests may leave stores behind. The key assertion
+		// is that the empty-string wire shape doesn't error.
+		_ = list
+	}
+}
+
+func TestWMTSStores_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+	_, err := c.WMTSStores.InWorkspace("topp").Get(ctx, "v2_it_definitely_not_a_store")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/v2/rest/wmtsstores/wmtsstores_test.go
+++ b/v2/rest/wmtsstores/wmtsstores_test.go
@@ -1,0 +1,151 @@
+package wmtsstores_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/wmtsstores"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_EmptyStringWireShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsStores":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMTSStores.InWorkspace("topp").List(context.Background(), wmtsstores.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty list, got %d entries", len(list))
+	}
+}
+
+func TestList_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/workspaces/topp/wmtsstores" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsStores":{"wmtsStore":[
+			{"name":"altgs","href":"http://srv/rest/workspaces/topp/wmtsstores/altgs.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WMTSStores.InWorkspace("topp").List(context.Background(), wmtsstores.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "altgs" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_OK_WrappedShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"wmtsStore":{"name":"altgs","type":"WMS","enabled":true,"capabilitiesURL":"http://upstream/wms?request=GetCapabilities","maxConnections":6}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	s, err := c.WMTSStores.InWorkspace("topp").Get(context.Background(), "altgs")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if s.Name != "altgs" || s.CapabilitiesURL == "" || s.MaxConnections != 6 {
+		t.Errorf("store = %+v", s)
+	}
+}
+
+func TestCreate_BodyWrapsInWMTSStoreEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"wmtsStore":{`, `"name":"new"`, `"capabilitiesURL":"http://upstream/wms"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.WMTSStores.InWorkspace("topp").Create(context.Background(), &wmtsstores.WMTSStore{
+		Name:            "new",
+		CapabilitiesURL: "http://upstream/wms",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestCreate_RequiresFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	for _, in := range []*wmtsstores.WMTSStore{nil, {}, {Name: "x"}, {CapabilitiesURL: "y"}} {
+		if err := c.WMTSStores.InWorkspace("topp").Create(context.Background(), in); err == nil {
+			t.Errorf("expected error for %+v", in)
+		}
+	}
+}
+
+func TestDelete_RecurseQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/workspaces/topp/wmtsstores/altgs" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("recurse") != "true" {
+			t.Errorf("recurse = %q", r.URL.Query().Get("recurse"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.WMTSStores.InWorkspace("topp").Delete(context.Background(), "altgs", wmtsstores.DeleteOptions{Recurse: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WMTSStores.InWorkspace("topp").Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the cascaded-WMS/WMTS tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Cascaded stores reference a remote WMS / WMTS server; cascaded layers re-publish that remote server's layers through the local GeoServer (federation / proxy setups).

## What lands

Four new sub-clients on the root `*Client`:

- `c.WMSStores` at `/rest/workspaces/{ws}/wmsstores` — workspace-scoped CRUD + `Iter`.
- `c.WMSLayers` at `/rest/workspaces/{ws}/wmsstores/{store}/wmslayers` (canonical) and `/rest/workspaces/{ws}/wmslayers` (cross-store list) — 2-level scoped via `InWorkspace(ws).InStore(s)`.
- `c.WMTSStores` + `c.WMTSLayers` — parallel surface for cascaded WMTS.

`WMSStore` / `WMTSStore` daily-driver fields: `Name`, `Type`, `Enabled`, `CapabilitiesURL`, `User`/`Password`/`AuthKey`/`HeaderName`/`HeaderValue`, `MaxConnections`, `ReadTimeout`, `ConnectTimeout`, `UseHTTPConnPool`.

`WMSLayer` / `WMTSLayer` daily-driver fields: `Name`, `NativeName`, `Title`, `Abstract`, `Keywords`, `NativeCRS`/`SRS`, `NativeBoundingBox`/`LatLonBoundingBox`, `ProjectionPolicy`, `Enabled`, `ForcedRemoteStyle`, `PreferredFormat`, `MinScale`/`MaxScale`.

## Wire-format handling

- `MarshalJSON` wraps in the documented per-type envelope: `{"wmsStore":{...}}` / `{"wmsLayer":{...}}` / `{"wmtsStore":{...}}` / `{"wmtsLayer":{...}}`.
- `UnmarshalJSON` accepts both wrapped and flat shapes.
- List endpoints handle the empty-collection wire shape (`{"wmsStores":""}` etc.) as a nil slice.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/wms... ./rest/wmts...` — unit tests pass for all four packages.
- [x] `golangci-lint run ./rest/wms... ./rest/wmts...` — 0 issues (`gosec` G117 suppressed for the documented Password/AuthKey config fields).
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/wms... ./rest/wmts...` — empty-list and 404 paths verified against the live stack. Full CRUD requires an upstream WMS/WMTS to cascade FROM and isn't exercised in the dev/test stack — unit tests cover the wire-shape round-trip.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.