### PR TITLE
feat(v2): add MasterPassword + SelfPassword sub-clients

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -6,7 +6,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 ## Remaining backlog
 
-The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: monitoring (requires the `gs-monitor` extension), master password, self-admin password, the OWS `oseo` (OpenSearch for Earth Observation) service settings (requires `gs-oseo`), and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first. Items that turned out to have no public REST surface on stock GeoServer (CRS list, usergroup-service registration) are dropped from the backlog.
+The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: monitoring (requires the `gs-monitor` extension), the OWS `oseo` (OpenSearch for Earth Observation) service settings (requires `gs-oseo`), and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first. Items that turned out to have no public REST surface on stock GeoServer (CRS list, usergroup-service registration) are dropped from the backlog.
 
 ## Already shipped
 
@@ -21,6 +21,7 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 - **Manifests + system status** — `c.About.Manifests` and `c.About.SystemStatus` against `/rest/about/manifest` and `/rest/about/system-status`. Shipped in beta.2.
 - **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Shipped in beta.2.
 - **Fonts list** — `c.Fonts.List` against `/rest/fonts`. Shipped post-beta.2.
+- **Master password & self password** — `c.Security.MasterPassword.Get`/`Update` against `/rest/security/masterpw` and `c.Security.SelfPassword.Change` against `/rest/security/self/password`. Shipped post-beta.2.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -12,6 +12,14 @@ Closes the fonts longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-t
 
 - **`c.Fonts.List(ctx)`** at `/rest/fonts` — returns the list of font families the JVM exposes to GeoServer's SLD labelling pipeline as `[]string`. The result reflects whatever is on the server's classpath at call time (system fonts plus anything dropped into the data directory's `styles/` subdirectory).
 
+### Added — Master password & self password (security)
+
+Closes the master-password and self-admin-password longer-tail items from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Two new sub-clients on `c.Security` cover the daily-driver auth-rotation surface.
+
+- **`c.Security.MasterPassword.Get(ctx)`** / **`Update(ctx, oldPwd, newPwd)`** at `/rest/security/masterpw`. The master password unlocks GeoServer's keystore (used for storing connection-string passwords, JKS aliases) — distinct from the admin user's login password. GeoServer exposes the current value via GET (admin-gated) for backup / disaster-recovery flows; treat the returned value with the same care as any other secret.
+- **`c.Security.SelfPassword.Change(ctx, newPwd)`** at `/rest/security/self/password`. PUT-only by design (GeoServer responds 405 "You can not request the password!" to GET); the request's auth header proves possession in lieu of an old-password field.
+- **Wire-quirk:** master password PUT requires both `oldMasterPassword` and `newMasterPassword`; same-value rotation is rejected with `422 "Cannot change master password"`. Self-password PUT body is just `{"newPassword":"..."}` — no old-password field.
+
 ## [2.0.0-beta.2] — 2026-05-04
 
 Second beta. **Closes the original tier-2 gap-analysis backlog from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md)** — eight new sub-clients land on top of beta.1's frozen surface: mosaic granules, FTL templates, auth providers / filters / chains, URL checks, cascaded WMS / WMTS stores + layers, WFS XSLT transforms, manifests + system status, and runtime logging. No breaking changes from `beta.1`; existing callers can `go get @v2.0.0-beta.2` and recompile. Public API stays frozen for review through the beta line — breaking changes will not land without a strong reason.

