### PR TITLE
chore(v2): graduate to v2.0.0-beta.2; close tier-2 backlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ coverage.html
 # .claude/skills, .claude/commands; only the local settings file is ignored)
 .claude/settings.local.json
 .claude/.cache/
+.claude/scheduled_tasks.lock

--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -1,6 +1,6 @@
 # v2 — tier-2 gap-analysis backlog
 
-The v2 client closes every "everyone needs it" REST API surface plus the original tier-2 backlog as of `v2.0.0-beta.1` and the post-beta tier-2 PRs (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the **complete shipped tier-2 surface** plus the leftover narrow-audience endpoints not on the original list — each tractable as its own follow-up PR.
+The v2 client closes every "everyone needs it" REST API surface plus the original tier-2 backlog as of `v2.0.0-beta.2` (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the **complete shipped tier-2 surface** plus the leftover narrow-audience endpoints not on the original list — each tractable as its own follow-up PR.
 
 Each entry below is independently tractable as its own follow-up PR. None block `v2.0.0`. Each is grounded in the official GeoServer REST docs (`https://docs.geoserver.org/latest/en/user/rest/`) and reuses the existing v2 plumbing (`internal/transport.BuildURL`, `transport.DoJSON` / `DoXML` / `DoRaw`, the per-resource `Core` interface, the `*Client → InWorkspace(ws) → *WorkspaceClient` scoping pattern). PRs welcome — open an issue first if the work touches a new wire-format quirk so the design conversation can happen in public.
 
@@ -10,16 +10,16 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 
 ## Already shipped
 
-- **ACL services / REST / catalog rules** — `c.ACL.Services()` / `c.ACL.REST()` / `c.ACL.Catalog()`. Closed in beta.1.
-- **Resource API** — `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}`. Closed in beta.1.
-- **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Closed post-beta.1.
-- **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Closed post-beta.1.
-- **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Closed post-beta.1.
-- **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Closed post-beta.1.
-- **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Closed post-beta.1.
-- **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Closed post-beta.1.
-- **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Closed post-beta.1.
-- **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Closed post-beta.1.
+- **ACL services / REST / catalog rules** — `c.ACL.Services()` / `c.ACL.REST()` / `c.ACL.Catalog()`. Shipped in beta.1.
+- **Resource API** — `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}`. Shipped in beta.1.
+- **Mosaic / structured-coverage granules** — `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` Schema / List / Get / Delete / DeleteByFilter. Shipped in beta.2.
+- **Templates (FTL)** — `c.Templates` (global) plus six fluent scopes (`InWorkspace`/`InDatastore`/`InFeatureType`/`InCoverageStore`/`InCoverage`); List / Get / Put / PutString / Delete. Shipped in beta.2.
+- **Auth providers + filter chains** — `c.Security.AuthProviders` / `c.Security.AuthFilters` / `c.Security.FilterChains` (each List / Get / Create / Update / Delete; AuthProviders + FilterChains also have SetOrder). Shipped in beta.2.
+- **URL checks** — `c.URLChecks` List / Get / Create / Update / Delete against `/rest/urlchecks`. Shipped in beta.2.
+- **Cascaded WMS / WMTS stores + layers** — `c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers` (workspace-scoped stores; 2-level scoped layers via `InWorkspace(ws).InStore(s)`). Shipped in beta.2.
+- **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Shipped in beta.2.
+- **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Shipped in beta.2.
+- **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Shipped in beta.2.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.0.0-beta.2] — 2026-05-04
+
+Second beta. **Closes the original tier-2 gap-analysis backlog from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md)** — eight new sub-clients land on top of beta.1's frozen surface: mosaic granules, FTL templates, auth providers / filters / chains, URL checks, cascaded WMS / WMTS stores + layers, WFS XSLT transforms, manifests + system status, and runtime logging. No breaking changes from `beta.1`; existing callers can `go get @v2.0.0-beta.2` and recompile. Public API stays frozen for review through the beta line — breaking changes will not land without a strong reason.
+
 ### Added — Logging configuration
 
 Closes the logging tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Adjust the active log4j profile and stdout-mirror toggle at runtime without bouncing the server — the daily-driver use case for production debugging.

