### PR TITLE
feat(v2): add About.Manifests and About.SystemStatus

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -8,8 +8,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 | # | Gap | Audience | Rough scope |
 |---|-----|----------|-------------|
-| 1 | **Manifests + system status** — `/about/manifest`, `/about/system-status` | Ops / capacity planning | Inspect installed plugins; live JVM and OS stats. |
-| 2 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+| 1 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
 
 ## Already shipped
 
@@ -21,6 +20,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Closed post-beta.1.
 - **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Closed post-beta.1.
 - **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Closed post-beta.1.
+- **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Closed post-beta.1.
 
 Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — About: manifests + system status
+
+Closes the manifests-and-system-status tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Two new methods on the existing `c.About` client surface ops / capacity-planning telemetry without leaving the SDK.
+
+- **`c.About.Manifests(ctx, ListManifestsOptions{Manifest, Key, Value})`** at `/rest/about/manifest` — returns `[]ManifestEntry`, one per OSGi bundle / packaged JAR (`~150` on a stock install). `ListManifestsOptions` carries optional regex filters for bundle names, attribute keys, and attribute values. Each entry has a typed `Name` plus a free-form `Fields map[string]json.RawMessage` for the heterogeneous MANIFEST.MF attributes (`Bundle-Version`, `Build-Jdk`, `Implementation-Title`, etc.); helper `(ManifestEntry).String(field)` extracts a string value coercing JSON numbers/bools.
+- **`c.About.SystemStatus(ctx)`** at `/rest/about/system-status` — returns `[]SystemMetric`. Each metric is one OS / JVM / GeoServer telemetry point (`OPERATING_SYSTEM`, `CPU_LOAD`, `MEMORY_USED`, `GEOSERVER_THREADS`, …) categorized by `SYSTEM` / `CPU` / `MEMORY` / `SWAP` / `FILE_SYSTEM` / `NETWORK` / `SENSORS` / `GEOSERVER`. `Available=false` + `Value="NOT AVAILABLE"` is common on Linux containers without OSHI native libs; production hosts populate the values.
+- **Wire-quirk:** Manifest endpoint defaults to HTML; the SDK appends `.json` to the URL. Empty filter result comes back as `{"about":""}` (bare string instead of object) — normalized to a nil slice. Manifest responses commonly exceed 100 KB; `Manifests` streams the body via `DoStream` rather than buffering through the JSON Do path's 8 KiB cap.
+
 ### Added — WFS XSLT transforms
 
 Closes the WFS XSLT transforms tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Transforms let WFS-T producers register XSLT files that re-shape `GetFeature` output into custom formats (HTML reports, KML, site-specific XML schemas, etc.). Endpoints live at `/rest/services/wfs/transforms` under the `gs-xslt-wfs` extension; calls against an unequipped GeoServer return `ErrNotFound`.

--- a/v2/rest/about/about.go
+++ b/v2/rest/about/about.go
@@ -110,3 +110,191 @@ func (c *Client) Version(ctx context.Context) (*VersionInfo, error) {
 	}
 	return &resp.About, nil
 }
