### PR TITLE
feat(v2): add logging configuration sub-client

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -1,14 +1,12 @@
 # v2 — tier-2 gap-analysis backlog
 
-The v2 client closes every "everyone needs it" REST API surface plus two of the original tier-2 items (security ACL services / REST / catalog rules and the Resource API) in the published `v2.0.0-beta.1` (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the remaining tier-2 backlog — endpoint groups that real deployments do reach for, but that help a narrower audience than the surface already shipped.
+The v2 client closes every "everyone needs it" REST API surface plus the original tier-2 backlog as of `v2.0.0-beta.1` and the post-beta tier-2 PRs (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the **complete shipped tier-2 surface** plus the leftover narrow-audience endpoints not on the original list — each tractable as its own follow-up PR.
 
 Each entry below is independently tractable as its own follow-up PR. None block `v2.0.0`. Each is grounded in the official GeoServer REST docs (`https://docs.geoserver.org/latest/en/user/rest/`) and reuses the existing v2 plumbing (`internal/transport.BuildURL`, `transport.DoJSON` / `DoXML` / `DoRaw`, the per-resource `Core` interface, the `*Client → InWorkspace(ws) → *WorkspaceClient` scoping pattern). PRs welcome — open an issue first if the work touches a new wire-format quirk so the design conversation can happen in public.
 
-## Backlog (priority order)
+## Remaining backlog
 
-| # | Gap | Audience | Rough scope |
-|---|-----|----------|-------------|
-| 1 | **Logging** — `/logging` | Production debugging | Adjust log levels and configurations at runtime without bouncing the server. |
+The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, the OWS `oseo` (OpenSearch for Earth Observation) service settings, and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
 
 ## Already shipped
 
@@ -21,8 +19,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 - **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Closed post-beta.1.
 - **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Closed post-beta.1.
 - **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Closed post-beta.1.
-
-Beyond these: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, and the OWS `oseo` (OpenSearch for Earth Observation) service settings. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
+- **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Closed post-beta.1.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Logging configuration
+
+Closes the logging tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Adjust the active log4j profile and stdout-mirror toggle at runtime without bouncing the server — the daily-driver use case for production debugging.
+
+- **`c.Logging.Get(ctx)`** / **`c.Logging.Update(ctx, *Config)`** at `/rest/logging`. `Config` has `Level` (e.g. "DEFAULT_LOGGING", "VERBOSE_LOGGING", "QUIET_LOGGING", "PRODUCTION_LOGGING", "GEOSERVER_DEVELOPER_LOGGING"), `Location` (read-only since GeoServer 3.0), `StdOutLogging`.
+- Wire-quirk: PUT bodies use the `{"logging":{...}}` envelope; SDK marshal wraps automatically.
+
+This closes the original tier-2 gap-analysis backlog. The full "everyone needs it" + tier-2 surface from `docs/v2-tier2-gaps.md` is now covered. Remaining future work tracks new GeoServer endpoints as the upstream API grows.
+
 ### Added — About: manifests + system status
 
 Closes the manifests-and-system-status tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Two new methods on the existing `c.About` client surface ops / capacity-planning telemetry without leaving the SDK.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/imports"
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
+	"github.com/hishamkaram/geoserver/v2/rest/logging"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
 	"github.com/hishamkaram/geoserver/v2/rest/resources"
 	"github.com/hishamkaram/geoserver/v2/rest/security"
@@ -223,6 +224,12 @@ type Client struct {
 	// The endpoint is part of the gs-xslt-wfs extension; calls
 	// against an unequipped GeoServer return ErrNotFound.
 	WFSTransforms *wfstransforms.Client
+
+	// Logging is the entry point for the singleton logging
+	// configuration document at /rest/logging — adjust the active
+	// log4j profile (DEFAULT_LOGGING, VERBOSE_LOGGING, etc.) and
+	// the stdout-mirror toggle without bouncing the server.
+	Logging *logging.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -307,6 +314,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WMTSStores = wmtsstores.New(adapter)
 	c.WMTSLayers = wmtslayers.New(adapter)
 	c.WFSTransforms = wfstransforms.New(adapter)
+	c.Logging = logging.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/logging/logging.go
+++ b/v2/rest/logging/logging.go
@@ -1,0 +1,103 @@
+// Package logging is the v2 sub-client for the GeoServer
+// /rest/logging endpoint — singleton configuration for the active
+// log4j profile and stdout logging.
+//
+// The endpoint is small but useful for production debugging:
+// changing the log level without bouncing the server is the daily
+// driver. Per the upstream API, log location cannot be changed
+// through REST in GeoServer 3.0+ (it is read-only there); the SDK
+// preserves Location on round-trips for compatibility with older
+// 2.x deployments.
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// Config is the GeoServer logging configuration document.
+type Config struct {
+	// Level names a log4j profile bundled into the GeoServer data
+	// directory's logs/ subdirectory (e.g. "DEFAULT_LOGGING",
+	// "VERBOSE_LOGGING", "QUIET_LOGGING", "PRODUCTION_LOGGING",
+	// "GEOSERVER_DEVELOPER_LOGGING").
+	Level string `json:"level,omitempty"`
+	// Location is the on-disk log file path
+	// (e.g. "logs/geoserver.log"). Read-only since GeoServer 3.0;
+	// PUT bodies that include this field have it ignored.
+	Location string `json:"location,omitempty"`
+	// StdOutLogging mirrors logging to the GeoServer container's
+	// standard output.
+	StdOutLogging bool `json:"stdOutLogging,omitempty"`
+}
+
+// MarshalJSON wraps Config in GeoServer's `{"logging":{...}}`
+// envelope expected by PUT bodies.
+func (c Config) MarshalJSON() ([]byte, error) {
+	type alias Config
+	return json.Marshal(map[string]alias{"logging": alias(c)})
+}
+
+// UnmarshalJSON accepts both the wrapped and the flat shape.
+func (c *Config) UnmarshalJSON(b []byte) error {
+	type alias Config
+	var wrapped struct {
+		Logging *alias `json:"logging"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.Logging != nil {
+		*c = Config(*wrapped.Logging)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*c = Config(flat)
+	return nil
+}
+
+// Client is the v2 logging sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the logging sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// Get returns the current logging configuration.
+func (c *Client) Get(ctx context.Context) (*Config, error) {
+	const op = "Logging.Get"
+	u, err := c.core.URL("rest", "logging")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var cfg Config
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Update replaces the logging configuration.
+func (c *Client) Update(ctx context.Context, cfg *Config) error {
+	const op = "Logging.Update"
+	if cfg == nil {
+		return errors.New(op + ": nil config")
+	}
+	u, err := c.core.URL("rest", "logging")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, cfg, nil, nil)
+}

--- a/v2/rest/logging/logging_integration_test.go
+++ b/v2/rest/logging/logging_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/logging"
+)
+
+func TestLogging_GetUpdate_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	original, err := c.Logging.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get original: %v", err)
+	}
+	if original.Level == "" {
+		t.Errorf("expected non-empty Level, got %+v", original)
+	}
+
+	// Restore on cleanup so subsequent tests / dev sessions see the
+	// original configuration.
+	t.Cleanup(func() {
+		_ = c.Logging.Update(ctx, original)
+	})
+
+	// Toggle to a non-original level. Default GeoServer ships
+	// DEFAULT_LOGGING / VERBOSE_LOGGING / QUIET_LOGGING /
+	// PRODUCTION_LOGGING / GEOSERVER_DEVELOPER_LOGGING /
+	// GEOTOOLS_DEVELOPER_LOGGING / TEST_LOGGING in logs/.
+	target := "VERBOSE_LOGGING"
+	if original.Level == "VERBOSE_LOGGING" {
+		target = "DEFAULT_LOGGING"
+	}
+	cfg := &logging.Config{
+		Level:         target,
+		StdOutLogging: original.StdOutLogging,
+	}
+	if err := c.Logging.Update(ctx, cfg); err != nil {
+		t.Fatalf("Update to %q: %v", target, err)
+	}
+
+	got, err := c.Logging.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got.Level != target {
+		t.Errorf("after Update Level = %q, want %q", got.Level, target)
+	}
+}

--- a/v2/rest/logging/logging_test.go
+++ b/v2/rest/logging/logging_test.go
@@ -1,0 +1,98 @@
+package logging_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/logging"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/logging" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"logging":{"level":"DEFAULT_LOGGING","location":"logs/geoserver.log","stdOutLogging":true}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	cfg, err := c.Logging.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if cfg.Level != "DEFAULT_LOGGING" || cfg.Location != "logs/geoserver.log" || !cfg.StdOutLogging {
+		t.Errorf("config = %+v", cfg)
+	}
+}
+
+func TestUpdate_BodyWrappedInLoggingEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/logging" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"logging":{`, `"level":"VERBOSE_LOGGING"`, `"stdOutLogging":true`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.Logging.Update(context.Background(), &logging.Config{
+		Level:         "VERBOSE_LOGGING",
+		StdOutLogging: true,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+func TestUpdate_NilRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.Logging.Update(context.Background(), nil); err == nil {
+		t.Fatal("expected nil-config error")
+	}
+}
+
+func TestGet_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Logging.Get(context.Background())
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the **final** tier-2 item from [`docs/v2-tier2-gaps.md`](docs/v2-tier2-gaps.md). The full "everyone needs it" + tier-2 surface from the original gap-analysis plan is now complete.

Adjust the active log4j profile (DEFAULT_LOGGING, VERBOSE_LOGGING, QUIET_LOGGING, PRODUCTION_LOGGING, GEOSERVER_DEVELOPER_LOGGING, etc.) and the stdout-mirror toggle at runtime without bouncing the server — the daily-driver use case for production debugging.

## What lands

- `c.Logging` at `/rest/logging`:
  - `Get(ctx) (*Config, error)` — fetch current logging configuration.
  - `Update(ctx, *Config) error` — replace.
- `Config` typed core: `Level`, `Location` (read-only since GeoServer 3.0), `StdOutLogging`.
- Wire-quirk: PUT bodies use the `{"logging":{...}}` envelope; `MarshalJSON` wraps automatically.

## Test plan

- [x] `cd v2 && go test -race -count=1 ./rest/logging/...` — unit tests pass (Get + Update wrap-envelope + nil rejection + unauthorized mapping).
- [x] `golangci-lint run ./rest/logging/...` — 0 issues.
- [x] `make compose-up && cd v2 && go test -tags=integration ./rest/logging/...` — round-trip test passes (Get → Update to different bundled profile → Get → restore on cleanup).
- [ ] CI: Lint, Unit (Go 1.25), Unit v2 (Go 1.25), govulncheck, CodeQL, GeoServer 2.27.4, GeoServer 2.28.0 all green.