--- a/v2/README.md
+++ b/v2/README.md
@@ -6,19 +6,21 @@
 [![License: MIT](https://img.shields.io/github/license/hishamkaram/geoserver.svg)](../LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/hishamkaram/geoserver?include_prereleases&sort=semver)](https://github.com/hishamkaram/geoserver/releases)
 
-> 🧪 **`v2.0.0-beta.1` is published — public API now frozen for review.** v2 closes the gap-analysis plan's "everyone needs it" surface plus the security and Resource-API tier-2 items. Coverage at `master`:
+> 🧪 **`v2.0.0-beta.2` is published — public API frozen for review; the original tier-2 backlog is closed.** v2 covers the gap-analysis plan's "everyone needs it" surface plus every tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Coverage at `master`:
 >
 > - **Catalog**: workspaces, datastores, feature types, coverage stores, coverages, layers (incl. add-style sub-resource), layer groups, styles, namespaces.
 > - **Settings**: global `c.Settings` + per-service `c.Services.WMS()`/`WFS()`/`WCS()`/`WMTS()` (global + per-workspace overrides).
-> - **System**: `c.System.Reload` and `ResetCache`. **About**: ping + version.
-> - **Security**: users, groups, roles, role-user assignment + ACL `Layers()`/`Services()`/`REST()`/`Catalog()`.
-> - **Resources**: `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}` — read or write any file in the data dir.
+> - **System**: `c.System.Reload` and `ResetCache`. **About**: ping, version, manifests, system status. **Logging**: `c.Logging.Get`/`Update` for runtime log-level changes.
+> - **Security**: users, groups, roles, role-user assignment + ACL `Layers()`/`Services()`/`REST()`/`Catalog()` + auth providers / filters / filter chains + URL checks (SSRF allow-list).
+> - **Resources**: `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}` — read or write any file in the data dir. **Templates (FTL)**: `c.Templates` global + six fluent scopes.
 > - **File-upload publishing**: `c.Datastores.UploadFile` (Shapefile / GeoPackage / external) and `c.CoverageStores.UploadFile` + `HarvestGranule` (GeoTIFF / ImageMosaic / mosaic granules).
+> - **Mosaic granules**: `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` — Schema / List / Get / Delete / DeleteByFilter for image-mosaic / structured coverages.
+> - **Cascaded stores + layers**: `c.WMSStores` / `c.WMSLayers` / `c.WMTSStores` / `c.WMTSLayers` for federation / proxy setups.
 > - **GeoWebCache**: `c.GWC.Layers()` (cache config), `Seed()` (seed/reseed/truncate), `DiskQuota()`.
 > - **Importer extension**: `c.Imports` (sessions + tasks). The dev/test docker image bakes the plugin in for CI integration coverage.
-> - **OWS**: `c.WMS` / `c.WFS` / `c.WCS` GetCapabilities; WFS `DescribeFeatureType`; WCS `DescribeCoverage`.
+> - **OWS**: `c.WMS` / `c.WFS` / `c.WCS` GetCapabilities; WFS `DescribeFeatureType`; WCS `DescribeCoverage`. **WFS XSLT transforms**: `c.WFSTransforms` (requires the `gs-xslt-wfs` extension).
 >
-> Surface is locked — breaking changes will not land in subsequent betas without a strong reason. v1.x remains the recommended import for production code. The remaining tier-2 endpoints tracked in [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md) can be added in subsequent betas without breaking shape.
+> Surface is locked — breaking changes will not land in subsequent betas without a strong reason. v1.x remains the recommended import for production code. Longer-tail endpoints (CRS list, fonts, monitoring, master password, OSEO settings, etc. — see [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md)) can be added without breaking shape.
 
 This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).
 
@@ -35,7 +37,7 @@ This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independent
 ## Install
 
 ```bash
-go get github.com/hishamkaram/geoserver/v2@v2.0.0-beta.1
+go get github.com/hishamkaram/geoserver/v2@v2.0.0-beta.2
 ```
 
 ```go
@@ -205,12 +207,20 @@ Run any with `go run ./v2/examples/<name>` against a `make compose-up` stack, or
 | WMS GetCapabilities | full | **ported** (`c.WMS.GetCapabilities` + `InWorkspace`) |
 | WFS GetCapabilities + DescribeFeatureType | (none — WMS only) | **new** in v2 (`c.WFS.GetCapabilities`, `DescribeFeatureType`) |
 | WCS GetCapabilities + DescribeCoverage | (none — WMS only) | **new** in v2 (`c.WCS.GetCapabilities`, `DescribeCoverage`) |
+| Mosaic / structured-coverage granules | (none) | **new** in v2 (`c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` — Schema / List / Get / Delete / DeleteByFilter) |
+| FTL templates | (none) | **new** in v2 (`c.Templates` + six fluent scopes; List / Get / Put / Delete) |
+| Auth providers / filters / chains | (none) | **new** in v2 (`c.Security.AuthProviders`, `AuthFilters`, `FilterChains`) |
+| URL checks (SSRF allow-list) | (none) | **new** in v2 (`c.URLChecks`) |
+| Cascaded WMS / WMTS stores + layers | (none) | **new** in v2 (`c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers`) |
+| WFS XSLT transforms | (none) | **new** in v2 (`c.WFSTransforms`; requires the `gs-xslt-wfs` extension on the server) |
+| About — manifests + system status | (none) | **new** in v2 (`c.About.Manifests`, `c.About.SystemStatus`) |
+| Logging (runtime log-level config) | (none) | **new** in v2 (`c.Logging.Get` / `Update`) |
 
-See [`../ROADMAP.md`](../ROADMAP.md) for the milestone checklist and [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md) for the tier-2 gap-analysis backlog (mosaic granules, Resource API, FTL templates, auth providers, ACL services/REST/catalog, URL checks, cascaded WMS/WMTS, XSLT transforms, manifests, runtime logging) — each tractable as its own follow-up PR.
+See [`../ROADMAP.md`](../ROADMAP.md) for the milestone checklist. The original tier-2 gap-analysis backlog is closed; remaining longer-tail endpoints (CRS list, fonts, monitoring, master password, OSEO settings, individual filter-chain editing) are tracked in [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md) — each tractable as its own follow-up PR.
 
 ## Contributing to v2
 
-The "everyone needs it" surface is closed; remaining work is the tier-2 list above plus wire-quirk fixes when adopters report them.
+The "everyone needs it" surface and the tier-2 backlog are both closed; remaining work is the longer-tail list above plus wire-quirk fixes when adopters report them.
 
 To add a new sub-client:
 

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -14,11 +14,11 @@
 // extension (batch ingest), and the OWS read-only trio
 // (GetCapabilities + DescribeFeatureType + DescribeCoverage).
 //
-// Public API may still refine before v2.0.0 based on early-adopter
-// feedback. The latest published preview tag is one of the
-// v2.0.0-alpha.* line — see the v2 README for the current pin.
-// Until v2 reaches v2.0.0, the v1 line remains the recommended
-// import for production:
+// Public API is frozen for review through the v2.0.0-beta.* line —
+// breaking changes will not land without a strong reason. The latest
+// published preview tag is on the v2.0.0-beta.* line; see the v2 README
+// for the current pin. Until v2 reaches v2.0.0, the v1 line remains
+// the recommended import for production:
 //
 //	import "github.com/hishamkaram/geoserver"        // v1: stable, full surface
 //	import "github.com/hishamkaram/geoserver/v2"     // v2: preview


### PR DESCRIPTION
## Summary

- Closes the original tier-2 gap-analysis backlog from `docs/v2-tier2-gaps.md` — eight new sub-clients shipped on top of beta.1's frozen surface (mosaic granules, FTL templates, auth providers/filters/chains, URL checks, cascaded WMS/WMTS stores + layers, WFS XSLT transforms, manifests + system status, runtime logging).
- No breaking changes from beta.1. Public API stays frozen for review through the beta line.
- Doc-only changes — no code touched. Bumps install pin from `v2.0.0-beta.1` → `v2.0.0-beta.2`, graduates `[Unreleased]` → `[2.0.0-beta.2]` dated 2026-05-04, refreshes the v2 README banner + resource-status table for the eight new sub-clients, and updates the version-line wording in `v2/doc.go`.
- `.gitignore`: also adds `.claude/scheduled_tasks.lock` (per-machine runtime state — caught a near-miss in this PR).

## Test plan

- [x] `make lint` — 0 issues.
- [x] `cd v2 && go test ./...` — all packages pass (unit tests).
- [x] CI matrix on this PR: lint + Go vet + v1 unit + v2 unit + integration on GeoServer 2.27.4 LTS + 2.28.0 stable + CodeQL + govulncheck.
- [x] Squash-merge once CI is green; tag `v2.0.0-beta.2` against the resulting master commit.