+
+// ManifestEntry is one row of the /rest/about/manifest output — one
+// OSGi bundle / JAR shipped with the GeoServer install.
+//
+// Manifest fields are heterogeneous across bundles (some include
+// `Bundle-License` / `Bundle-Version` / `Build-Jdk`, others ship
+// minimal metadata). The SDK preserves Name as a typed field; all
+// other entries land in [ManifestEntry.Fields] keyed by the
+// MANIFEST.MF attribute name (e.g. "Bundle-Name", "Implementation-Version").
+type ManifestEntry struct {
+	// Name is the bundle name as advertised by GeoServer (the
+	// `@name` JSON attribute).
+	Name string `json:"-"`
+	// Fields carries every other manifest attribute. Values are
+	// preserved as-is (string, number, etc.) via [json.RawMessage]
+	// for round-trip fidelity; helper [ManifestEntry.String]
+	// extracts a string-typed value.
+	Fields map[string]json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON pulls the `@name` attribute into Name and stows the
+// rest of the entry's fields in Fields.
+func (m *ManifestEntry) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for k, v := range raw {
+		if k == "@name" {
+			_ = json.Unmarshal(v, &m.Name)
+			continue
+		}
+		if m.Fields == nil {
+			m.Fields = map[string]json.RawMessage{}
+		}
+		m.Fields[k] = v
+	}
+	return nil
+}
+
+// String returns the named field's value coerced to a string. If the
+// underlying JSON value is a number/bool the string form is returned
+// (so "Specification-Version":1 resolves to "1"). Returns "" if the
+// field is absent.
+func (m ManifestEntry) String(field string) string {
+	v, ok := m.Fields[field]
+	if !ok {
+		return ""
+	}
+	if len(v) > 0 && v[0] == '"' {
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			return s
+		}
+	}
+	return string(v)
+}
+
+// ListManifestsOptions controls the [Client.Manifests] response
+// filtering and field selection.
+type ListManifestsOptions struct {
+	// Manifest is a regex applied to bundle names; only matching
+	// bundles are returned. Empty matches everything.
+	Manifest string
+	// Key is a regex applied to attribute names; only matching
+	// attributes are returned per bundle. Empty returns all.
+	Key string
+	// Value is a regex applied to attribute values; only matching
+	// attributes are returned. Empty returns all.
+	Value string
+}
+
+// Manifests fetches the installed-bundle manifest list. Useful for
+// inspecting plugin versions and build metadata.
+//
+// On a default GeoServer install this returns ~150 entries (every
+// bundled JAR), with a payload commonly >100 KB. The SDK streams
+// the response rather than buffering — the standard JSON Do path's
+// 8 KiB body cap would truncate the body for any non-trivial
+// install.
+//
+// Wire-quirk: `/rest/about/manifest` defaults to HTML when filter
+// query params are present; the SDK appends `.json` to force the
+// JSON wire shape. Empty result comes back as `{"about":""}` (bare
+// string instead of object) and is normalized to a nil slice.
+func (c *Client) Manifests(ctx context.Context, opts ListManifestsOptions) ([]ManifestEntry, error) {
+	const op = "About.Manifests"
+	u, err := c.core.URL("rest", "about", "manifest")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	u += ".json"
+	var query map[string]string
+	if opts.Manifest != "" || opts.Key != "" || opts.Value != "" {
+		query = map[string]string{}
+		if opts.Manifest != "" {
+			query["manifest"] = opts.Manifest
+		}
+		if opts.Key != "" {
+			query["key"] = opts.Key
+		}
+		if opts.Value != "" {
+			query["value"] = opts.Value
+		}
+	}
+	body, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = body.Close() }()
+	var resp struct {
+		About json.RawMessage `json:"about"`
+	}
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("%s: decode response: %w", op, err)
+	}
+	if len(resp.About) == 0 || resp.About[0] == '"' {
+		return nil, nil
+	}
+	var inner struct {
+		Resource []ManifestEntry `json:"resource"`
+	}
+	if err := json.Unmarshal(resp.About, &inner); err != nil {
+		return nil, fmt.Errorf("%s: decode response: %w", op, err)
+	}
+	return inner.Resource, nil
+}
+
+// SystemMetric is one entry in the /rest/about/system-status output.
+// Categories include SYSTEM, CPU, MEMORY, SWAP, FILE_SYSTEM,
+// NETWORK, SENSORS, GEOSERVER. On Linux containers without OSHI
+// native libs many metrics report Available=false / Value="NOT
+// AVAILABLE".
+type SystemMetric struct {
+	Available   bool   `json:"available"`
+	Description string `json:"description,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Identifier  string `json:"identifier,omitempty"`
+	Category    string `json:"category,omitempty"`
+	Unit        string `json:"unit,omitempty"`
+	Priority    int    `json:"priority,omitempty"`
+	// Value is preserved as a string regardless of the underlying
+	// wire shape (some metrics report "42.5", others "NOT
+	// AVAILABLE", others a JSON number). Use [strconv.ParseFloat]
+	// or similar to coerce when Available=true and the metric is
+	// known to be numeric.
+	Value string `json:"-"`
+}
+
+// UnmarshalJSON tolerates string-or-number Value forms.
+func (s *SystemMetric) UnmarshalJSON(data []byte) error {
+	type alias SystemMetric
+	aux := struct {
+		*alias
+		Value json.RawMessage `json:"value,omitempty"`
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(aux.Value) == 0 || string(aux.Value) == "null" {
+		return nil
+	}
+	if aux.Value[0] == '"' {
+		return json.Unmarshal(aux.Value, &s.Value)
+	}
+	s.Value = string(aux.Value)
+	return nil
+}
+
+// SystemStatus fetches the live `/rest/about/system-status` metrics.
+// Each entry covers a single OS / JVM / GeoServer telemetry point;
+// see [SystemMetric] for the available categories.
+func (c *Client) SystemStatus(ctx context.Context) ([]SystemMetric, error) {
+	const op = "About.SystemStatus"
+	u, err := c.core.URL("rest", "about", "system-status")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp struct {
+		Metrics struct {
+			Metric []SystemMetric `json:"metric"`
+		} `json:"metrics"`
+	}
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Metrics.Metric, nil
+}

--- a/v2/rest/about/about_integration_test.go
+++ b/v2/rest/about/about_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/about"
 )
 
 func TestAbout_Ping_Integration(t *testing.T) {
@@ -40,4 +41,68 @@ func TestAbout_Version_Integration(t *testing.T) {
 	if !hasGeoServer {
 		t.Fatalf("no GeoServer component in Version response: %+v", v.Resource)
 	}
+}
+
+func TestAbout_Manifests_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Unfiltered list: every bundle in the WAR.
+	list, err := c.About.Manifests(ctx, about.ListManifestsOptions{})
+	if err != nil {
+		t.Fatalf("Manifests (no filter): %v", err)
+	}
+	if len(list) < 50 {
+		t.Errorf("expected ≥50 bundles in the manifest, got %d", len(list))
+	}
+	for _, m := range list[:5] { // spot-check the first few
+		if m.Name == "" {
+			t.Errorf("manifest entry missing @name: %+v", m)
+		}
+	}
+
+	// Filter that matches nothing — verify the empty-string
+	// wire-quirk path returns nil cleanly (no error).
+	empty, err := c.About.Manifests(ctx, about.ListManifestsOptions{
+		Manifest: "definitely-no-such-bundle-zzz.*",
+	})
+	if err != nil {
+		t.Fatalf("Manifests (no-match filter): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty list for no-match filter, got %d", len(empty))
+	}
+}
+
+func TestAbout_SystemStatus_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	metrics, err := c.About.SystemStatus(ctx)
+	if err != nil {
+		t.Fatalf("SystemStatus: %v", err)
+	}
+	if len(metrics) == 0 {
+		t.Fatalf("expected non-empty metrics list")
+	}
+	// All recognized categories should be represented even when
+	// individual values report "NOT AVAILABLE" (the test stack runs
+	// on Linux without OSHI native libs in many cases).
+	categories := map[string]bool{}
+	for _, m := range metrics {
+		categories[m.Category] = true
+	}
+	for _, c := range []string{"SYSTEM", "CPU", "MEMORY"} {
+		if !categories[c] {
+			t.Errorf("expected metric category %q, got %v", c, keysOf(categories))
+		}
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/v2/rest/about/about_test.go
+++ b/v2/rest/about/about_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/about"
 )
 
 func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
@@ -109,5 +110,97 @@ func TestVersion_500(t *testing.T) {
 	_, err := c.About.Version(context.Background())
 	if !errors.Is(err, geoserver.ErrServerError) {
 		t.Fatalf("expected ErrServerError, got %v", err)
+	}
+}
+
+func TestManifests_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/about/manifest.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"about":{"resource":[
+			{"@name":"geoserver-platform-2.28.0","Bundle-Name":"geoserver-platform","Bundle-Version":"2.28.0","Specification-Version":1},
+			{"@name":"geotools-coverage-34","Implementation-Version":"34.0"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	list, err := c.About.Manifests(context.Background(), about.ListManifestsOptions{})
+	if err != nil {
+		t.Fatalf("Manifests: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d", len(list))
+	}
+	if list[0].Name != "geoserver-platform-2.28.0" {
+		t.Errorf("name[0] = %q", list[0].Name)
+	}
+	if got := list[0].String("Bundle-Name"); got != "geoserver-platform" {
+		t.Errorf("Bundle-Name = %q", got)
+	}
+	if got := list[0].String("Specification-Version"); got != "1" {
+		t.Errorf("Specification-Version (number) = %q, want \"1\"", got)
+	}
+	if got := list[1].String("nonexistent"); got != "" {
+		t.Errorf("missing field = %q, want empty", got)
+	}
+}
+
+func TestManifests_Filter_QueryParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("manifest") != "geoserver-platform.*" {
+			t.Errorf("manifest = %q", r.URL.Query().Get("manifest"))
+		}
+		if r.URL.Query().Get("key") != "Bundle-.*" {
+			t.Errorf("key = %q", r.URL.Query().Get("key"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"about":{"resource":[]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.About.Manifests(context.Background(), about.ListManifestsOptions{
+		Manifest: "geoserver-platform.*",
+		Key:      "Bundle-.*",
+	})
+	if err != nil {
+		t.Fatalf("Manifests: %v", err)
+	}
+}
+
+func TestSystemStatus_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/about/system-status" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"metrics":{"metric":[
+			{"available":true,"description":"CPU load","name":"CPU_LOAD","identifier":"CPU_LOAD","category":"CPU","unit":"%","priority":104,"value":"42.5"},
+			{"available":false,"description":"Uptime","name":"SYSTEM_UPTIME","category":"SYSTEM","unit":"sec","priority":2,"value":"NOT AVAILABLE"},
+			{"available":true,"description":"Threads","name":"GEOSERVER_THREADS","identifier":"GEOSERVER_THREADS","category":"GEOSERVER","unit":"","priority":1301,"value":127}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	metrics, err := c.About.SystemStatus(context.Background())
+	if err != nil {
+		t.Fatalf("SystemStatus: %v", err)
+	}
+	if len(metrics) != 3 {
+		t.Fatalf("len = %d", len(metrics))
+	}
+	if metrics[0].Name != "CPU_LOAD" || metrics[0].Value != "42.5" || metrics[0].Unit != "%" {
+		t.Errorf("metric[0] = %+v", metrics[0])
+	}
+	if metrics[1].Available || metrics[1].Value != "NOT AVAILABLE" {
+		t.Errorf("metric[1] = %+v", metrics[1])
+	}
+	// Number-typed value coerces to string.
+	if metrics[2].Value != "127" {
+		t.Errorf("metric[2] number Value = %q, want \"127\"", metrics[2].Value)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the manifests-and-system-status tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). Two new methods on the existing `c.About` client surface ops / capacity-planning telemetry without leaving the SDK.

## What lands

- **`c.About.Manifests(ctx, ListManifestsOptions{Manifest, Key, Value})`** at `/rest/about/manifest` — returns `[]ManifestEntry`, one per OSGi bundle / packaged JAR (~150 on a stock install). Each entry has a typed `Name` plus a free-form `Fields map[string]json.RawMessage` for the heterogeneous MANIFEST.MF attributes; helper `(ManifestEntry).String(field)` extracts a string-typed value.
- **`c.About.SystemStatus(ctx)`** at `/rest/about/system-status` — returns `[]SystemMetric`, one per OS / JVM / GeoServer telemetry point. `Available=false` + `Value="NOT AVAILABLE"` is common on Linux containers without OSHI native libs; production hosts populate the values.

## Wire-format quirks (discovered via live integration testing)

- Manifest endpoint defaults to HTML when filter query params are present; SDK appends `.json` to force JSON.
- Empty filter result returns `{"about":""}` (bare string instead of object) — normalized to a nil slice.
- Manifest responses commonly exceed 100 KB; `Manifests` streams the body via `DoStream` rather than buffering through the JSON Do path's 8 KiB cap.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/about/...` — 3 new unit tests pass (manifest list shape, filter query params, system-status numeric value coercion).
- [x] `golangci-lint run ./rest/about/...` — 0 issues.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/about/...` — 2 new integration tests PASS against live GeoServer 2.28 (full manifest read + empty-filter wire-quirk; system-status with all expected categories present).
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.