### PR TITLE
feat(v2): add Fonts list sub-client (c.Fonts)

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -6,7 +6,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 ## Remaining backlog
 
-The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: CRS list, fonts list, monitoring, master password, self-admin password, usergroup-service registration, individual filter-chain editing, the OWS `oseo` (OpenSearch for Earth Observation) service settings, and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first.
+The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: monitoring (requires the `gs-monitor` extension), master password, self-admin password, the OWS `oseo` (OpenSearch for Earth Observation) service settings (requires `gs-oseo`), and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first. Items that turned out to have no public REST surface on stock GeoServer (CRS list, usergroup-service registration) are dropped from the backlog.
 
 ## Already shipped
 
@@ -20,6 +20,7 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 - **WFS XSLT transforms** — `c.WFSTransforms` List / Get / Create / Update / Delete + GetXSLT / PutXSLT / CreateWithXSLT against `/rest/services/wfs/transforms`. Requires the `gs-xslt-wfs` extension on the server. Shipped in beta.2.
 - **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Shipped in beta.2.
 - **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Shipped in beta.2.
+- **Fonts list** — `c.Fonts.List` against `/rest/fonts`. Shipped post-beta.2.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added — Fonts list
+
+Closes the fonts longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Sanity-check before publishing styles that reference specific fonts — typos would otherwise surface as silent label-rendering fallbacks.
+
+- **`c.Fonts.List(ctx)`** at `/rest/fonts` — returns the list of font families the JVM exposes to GeoServer's SLD labelling pipeline as `[]string`. The result reflects whatever is on the server's classpath at call time (system fonts plus anything dropped into the data directory's `styles/` subdirectory).
+
 ## [2.0.0-beta.2] — 2026-05-04
 
 Second beta. **Closes the original tier-2 gap-analysis backlog from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md)** — eight new sub-clients land on top of beta.1's frozen surface: mosaic granules, FTL templates, auth providers / filters / chains, URL checks, cascaded WMS / WMTS stores + layers, WFS XSLT transforms, manifests + system status, and runtime logging. No breaking changes from `beta.1`; existing callers can `go get @v2.0.0-beta.2` and recompile. Public API stays frozen for review through the beta line — breaking changes will not land without a strong reason.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/coveragestores"
 	"github.com/hishamkaram/geoserver/v2/rest/datastores"
 	"github.com/hishamkaram/geoserver/v2/rest/featuretypes"
+	"github.com/hishamkaram/geoserver/v2/rest/fonts"
 	"github.com/hishamkaram/geoserver/v2/rest/gwc"
 	"github.com/hishamkaram/geoserver/v2/rest/imports"
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
@@ -230,6 +231,13 @@ type Client struct {
 	// log4j profile (DEFAULT_LOGGING, VERBOSE_LOGGING, etc.) and
 	// the stdout-mirror toggle without bouncing the server.
 	Logging *logging.Client
+
+	// Fonts is the entry point for the read-only /rest/fonts
+	// endpoint — list of font families the JVM exposes to GeoServer's
+	// SLD labelling pipeline. Sanity-check before publishing styles
+	// that reference specific fonts; typos would otherwise surface as
+	// silent label-rendering fallbacks.
+	Fonts *fonts.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -315,6 +323,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WMTSLayers = wmtslayers.New(adapter)
 	c.WFSTransforms = wfstransforms.New(adapter)
 	c.Logging = logging.New(adapter)
+	c.Fonts = fonts.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/fonts/fonts.go
+++ b/v2/rest/fonts/fonts.go
@@ -1,0 +1,53 @@
+// Package fonts is the v2 sub-client for the GeoServer
+// /rest/fonts endpoint. It returns the list of font families the
+// JVM exposes to GeoServer's labelling pipeline (SLD TextSymbolizer,
+// WMS GetMap labelling). Useful as a sanity check before publishing
+// styles that reference specific fonts — typos surface as silent
+// label-rendering fallbacks rather than errors otherwise.
+package fonts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	Do(ctx context.Context, op string, method, requestURL string, body any, query map[string]string, out any) error
+}
+
+// Client is the v2 fonts sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the fonts sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// fontsResponse matches the GeoServer wire shape `{"fonts":[...]}`.
+type fontsResponse struct {
+	Fonts []string `json:"fonts"`
+}
+
+// List returns every font family GeoServer can use for SLD labelling.
+// The list is sourced from the JVM's `GraphicsEnvironment` plus any
+// font files dropped into the data directory's `styles/` subdirectory,
+// so the result reflects whatever is on the server's classpath at
+// the time of the call. Order is server-defined (typically
+// alphabetical for system fonts).
+func (c *Client) List(ctx context.Context) ([]string, error) {
+	const op = "Fonts.List"
+	u, err := c.core.URL("rest", "fonts")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var resp fontsResponse
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Fonts, nil
+}

--- a/v2/rest/fonts/fonts_integration_test.go
+++ b/v2/rest/fonts/fonts_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package fonts_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+)
+
+func TestFonts_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.Fonts.List(ctx)
+	if err != nil {
+		t.Fatalf("Fonts.List: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one font, got empty list")
+	}
+
+	// Sanity-check that the list is non-empty and entries are strings
+	// (not all-empty). The exact set is JVM- and OS-dependent, so we
+	// only assert "at least one non-empty entry."
+	var nonEmpty int
+	for _, f := range got {
+		if strings.TrimSpace(f) != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty == 0 {
+		t.Fatalf("every font name was empty: %v", got)
+	}
+}

--- a/v2/rest/fonts/fonts_test.go
+++ b/v2/rest/fonts/fonts_test.go
@@ -1,0 +1,81 @@
+package fonts_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestList_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/fonts" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"fonts":["DejaVu Sans","DejaVu Sans Bold","Dialog"]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Fonts.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := []string{"DejaVu Sans", "DejaVu Sans Bold", "Dialog"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"fonts":[]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Fonts.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want empty, got %v", got)
+	}
+}
+
+func TestList_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Fonts.List(context.Background())
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- New `c.Fonts.List(ctx)` at `/rest/fonts` — returns the list of font families the JVM exposes to GeoServer's SLD labelling pipeline as `[]string`. Useful as a sanity check before publishing styles that reference specific fonts (typos would otherwise surface as silent label-rendering fallbacks).
- Closes the fonts longer-tail item from `docs/v2-tier2-gaps.md`. CRS list and usergroup-service registration are dropped from the backlog (no public REST surface on stock GeoServer); monitoring / OSEO / master password / self-admin password remain.

## Test plan

- [x] Unit tests (httptest happy path, empty-list, 401 → `ErrUnauthorized`).
- [x] Integration test against `make compose-up` stack (assertion: list is non-empty; stock images bundle DejaVu / Dialog families). Local run passed against GeoServer 2.28.0.
- [x] `make lint` — 0 issues.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.