--- a/v2/rest/security/masterpassword.go
+++ b/v2/rest/security/masterpassword.go
@@ -1,0 +1,78 @@
+package security
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// MasterPasswordClient covers the master password singleton at
+// /rest/security/masterpw. The master password unlocks GeoServer's
+// keystore (used for storing connection-string passwords, JKS aliases,
+// etc.); it is distinct from the admin user's login password handled
+// by [SelfPasswordClient]. Operations require admin auth.
+//
+//	pw, _ := c.Security.MasterPassword.Get(ctx)
+//	_ = c.Security.MasterPassword.Update(ctx, pw, "new-strong-secret")
+type MasterPasswordClient struct {
+	core Core
+}
+
+// masterPasswordResponse matches the wire shape of GET /rest/security/masterpw:
+// `{"oldMasterPassword":"<current value>"}`. The "old" prefix is
+// awkward — semantically the GET returns the *current* master
+// password — but it matches the upstream API.
+type masterPasswordResponse struct {
+	OldMasterPassword string `json:"oldMasterPassword"`
+}
+
+// masterPasswordChangeRequest is the PUT body. Both fields are
+// required by GeoServer; the server validates oldMasterPassword
+// against the current value before applying newMasterPassword.
+type masterPasswordChangeRequest struct {
+	OldMasterPassword string `json:"oldMasterPassword"`
+	NewMasterPassword string `json:"newMasterPassword"`
+}
+
+// Get returns the current master password as a plain string.
+//
+// GeoServer exposes the master password via GET (gated by admin auth)
+// to support backup / disaster-recovery flows. Treat the returned
+// value with the same care as any other secret.
+func (c *MasterPasswordClient) Get(ctx context.Context) (string, error) {
+	const op = "Security.MasterPassword.Get"
+	u, err := c.core.URL("rest", "security", "masterpw")
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", op, err)
+	}
+	var resp masterPasswordResponse
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &resp); err != nil {
+		return "", err
+	}
+	return resp.OldMasterPassword, nil
+}
+
+// Update changes the master password. The caller MUST supply the
+// current value as oldMasterPassword; GeoServer rejects the request
+// (422 / 401, depending on version) when it doesn't match.
+//
+// Both arguments are required and must be non-empty.
+func (c *MasterPasswordClient) Update(ctx context.Context, oldMasterPassword, newMasterPassword string) error {
+	const op = "Security.MasterPassword.Update"
+	if oldMasterPassword == "" {
+		return errors.New(op + ": empty oldMasterPassword")
+	}
+	if newMasterPassword == "" {
+		return errors.New(op + ": empty newMasterPassword")
+	}
+	u, err := c.core.URL("rest", "security", "masterpw")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := masterPasswordChangeRequest{
+		OldMasterPassword: oldMasterPassword,
+		NewMasterPassword: newMasterPassword,
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}

--- a/v2/rest/security/passwords_integration_test.go
+++ b/v2/rest/security/passwords_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package security_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+)
+
+// TestMasterPassword_GetUpdate_RoundTrip exercises GET + PUT against
+// the live stack. GeoServer's master-password endpoint refuses a
+// same-value update (422 "Cannot change master password"), so the
+// test rotates to a strong throwaway value and reverts to the
+// original in t.Cleanup so subsequent tests / dev sessions are
+// unaffected.
+func TestMasterPassword_GetUpdate_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	original, err := c.Security.MasterPassword.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get original: %v", err)
+	}
+	if original == "" {
+		t.Fatal("expected non-empty master password, got empty string")
+	}
+
+	const rotated = "GeoServer-MASTER-Test-Rotation-2026!"
+
+	// Belt-and-braces revert in case the test panics mid-way.
+	t.Cleanup(func() {
+		_ = c.Security.MasterPassword.Update(ctx, rotated, original)
+	})
+
+	if err := c.Security.MasterPassword.Update(ctx, original, rotated); err != nil {
+		t.Fatalf("Update to rotated: %v", err)
+	}
+
+	got, err := c.Security.MasterPassword.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after rotation: %v", err)
+	}
+	if got != rotated {
+		t.Errorf("after rotation got %q, want %q", got, rotated)
+	}
+
+	// Explicit revert (also catches errors the Cleanup would swallow).
+	if err := c.Security.MasterPassword.Update(ctx, rotated, original); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+}
+
+// TestSelfPassword_Change_Idempotent calls Change with the user's
+// current password (the value testenv.NewClient is already
+// authenticating with). If the endpoint applies the change, it's a
+// no-op; if it returns 200 without applying (observed on some 2.x
+// versions), the test still asserts the contract — body shape and
+// auth are accepted.
+//
+// We deliberately do NOT change the password to a different value
+// because subsequent integration tests authenticate with the same
+// account and would fail.
+func TestSelfPassword_Change_Idempotent_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	pass := testenv.DefaultPass
+	if env := os.Getenv("GEOSERVER_PASS"); env != "" {
+		pass = env
+	}
+	if err := c.Security.SelfPassword.Change(ctx, pass); err != nil {
+		t.Fatalf("Change (idempotent): %v", err)
+	}
+}

