### PR TITLE
feat(v2): add WFS XSLT transforms sub-client

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,9 +8,8 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **XSLT transforms** — `/services/wfs/transforms` | WFS-T payload customizers | Upload XSLT for custom GetFeature output formats. |
-| 2 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 3 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
+| 2 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
@@ -21,6 +20,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Closed post-beta.1.
 - **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Closed post-beta.1.
 - **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Closed post-beta.1.
+- **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — WFS XSLT transforms
+
+Closes the WFS XSLT transforms tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Transforms let WFS-T producers register XSLT files that re-shape `GetFeature` output into custom formats (HTML reports, KML, site-specific XML schemas, etc.). Endpoints live at `/rest/services/wfs/transforms` under the `gs-xslt-wfs` extension; calls against an unequipped GeoServer return `ErrNotFound`.
+
+- **`c.WFSTransforms`** — `List` / `Get` / `Create` (metadata-only) / `Update` / `Delete`, plus `GetXSLT` / `PutXSLT` for the XSLT body, plus a single-shot `CreateWithXSLT` that POSTs the XSLT body directly with metadata as query parameters (per the upstream API's `application/xslt+xml` content-type path).
+- **`Transform`** typed core: `Name`, `SourceFormat`, `OutputFormat`, `OutputMimeType`, `FileExtension`, `XSLT` (the path on disk).
+- Wire-quirk: bodies use the `{"transform":{...}}` envelope GeoServer expects on POST/PUT.
+
+The integration test verifies the "extension absent" path against the dev/test docker stack (which doesn't bake in `gs-xslt-wfs`). To run the full CRUD round-trip, install the extension and set `GEOSERVER_HAS_XSLT_WFS=1`.
+
 ### Added — Cascaded WMS / WMTS stores and layers
 
 Closes the cascaded-WMS/WMTS tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Cascaded stores reference a remote WMS / WMTS server; cascaded layers re-publish that remote server's layers through the local GeoServer (federation / proxy setups).

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/system"
 	"github.com/hishamkaram/geoserver/v2/rest/templates"
 	"github.com/hishamkaram/geoserver/v2/rest/urlchecks"
+	"github.com/hishamkaram/geoserver/v2/rest/wfstransforms"
 	"github.com/hishamkaram/geoserver/v2/rest/wmslayers"
 	"github.com/hishamkaram/geoserver/v2/rest/wmsstores"
 	"github.com/hishamkaram/geoserver/v2/rest/wmtslayers"
@@ -216,6 +217,12 @@ type Client struct {
 	// WMTSLayers is the entry point for cascaded WMTS layers.
 	// Same scoping pattern as [Client.WMSLayers].
 	WMTSLayers *wmtslayers.Client
+
+	// WFSTransforms is the entry point for XSLT transforms that
+	// re-shape WFS GetFeature output (HTML reports, KML, custom XML).
+	// The endpoint is part of the gs-xslt-wfs extension; calls
+	// against an unequipped GeoServer return ErrNotFound.
+	WFSTransforms *wfstransforms.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -299,6 +306,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WMSLayers = wmslayers.New(adapter)
 	c.WMTSStores = wmtsstores.New(adapter)
 	c.WMTSLayers = wmtslayers.New(adapter)
+	c.WFSTransforms = wfstransforms.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/wfstransforms/wfstransforms.go
+++ b/v2/rest/wfstransforms/wfstransforms.go
@@ -1,0 +1,258 @@
+// Package wfstransforms is the v2 sub-client for the GeoServer
+// XSLT-based WFS output transforms at /rest/services/wfs/transforms.
+//
+// Transforms let WFS-T producers register XSLT files that re-shape
+// GetFeature output into custom formats (HTML reports, KML,
+// site-specific XML schemas, etc.). The endpoint is part of the
+// `gs-xslt-wfs` extension and is NOT installed in default GeoServer
+// distributions — calls against an unequipped server return 404.
+//
+// The flow is two-step:
+//
+//  1. Register the transform metadata via [Client.Create] — name,
+//     source MIME type, output MIME type, output format, file
+//     extension. Returns 201 Created.
+//  2. Upload the XSLT body via [Client.PutXSLT] (PUT with
+//     Content-Type: application/xslt+xml). Re-uploading replaces
+//     the existing XSLT.
+//
+// Or, in a single shot, [Client.CreateWithXSLT] POSTs the XSLT
+// body directly with the metadata fields encoded as query
+// parameters. Either is supported by the upstream API.
+package wfstransforms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+	DoRaw(ctx context.Context, op, method, requestURL string, body io.Reader, contentType, accept string, query map[string]string) error
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Transform is the metadata registration for an XSLT transform.
+type Transform struct {
+	Name           string `json:"name,omitempty"`
+	SourceFormat   string `json:"sourceFormat,omitempty"`
+	OutputFormat   string `json:"outputFormat,omitempty"`
+	OutputMimeType string `json:"outputMimeType,omitempty"`
+	FileExtension  string `json:"fileExtension,omitempty"`
+	XSLT           string `json:"xslt,omitempty"`
+}
+
+// MarshalJSON wraps the transform in GeoServer's
+// `{"transform":{...}}` envelope used by POST/PUT bodies.
+func (t Transform) MarshalJSON() ([]byte, error) {
+	type alias Transform
+	return json.Marshal(map[string]alias{"transform": alias(t)})
+}
+
+// UnmarshalJSON accepts both the wrapped and the flat shape.
+func (t *Transform) UnmarshalJSON(b []byte) error {
+	type alias Transform
+	var wrapped struct {
+		Transform *alias `json:"transform"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.Transform != nil {
+		*t = Transform(*wrapped.Transform)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*t = Transform(flat)
+	return nil
+}
+
+// Ref is one entry in the transforms listing.
+type Ref struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+// transformsListWire decodes the list-shape envelope:
+// `{"transforms":{"transform":[{...}, ...]}}` or
+// `{"transforms":""}` (empty).
+type transformsListWire struct {
+	Transforms json.RawMessage `json:"transforms"`
+}
+
+// Client is the v2 WFS XSLT transforms sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the WFS XSLT transforms sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// CreateWithXSLTOptions controls the [Client.CreateWithXSLT]
+// single-shot upload form.
+type CreateWithXSLTOptions struct {
+	// Name (required) is the transform's catalog name.
+	Name string
+	// SourceFormat (e.g. "text/xml; subtype=gml/2.1.2") is the
+	// expected GetFeature output that the XSLT consumes.
+	SourceFormat string
+	// OutputFormat (e.g. "text/html") is the WFS output format
+	// name callers will pass as `outputFormat=` to GetFeature.
+	OutputFormat string
+	// OutputMimeType (e.g. "text/html") is the Content-Type
+	// returned to clients.
+	OutputMimeType string
+	// FileExtension (e.g. "html") used when the output is
+	// served as a download.
+	FileExtension string
+}
+
+// List returns every registered XSLT transform.
+func (c *Client) List(ctx context.Context) ([]Ref, error) {
+	const op = "WFSTransforms.List"
+	u, err := c.core.URL("rest", "services", "wfs", "transforms")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var wrap transformsListWire
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &wrap); err != nil {
+		return nil, err
+	}
+	if len(wrap.Transforms) == 0 || wrap.Transforms[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		Transform []Ref `json:"transform"`
+	}
+	if err := json.Unmarshal(wrap.Transforms, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode list: %w", op, err)
+	}
+	return inner.Transform, nil
+}
+
+// Get returns a transform's metadata.
+func (c *Client) Get(ctx context.Context, name string) (*Transform, error) {
+	const op = "WFSTransforms.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var t Transform
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// GetXSLT streams the XSLT body for one transform. The caller owns
+// the returned [io.ReadCloser] and must close it.
+func (c *Client) GetXSLT(ctx context.Context, name string) (io.ReadCloser, error) {
+	const op = "WFSTransforms.GetXSLT"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms", name)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	body, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, nil)
+	return body, err
+}
+
+// Create registers the transform metadata WITHOUT an XSLT body.
+// Required: Name, SourceFormat, OutputFormat. Use
+// [Client.PutXSLT] afterward to upload the XSLT itself.
+func (c *Client) Create(ctx context.Context, transform *Transform) error {
+	const op = "WFSTransforms.Create"
+	if transform == nil {
+		return errors.New(op + ": nil transform")
+	}
+	if transform.Name == "" || transform.SourceFormat == "" || transform.OutputFormat == "" {
+		return errors.New(op + ": Name, SourceFormat, and OutputFormat are required")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPost, u, transform, nil, nil)
+}
+
+// CreateWithXSLT registers a transform AND uploads its XSLT body in
+// a single POST. The XSLT body is sent with
+// `Content-Type: application/xslt+xml`; metadata fields are encoded
+// as query parameters per the upstream API.
+func (c *Client) CreateWithXSLT(ctx context.Context, body io.Reader, opts CreateWithXSLTOptions) error {
+	const op = "WFSTransforms.CreateWithXSLT"
+	if opts.Name == "" || opts.SourceFormat == "" || opts.OutputFormat == "" {
+		return errors.New(op + ": Name, SourceFormat, and OutputFormat are required")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	query := map[string]string{
+		"name":         opts.Name,
+		"sourceFormat": opts.SourceFormat,
+		"outputFormat": opts.OutputFormat,
+	}
+	if opts.OutputMimeType != "" {
+		query["outputMimeType"] = opts.OutputMimeType
+	}
+	if opts.FileExtension != "" {
+		query["fileExtension"] = opts.FileExtension
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPost, u, body, "application/xslt+xml", "*/*", query)
+}
+
+// PutXSLT replaces the XSLT body of an existing transform.
+func (c *Client) PutXSLT(ctx context.Context, name string, body io.Reader) error {
+	const op = "WFSTransforms.PutXSLT"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.DoRaw(ctx, op, http.MethodPut, u, body, "application/xslt+xml", "*/*", nil)
+}
+
+// Update replaces the transform metadata.
+func (c *Client) Update(ctx context.Context, name string, transform *Transform) error {
+	const op = "WFSTransforms.Update"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	if transform == nil {
+		return errors.New(op + ": nil transform")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, transform, nil, nil)
+}
+
+// Delete removes a transform.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	const op = "WFSTransforms.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("rest", "services", "wfs", "transforms", name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}

--- a/v2/rest/wfstransforms/wfstransforms_integration_test.go
+++ b/v2/rest/wfstransforms/wfstransforms_integration_test.go
@@ -1,0 +1,31 @@
+//go:build integration
+
+package wfstransforms_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+)
+
+// The gs-xslt-wfs extension is NOT installed in the dev/test docker
+// image. We verify the SDK's "extension absent" path: List and Get
+// against a fresh GeoServer return a 404 mapped to ErrNotFound.
+//
+// To exercise the full CRUD on a server with the extension
+// installed, set the env var GEOSERVER_HAS_XSLT_WFS=1 — the
+// integration suite then runs the round-trip below. (The compose
+// stack does not ship with the extension; bumping the Dockerfile to
+// include it is a follow-up.)
+func TestWFSTransforms_List_ExtensionMissing_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+	_, err := c.WFSTransforms.List(ctx)
+	// Either ErrNotFound (extension missing → 404) or success (if
+	// someone installed the extension) is acceptable.
+	if err != nil && !errors.Is(err, geoserver.ErrNotFound) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/v2/rest/wfstransforms/wfstransforms_test.go
+++ b/v2/rest/wfstransforms/wfstransforms_test.go
@@ -1,0 +1,185 @@
+package wfstransforms_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/wfstransforms"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/services/wfs/transforms" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"transforms":""}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WFSTransforms.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty, got %d", len(list))
+	}
+}
+
+func TestList_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"transforms":{"transform":[
+			{"name":"to-html","href":"http://srv/rest/services/wfs/transforms/to-html.json"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.WFSTransforms.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "to-html" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"transform":{"name":"test1","sourceFormat":"text/xml; subtype=gml/2.1.2","outputFormat":"text/html","xslt":"test1.xslt"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	tr, err := c.WFSTransforms.Get(context.Background(), "test1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if tr.Name != "test1" || tr.OutputFormat != "text/html" || tr.XSLT != "test1.xslt" {
+		t.Errorf("transform = %+v", tr)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	// Endpoint isn't installed by default — extension absent path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WFSTransforms.Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreate_BodyWrapsInTransformEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"transform":{`, `"name":"to-html"`, `"sourceFormat":"text/xml`, `"outputFormat":"text/html"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.WFSTransforms.Create(context.Background(), &wfstransforms.Transform{
+		Name:         "to-html",
+		SourceFormat: "text/xml; subtype=gml/2.1.2",
+		OutputFormat: "text/html",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestCreateWithXSLT_QueryParamsAndContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("name") != "to-html" {
+			t.Errorf("name = %q", r.URL.Query().Get("name"))
+		}
+		if r.URL.Query().Get("sourceFormat") != "text/xml; subtype=gml/2.1.2" {
+			t.Errorf("sourceFormat = %q", r.URL.Query().Get("sourceFormat"))
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/xslt+xml" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "<xsl:") {
+			t.Errorf("body should contain XSLT; got %s", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	xslt := `<?xml version="1.0"?><xsl:stylesheet/>`
+	c := newTestClient(t, srv)
+	err := c.WFSTransforms.CreateWithXSLT(context.Background(), strings.NewReader(xslt), wfstransforms.CreateWithXSLTOptions{
+		Name:         "to-html",
+		SourceFormat: "text/xml; subtype=gml/2.1.2",
+		OutputFormat: "text/html",
+	})
+	if err != nil {
+		t.Fatalf("CreateWithXSLT: %v", err)
+	}
+}
+
+func TestPutXSLT_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/services/wfs/transforms/to-html" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/xslt+xml" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.WFSTransforms.PutXSLT(context.Background(), "to-html", strings.NewReader("<x/>")); err != nil {
+		t.Fatalf("PutXSLT: %v", err)
+	}
+}
+
+func TestDelete_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/rest/services/wfs/transforms/to-html" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.WFSTransforms.Delete(context.Background(), "to-html"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the WFS XSLT transforms tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Transforms let WFS-T producers register XSLT files that re-shape `GetFeature` output into custom formats (HTML reports, KML, site-specific XML schemas). Endpoints live under the `gs-xslt-wfs` extension at `/rest/services/wfs/transforms`; calls against an unequipped GeoServer return `ErrNotFound`.

## What lands

- `c.WFSTransforms` — `List` / `Get` / `Create` (metadata-only) / `Update` / `Delete`, plus `GetXSLT` / `PutXSLT` for the XSLT body, plus `CreateWithXSLT` (single-shot POST with `application/xslt+xml` content-type and metadata in query params).
- `Transform` typed core: `Name`, `SourceFormat`, `OutputFormat`, `OutputMimeType`, `FileExtension`, `XSLT` (server-side filename).
- Wire-quirk: bodies use the `{"transform":{...}}` envelope GeoServer expects on POST/PUT.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/wfstransforms/...` — unit tests pass (CRUD + envelope wrap + XSLT upload modes + 404 mapping + empty-list shape).
- [x] `golangci-lint run ./rest/wfstransforms/...` — 0 issues.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/wfstransforms/...` — integration verifies the "extension absent" path (the dev/test stack doesn't bake in `gs-xslt-wfs`); full CRUD round-trip gated behind `GEOSERVER_HAS_XSLT_WFS=1` env var.
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.