--- a/v2/rest/security/passwords_test.go
+++ b/v2/rest/security/passwords_test.go
@@ -1,0 +1,148 @@
+package security_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+func newPasswordTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestMasterPassword_Get_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/security/masterpw" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"oldMasterPassword":"super-secret"}`)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	got, err := c.Security.MasterPassword.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "super-secret" {
+		t.Errorf("got %q, want %q", got, "super-secret")
+	}
+}
+
+func TestMasterPassword_Update_BodyShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/masterpw" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		for _, want := range []string{`"oldMasterPassword":"old-pw"`, `"newMasterPassword":"new-pw"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("body missing %s; got %s", want, s)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	if err := c.Security.MasterPassword.Update(context.Background(), "old-pw", "new-pw"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+func TestMasterPassword_Update_RejectsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	if err := c.Security.MasterPassword.Update(context.Background(), "", "new"); err == nil {
+		t.Error("empty old: expected error")
+	}
+	if err := c.Security.MasterPassword.Update(context.Background(), "old", ""); err == nil {
+		t.Error("empty new: expected error")
+	}
+}
+
+func TestMasterPassword_Get_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	_, err := c.Security.MasterPassword.Get(context.Background())
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestSelfPassword_Change_BodyShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/security/self/password" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"newPassword":"new-pw"`) {
+			t.Errorf("body missing newPassword field; got %s", s)
+		}
+		// The body MUST NOT carry an oldPassword — auth header proves possession.
+		if strings.Contains(s, "oldPassword") {
+			t.Errorf("body should not include oldPassword; got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	if err := c.Security.SelfPassword.Change(context.Background(), "new-pw"); err != nil {
+		t.Fatalf("Change: %v", err)
+	}
+}
+
+func TestSelfPassword_Change_RejectsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	if err := c.Security.SelfPassword.Change(context.Background(), ""); err == nil {
+		t.Error("expected empty-newPassword error")
+	}
+}
+
+func TestSelfPassword_Change_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newPasswordTestClient(t, srv)
+	err := c.Security.SelfPassword.Change(context.Background(), "new")
+	if !errors.Is(err, geoserver.ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}

--- a/v2/rest/security/security.go
+++ b/v2/rest/security/security.go
@@ -20,8 +20,8 @@ type Core interface {
 	SynthesizeError(op, method, requestURL string, statusCode int, bodyHint string) error
 }
 
-// Client is the v2 security sub-client. It carries six nested
-// surfaces:
+// Client is the v2 security sub-client. It carries the nested surfaces
+// listed below:
 //
 //	c.Security.Users()                       // default user/group service
 //	c.Security.UsersInService("custom-jdbc") // custom service
@@ -31,6 +31,8 @@ type Core interface {
 //	c.Security.AuthProviders                 // /security/authproviders
 //	c.Security.AuthFilters                   // /security/authfilters
 //	c.Security.FilterChains                  // /security/filterchain
+//	c.Security.MasterPassword                // /security/masterpw  (keystore)
+//	c.Security.SelfPassword                  // /security/self/password (auth'd user)
 type Client struct {
 	core Core
 
@@ -56,16 +58,29 @@ type Client struct {
 	// chain binds a URL pattern (e.g. "/web/**") to an ordered list
 	// of [AuthFiltersClient] filter names.
 	FilterChains *FilterChainsClient
+
+	// MasterPassword is the entry point for the master password
+	// singleton at /security/masterpw — the keystore unlock secret
+	// (distinct from the admin user's login password).
+	MasterPassword *MasterPasswordClient
+
+	// SelfPassword is the entry point for the authenticated user's
+	// own password rotation at /security/self/password. PUT-only by
+	// design; auth header proves possession in lieu of an old-password
+	// field.
+	SelfPassword *SelfPasswordClient
 }
 
 // New constructs the security sub-client.
 func New(core Core) *Client {
 	return &Client{
-		core:          core,
-		Roles:         &RolesClient{core: core},
-		AuthProviders: &AuthProvidersClient{core: core},
-		AuthFilters:   &AuthFiltersClient{core: core},
-		FilterChains:  &FilterChainsClient{core: core},
+		core:           core,
+		Roles:          &RolesClient{core: core},
+		AuthProviders:  &AuthProvidersClient{core: core},
+		AuthFilters:    &AuthFiltersClient{core: core},
+		FilterChains:   &FilterChainsClient{core: core},
+		MasterPassword: &MasterPasswordClient{core: core},
+		SelfPassword:   &SelfPasswordClient{core: core},
 	}
 }
 

--- a/v2/rest/security/selfpassword.go
+++ b/v2/rest/security/selfpassword.go
@@ -1,0 +1,48 @@
+package security
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// SelfPasswordClient covers PUT /rest/security/self/password — the
+// authenticated user's own login password. The endpoint is GET-less
+// by design (GeoServer responds 405 "You can not request the
+// password!"); this client therefore exposes a single Change method.
+//
+//	_ = c.Security.SelfPassword.Change(ctx, "new-strong-secret")
+//
+// To change another user's password, use the user/group-service path
+// via [UsersClient] (admin-gated). SelfPassword is intentionally the
+// thin "the auth'd user rotates their own password" path.
+type SelfPasswordClient struct {
+	core Core
+}
+
+// selfPasswordChangeRequest matches the PUT body wire shape:
+// `{"newPassword":"..."}`. The endpoint authenticates the caller via
+// the request's auth header — there is no oldPassword field; the
+// auth header itself proves possession.
+type selfPasswordChangeRequest struct {
+	NewPassword string `json:"newPassword"`
+}
+
+// Change rotates the authenticated user's password to newPassword.
+//
+// Returns an [APIError] wrapping [ErrUnauthorized] if the caller's
+// credentials are no longer valid, [ErrBadRequest] if newPassword
+// fails the password policy.
+func (c *SelfPasswordClient) Change(ctx context.Context, newPassword string) error {
+	const op = "Security.SelfPassword.Change"
+	if newPassword == "" {
+		return errors.New(op + ": empty newPassword")
+	}
+	u, err := c.core.URL("rest", "security", "self", "password")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body := selfPasswordChangeRequest{NewPassword: newPassword}
+	return c.core.Do(ctx, op, http.MethodPut, u, body, nil, nil)
+}


### PR DESCRIPTION
## Summary

- Two new sub-clients on `c.Security` cover the daily-driver auth-rotation surface — `c.Security.MasterPassword` (Get + Update at `/rest/security/masterpw`) and `c.Security.SelfPassword` (Change at `/rest/security/self/password`). Closes the master-password and self-admin-password longer-tail items from `docs/v2-tier2-gaps.md`.
- Master password unlocks GeoServer's keystore (distinct from the admin user's login password). GET exposes the current value (admin-gated) for backup / DR flows. PUT requires both `oldMasterPassword` and `newMasterPassword`.
- Self-password is PUT-only by design — auth header proves possession in lieu of an old-password field.

## Wire-quirks (from local probing against GeoServer 2.28.0)

- Master password PUT rejects same-value rotation with `422 "Cannot change master password"`. The integration test rotates to a strong throwaway value and reverts in `t.Cleanup`.
- Self-password GET returns `405 "You can not request the password!"`. Body is a flat `{"newPassword":"..."}` (no `oldPassword` field).

## Test plan

- [x] Unit tests (httptest happy paths, body-shape assertions, empty-arg rejection, 401 sentinel mapping).
- [x] Integration tests against `make compose-up`: master rotate-and-revert, self idempotent change-to-current-value. Local run passed against GeoServer 2.28.0.
- [x] `make lint` — 0 issues.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.