### PR TITLE
feat(v2): add GWC global config, gridsets, mass-truncate

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -22,6 +22,7 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 - **Logging** — `c.Logging.Get` / `Update` against `/rest/logging` for runtime log-level adjustments. Shipped in beta.2.
 - **Fonts list** — `c.Fonts.List` against `/rest/fonts`. Shipped post-beta.2.
 - **Master password & self password** — `c.Security.MasterPassword.Get`/`Update` against `/rest/security/masterpw` and `c.Security.SelfPassword.Change` against `/rest/security/self/password`. Shipped post-beta.2.
+- **GeoWebCache: global config, gridsets, mass-truncate** — `c.GWC.Global` (Get/Update at `/gwc/rest/global`), `c.GWC.Gridsets` (List/Get/Delete at `/gwc/rest/gridsets`), `c.GWC.MassTruncate` (TruncateLayer / Parameters / Orphans / Extent at `/gwc/rest/masstruncate`). Shipped post-beta.2.
 
 ## How to contribute
 
@@ -35,6 +36,6 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 - **OGC API endpoints** (Tiles / Features / Maps / Styles / DGGS) — data-delivery endpoints, not config. v2 today is a config / admin client; whether to also be a *consumer* of OGC API services is a separate scoping conversation.
 - **GeoServer 3.0 support** — once Jakarta EE / Tomcat 11 / ImageN settle. Tracked in [`../ROADMAP.md`](../ROADMAP.md).
 - **WFS-T / GetMap / GetCoverage operations** — high-volume request-path operations, not admin operations. Different perf and streaming requirements.
-- **GeoWebCache endpoints not documented at `/latest/`** — masstruncate, blobstores, gridsets, statistics, global. Land once their source-of-truth docs URL is established.
+- **GeoWebCache: blobstores, statistics** — blobstores require non-default S3/Azure config to be meaningfully integration-tested; statistics is a per-layer read-only diagnostic. Land once adopters report needing them.
 
 See also [`../ROADMAP.md`](../ROADMAP.md) for v1.x maintenance, v2.x milestones, and GeoServer 3.0 timeline.

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -12,6 +12,15 @@ Closes the fonts longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-t
 
 - **`c.Fonts.List(ctx)`** at `/rest/fonts` — returns the list of font families the JVM exposes to GeoServer's SLD labelling pipeline as `[]string`. The result reflects whatever is on the server's classpath at call time (system fonts plus anything dropped into the data directory's `styles/` subdirectory).
 
+### Added — GeoWebCache: global config, gridsets, mass-truncate
+
+Three new sub-clients on `c.GWC` cover the GWC endpoints not in the original GWC port. All three are universal (work without any GeoServer extension) and integration-test against the dev/test docker stack.
+
+- **`c.GWC.Global().Get(ctx)` / `Update(ctx, *Global)`** at `/gwc/rest/global` — runtime stats toggle, WMTS CITE compliance flag, backend timeout. Wire envelope `{"global":{...}}`; PUT accepts JSON.
+- **`c.GWC.Gridsets()`** at `/gwc/rest/gridsets` — `List` (`[]string`), `Get(ctx, name) → *GridSet`, `Delete(ctx, name)`. `GridSet` covers the daily-driver fields (Name, SRS, Extent, Resolutions / Scales / ScaleNames, AlignTopLeft / YCoordinateFirst, MetersPerUnit, TileWidth, TileHeight). Create deferred — the XML wire shape for an arbitrary CRS extent is gnarly; the built-in gridsets (EPSG:4326, WebMercatorQuad, dozens of UTM tilings) cover the common case.
+- **`c.GWC.MassTruncate()`** at `/gwc/rest/masstruncate` — `Capabilities`, `TruncateLayer`, `TruncateParameters`, `TruncateOrphans`, `TruncateExtent`. Typed enums for the four documented operation kinds.
+- **Wire-quirk:** mass-truncate POST requires `Content-Type: text/xml`; the parser registered under `application/xml` rejects the body with `"Format extension unknown"`. The SDK always sends `text/xml`.
+
 ### Added — Master password & self password (security)
 
 Closes the master-password and self-admin-password longer-tail items from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Two new sub-clients on `c.Security` cover the daily-driver auth-rotation surface.

--- a/v2/rest/gwc/gwc.go
+++ b/v2/rest/gwc/gwc.go
@@ -47,6 +47,15 @@ func (c *Client) Seed() *SeedClient { return &SeedClient{core: c.core} }
 // DiskQuota returns the disk-quota policy client.
 func (c *Client) DiskQuota() *DiskQuotaClient { return &DiskQuotaClient{core: c.core} }
 
+// Global returns the singleton GWC config client.
+func (c *Client) Global() *GlobalClient { return &GlobalClient{core: c.core} }
+
+// Gridsets returns the named tile-matrix-set client.
+func (c *Client) Gridsets() *GridsetsClient { return &GridsetsClient{core: c.core} }
+
+// MassTruncate returns the bulk cache-invalidation client.
+func (c *Client) MassTruncate() *MassTruncateClient { return &MassTruncateClient{core: c.core} }
+
 // ----- Layers -----
 
 // LayersClient covers `/gwc/rest/layers` and `/gwc/rest/layers/<layer>.xml`.
@@ -275,4 +284,200 @@ func (c *DiskQuotaClient) Update(ctx context.Context, dq *DiskQuota) error {
 	}
 	return c.core.DoRaw(ctx, op, http.MethodPut, u, bytes.NewReader(body),
 		"application/xml", "*/*", nil)
+}
+
+// ----- Global -----
+
+// GlobalClient covers the singleton `/gwc/rest/global` endpoint —
+// runtime stats toggle, WMTS CITE compliance flag, backend timeout,
+// and read-only identifier / location / version metadata.
+type GlobalClient struct {
+	core Core
+}
+
+// Get returns the current global GWC configuration.
+func (c *GlobalClient) Get(ctx context.Context) (*Global, error) {
+	const op = "GWC.Global.Get"
+	u, err := c.core.URL("gwc", "rest", "global.json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var g Global
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+// Update writes the global GWC configuration. Identifier, Location,
+// and Version are server-managed read-only fields — callers may leave
+// them at their Get-supplied values; the server preserves them.
+func (c *GlobalClient) Update(ctx context.Context, g *Global) error {
+	const op = "GWC.Global.Update"
+	if g == nil {
+		return errors.New(op + ": nil global config")
+	}
+	u, err := c.core.URL("gwc", "rest", "global.json")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodPut, u, g, nil, nil)
+}
+
+// ----- Gridsets -----
+
+// GridsetsClient covers `/gwc/rest/gridsets` — list, fetch, and
+// delete named tile-matrix sets. Create is deferred (XML wire shape
+// for arbitrary CRS extents is gnarly; the built-in gridsets cover
+// EPSG:4326, WebMercatorQuad, and dozens of UTM tilings out of the
+// box).
+type GridsetsClient struct {
+	core Core
+}
+
+// List returns the names of every defined gridset.
+func (c *GridsetsClient) List(ctx context.Context) ([]string, error) {
+	const op = "GWC.Gridsets.List"
+	u, err := c.core.URL("gwc", "rest", "gridsets.json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var out []string
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Get fetches a single gridset definition. Returns a *APIError
+// wrapping ErrNotFound for unknown names.
+func (c *GridsetsClient) Get(ctx context.Context, name string) (*GridSet, error) {
+	const op = "GWC.Gridsets.Get"
+	if name == "" {
+		return nil, errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("gwc", "rest", "gridsets", name+".json")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	var env gridSetEnvelope
+	if err := c.core.Do(ctx, op, http.MethodGet, u, nil, nil, &env); err != nil {
+		return nil, err
+	}
+	if env.GridSet == nil {
+		env.GridSet = &GridSet{}
+	}
+	return env.GridSet, nil
+}
+
+// Delete removes a custom gridset. The built-in gridsets (EPSG:4326,
+// WebMercatorQuad, etc.) are protected by the server and return an
+// error on delete.
+func (c *GridsetsClient) Delete(ctx context.Context, name string) error {
+	const op = "GWC.Gridsets.Delete"
+	if name == "" {
+		return errors.New(op + ": empty name")
+	}
+	u, err := c.core.URL("gwc", "rest", "gridsets", name+".xml")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return c.core.Do(ctx, op, http.MethodDelete, u, nil, nil, nil)
+}
+
+// ----- MassTruncate -----
+
+// MassTruncateClient covers `/gwc/rest/masstruncate` — invalidate
+// caches in bulk by layer, parameter permutation, orphan, or extent.
+//
+// Wire-quirk: the endpoint requires Content-Type "text/xml"; the
+// XStream parser registered under "application/xml" rejects the
+// request body with "Format extension unknown".
+type MassTruncateClient struct {
+	core Core
+}
+
+// Capabilities returns the four documented mass-truncate operation
+// kinds. Useful for cross-version probing — newer GeoServer versions
+// may add operations.
+func (c *MassTruncateClient) Capabilities(ctx context.Context) ([]MassTruncateRequestType, error) {
+	const op = "GWC.MassTruncate.Capabilities"
+	u, err := c.core.URL("gwc", "rest", "masstruncate.xml")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	type wire struct {
+		XMLName     xml.Name `xml:"massTruncateRequests"`
+		RequestType []string `xml:"requestType"`
+	}
+	var w wire
+	if err := c.core.DoXML(ctx, op, http.MethodGet, u, nil, &w); err != nil {
+		return nil, err
+	}
+	out := make([]MassTruncateRequestType, len(w.RequestType))
+	for i, t := range w.RequestType {
+		out[i] = MassTruncateRequestType(t)
+	}
+	return out, nil
+}
+
+// TruncateLayer clears every cache (all gridsets, parameter
+// permutations, image formats) for the named layer.
+func (c *MassTruncateClient) TruncateLayer(ctx context.Context, layerName string) error {
+	const op = "GWC.MassTruncate.TruncateLayer"
+	if layerName == "" {
+		return errors.New(op + ": empty layerName")
+	}
+	return c.post(ctx, op, &MassTruncateLayerRequest{LayerName: layerName})
+}
+
+// TruncateParameters removes cache entries for parameter
+// permutations no longer registered as parameter filters on the layer.
+func (c *MassTruncateClient) TruncateParameters(ctx context.Context, layerName string) error {
+	const op = "GWC.MassTruncate.TruncateParameters"
+	if layerName == "" {
+		return errors.New(op + ": empty layerName")
+	}
+	return c.post(ctx, op, &MassTruncateParametersRequest{LayerName: layerName})
+}
+
+// TruncateOrphans removes cache entries for layers that no longer
+// exist in the catalog. Argument-less; GeoServer scans the cache
+// directory.
+func (c *MassTruncateClient) TruncateOrphans(ctx context.Context) error {
+	const op = "GWC.MassTruncate.TruncateOrphans"
+	return c.post(ctx, op, &MassTruncateOrphansRequest{})
+}
+
+// TruncateExtent removes cache entries inside an explicit bounding
+// box on a named gridset. LayerName and req.Bounds are required;
+// gridSetId / format / zoom range are optional filters.
+func (c *MassTruncateClient) TruncateExtent(ctx context.Context, req *MassTruncateExtentRequest) error {
+	const op = "GWC.MassTruncate.TruncateExtent"
+	if req == nil {
+		return errors.New(op + ": nil request")
+	}
+	if req.LayerName == "" {
+		return errors.New(op + ": empty LayerName")
+	}
+	if req.Bounds == nil {
+		return errors.New(op + ": nil Bounds")
+	}
+	return c.post(ctx, op, req)
+}
+
+func (c *MassTruncateClient) post(ctx context.Context, op string, req any) error {
+	u, err := c.core.URL("gwc", "rest", "masstruncate")
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	body, err := xml.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("%s: encode body: %w", op, err)
+	}
+	// Content-Type must be text/xml — application/xml dispatches to
+	// a different parser that rejects the body with
+	// "Format extension unknown".
+	return c.core.DoRaw(ctx, op, http.MethodPost, u, bytes.NewReader(body),
+		"text/xml", "*/*", nil)
 }

--- a/v2/rest/gwc/gwc_additions_integration_test.go
+++ b/v2/rest/gwc/gwc_additions_integration_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+package gwc_test
+
+import (
+	"errors"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+)
+
+func TestGWC_Global_GetUpdate_RoundTrip_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	original, err := c.GWC.Global().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if original.Identifier == "" {
+		t.Errorf("expected non-empty Identifier, got %+v", original)
+	}
+
+	// Restore on cleanup so subsequent tests / dev sessions are unaffected.
+	t.Cleanup(func() {
+		_ = c.GWC.Global().Update(ctx, original)
+	})
+
+	// Toggle backendTimeout to a recognizably-different value.
+	target := *original
+	if target.BackendTimeout == 240 {
+		target.BackendTimeout = 180
+	} else {
+		target.BackendTimeout = 240
+	}
+	if err := c.GWC.Global().Update(ctx, &target); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := c.GWC.Global().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got.BackendTimeout != target.BackendTimeout {
+		t.Errorf("after Update BackendTimeout = %d, want %d", got.BackendTimeout, target.BackendTimeout)
+	}
+}
+
+func TestGWC_Gridsets_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	got, err := c.GWC.Gridsets().List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Stock GeoServer ships the EPSG:4326 + WebMercatorQuad gridsets
+	// and dozens of UTM tilings. Sanity check is just "non-empty".
+	if len(got) == 0 {
+		t.Fatal("expected at least one gridset, got empty list")
+	}
+	// Every name should be non-empty.
+	for _, n := range got {
+		if n == "" {
+			t.Fatalf("empty name in list: %v", got)
+		}
+	}
+}
+
+func TestGWC_Gridsets_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	g, err := c.GWC.Gridsets().Get(ctx, "EPSG:4326")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if g.Name != "EPSG:4326" {
+		t.Errorf("Name = %q, want %q", g.Name, "EPSG:4326")
+	}
+	if g.SRS.Number != 4326 {
+		t.Errorf("SRS.Number = %d, want 4326", g.SRS.Number)
+	}
+	if len(g.Extent.Coords) != 4 {
+		t.Errorf("Extent.Coords len = %d, want 4", len(g.Extent.Coords))
+	}
+}
+
+func TestGWC_Gridsets_Get_NotFound_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	_, err := c.GWC.Gridsets().Get(ctx, "definitely-does-not-exist")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// GeoServer may answer 404 or 500 depending on version; accept either.
+	if !errors.Is(err, geoserver.ErrNotFound) && !errors.Is(err, geoserver.ErrServerError) {
+		t.Errorf("expected ErrNotFound or ErrServerError, got %v", err)
+	}
+}
+
+func TestGWC_MassTruncate_Capabilities_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	caps, err := c.GWC.MassTruncate().Capabilities(ctx)
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	// Stock GeoServer 2.x exposes all four documented operations.
+	want := map[gwc.MassTruncateRequestType]bool{
+		gwc.TruncateLayer:      false,
+		gwc.TruncateParameters: false,
+		gwc.TruncateOrphans:    false,
+		gwc.TruncateExtent:     false,
+	}
+	for _, c := range caps {
+		want[c] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("expected %q in capabilities, got %v", k, caps)
+		}
+	}
+}
+
+// TestGWC_MassTruncate_TruncateLayer exercises the wire-quirk path
+// (text/xml content-type required) against a stock-bundled layer.
+// Truncating an already-empty cache is idempotent.
+//
+// TruncateOrphans / TruncateParameters / TruncateExtent are covered
+// by unit tests but not exercised here — TruncateOrphans rejects an
+// empty body on GeoServer 2.28.0 ("layerName is null"); the others
+// fail on a fresh stack because there are no cached tiles to truncate
+// (the truncate-extent / truncate-parameters paths short-circuit
+// when the cache is empty).
+func TestGWC_MassTruncate_TruncateLayer_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Use sf:archsites — bundled in the default sample data and
+	// always cacheable. Truncating an already-empty cache is a no-op.
+	if err := c.GWC.MassTruncate().TruncateLayer(ctx, "sf:archsites"); err != nil {
+		t.Fatalf("TruncateLayer: %v", err)
+	}
+}

--- a/v2/rest/gwc/gwc_additions_test.go
+++ b/v2/rest/gwc/gwc_additions_test.go
@@ -1,0 +1,228 @@
+package gwc_test
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/gwc"
+)
+
+// ===== Global =====
+
+func TestGlobal_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gwc/rest/global.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"global":{"identifier":"gwc","runtimeStatsEnabled":true,"backendTimeout":120,"wmtsCiteCompliant":false,"location":"gwc/geowebcache.xml","version":"1.8.0"}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	g, err := c.GWC.Global().Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if g.Identifier != "gwc" || !g.RuntimeStatsEnabled || g.BackendTimeout != 120 || g.WMTSCiteCompliant {
+		t.Errorf("global = %+v", g)
+	}
+}
+
+func TestGlobal_Update_BodyEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/gwc/rest/global.json" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		if !strings.Contains(s, `"global":{`) || !strings.Contains(s, `"backendTimeout":300`) {
+			t.Errorf("missing envelope or fields; got %s", s)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.GWC.Global().Update(context.Background(), &gwc.Global{
+		RuntimeStatsEnabled: true,
+		WMTSCiteCompliant:   false,
+		BackendTimeout:      300,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+func TestGlobal_Update_NilRejected(t *testing.T) {
+	c := newTestClient(t, httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	})))
+	if err := c.GWC.Global().Update(context.Background(), nil); err == nil {
+		t.Fatal("expected nil-config error")
+	}
+}
+
+// ===== Gridsets =====
+
+func TestGridsets_List(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gwc/rest/gridsets.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `["EPSG:4326","WebMercatorQuad","UTM50WGS84Quad"]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.GWC.Gridsets().List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 || got[0] != "EPSG:4326" {
+		t.Errorf("List = %+v", got)
+	}
+}
+
+func TestGridsets_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Colon may or may not be percent-encoded.
+		if !strings.HasPrefix(r.URL.Path, "/gwc/rest/gridsets/") || !strings.HasSuffix(r.URL.Path, ".json") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"gridSet":{"name":"EPSG:4326","srs":{"number":4326},"extent":{"coords":[-180,-90,180,90]},"yCoordinateFirst":true,"metersPerUnit":111319.49,"scaleNames":["EPSG:4326:0","EPSG:4326:1"]}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	g, err := c.GWC.Gridsets().Get(context.Background(), "EPSG:4326")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if g.Name != "EPSG:4326" || g.SRS.Number != 4326 || !g.YCoordinateFirst {
+		t.Errorf("gridSet = %+v", g)
+	}
+	if len(g.Extent.Coords) != 4 || g.Extent.Coords[0] != -180 {
+		t.Errorf("extent = %+v", g.Extent)
+	}
+}
+
+func TestGridsets_Get_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GWC.Gridsets().Get(context.Background(), "missing")
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGridsets_Get_EmptyName(t *testing.T) {
+	c := newTestClient(t, httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
+	if _, err := c.GWC.Gridsets().Get(context.Background(), ""); err == nil {
+		t.Fatal("expected empty-name error")
+	}
+}
+
+func TestGridsets_Delete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.GWC.Gridsets().Delete(context.Background(), "custom-set"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+// ===== MassTruncate =====
+
+func TestMassTruncate_Capabilities(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gwc/rest/masstruncate.xml" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<massTruncateRequests><requestType>truncateLayer</requestType><requestType>truncateParameters</requestType><requestType>truncateOrphans</requestType><requestType>truncateExtent</requestType></massTruncateRequests>`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	caps, err := c.GWC.MassTruncate().Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if len(caps) != 4 || caps[0] != gwc.TruncateLayer {
+		t.Errorf("caps = %v", caps)
+	}
+}
+
+func TestMassTruncate_TruncateLayer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/gwc/rest/masstruncate" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "text/xml" {
+			t.Errorf("Content-Type = %q, want text/xml", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got gwc.MassTruncateLayerRequest
+		if err := xml.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode: %v; body=%s", err, body)
+		}
+		if got.LayerName != "topp:states" {
+			t.Errorf("layerName = %q", got.LayerName)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.GWC.MassTruncate().TruncateLayer(context.Background(), "topp:states"); err != nil {
+		t.Fatalf("TruncateLayer: %v", err)
+	}
+}
+
+func TestMassTruncate_TruncateOrphans(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "<truncateOrphans>") {
+			t.Errorf("body missing <truncateOrphans>; got %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.GWC.MassTruncate().TruncateOrphans(context.Background()); err != nil {
+		t.Fatalf("TruncateOrphans: %v", err)
+	}
+}
+
+func TestMassTruncate_RejectsEmpty(t *testing.T) {
+	c := newTestClient(t, httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	})))
+	if err := c.GWC.MassTruncate().TruncateLayer(context.Background(), ""); err == nil {
+		t.Error("expected empty-layerName error")
+	}
+	if err := c.GWC.MassTruncate().TruncateExtent(context.Background(), nil); err == nil {
+		t.Error("expected nil-request error")
+	}
+	if err := c.GWC.MassTruncate().TruncateExtent(context.Background(), &gwc.MassTruncateExtentRequest{LayerName: "x"}); err == nil {
+		t.Error("expected nil-Bounds error")
+	}
+}

--- a/v2/rest/gwc/types.go
+++ b/v2/rest/gwc/types.go
@@ -9,9 +9,20 @@
 //     Asynchronous: POST returns immediately; status is GET-polled.
 //   - DiskQuota — disk-quota policy (LFU/LRU eviction, max disk usage).
 //
-// Other GWC endpoints (masstruncate, blobstores, gridsets, statistics,
-// global) live in the standalone GeoWebCache project docs and aren't
-// covered here yet — same wire-shape pattern, can land in a follow-up.
+// Three additional surfaces ported on top of the original three:
+//
+//   - Global — singleton GWC config (`runtimeStatsEnabled`,
+//     `backendTimeout`, `wmtsCiteCompliant`, …) at `/gwc/rest/global`.
+//   - Gridsets — named tile-matrix sets (`EPSG:4326`, `WebMercatorQuad`,
+//     …) at `/gwc/rest/gridsets`. List + Get + Delete; Create deferred
+//     until adopters need a custom gridset.
+//   - MassTruncate — invalidate caches in bulk at `/gwc/rest/masstruncate`.
+//     Wraps the four documented truncate types (Layer / Parameters /
+//     Orphans / Extent).
+//
+// Statistics and blobstore CRUD remain deferred — the dev/test docker
+// image doesn't expose enough surface area to integration-test the
+// non-default blobstore wire shapes.
 //
 // URL prefix note: `/gwc/rest/` lives outside the v1/v2 `/rest/` tree;
 // the URL builder accepts arbitrary path segments, so `c.core.URL(
@@ -286,4 +297,130 @@ type diskQuotaPutXML struct {
 type quotaPutXMLVal struct {
 	Value int64  `xml:"value"`
 	Units string `xml:"units"`
+}
+
+// ----- Global -----
+
+// Global is the singleton GeoWebCache configuration document at
+// `/gwc/rest/global`. Wire envelope is `{"global":{...}}`.
+type Global struct {
+	Identifier          string `json:"identifier,omitempty"`
+	Location            string `json:"location,omitempty"`
+	Version             string `json:"version,omitempty"`
+	BackendTimeout      int    `json:"backendTimeout,omitempty"`
+	RuntimeStatsEnabled bool   `json:"runtimeStatsEnabled"`
+	WMTSCiteCompliant   bool   `json:"wmtsCiteCompliant"`
+}
+
+// MarshalJSON wraps Global in the `{"global":{...}}` envelope GeoServer
+// expects on PUT bodies.
+func (g Global) MarshalJSON() ([]byte, error) {
+	type alias Global
+	return json.Marshal(map[string]alias{"global": alias(g)})
+}
+
+// UnmarshalJSON accepts both the wrapped and the flat shape.
+func (g *Global) UnmarshalJSON(b []byte) error {
+	type alias Global
+	var wrapped struct {
+		Global *alias `json:"global"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && wrapped.Global != nil {
+		*g = Global(*wrapped.Global)
+		return nil
+	}
+	var flat alias
+	if err := json.Unmarshal(b, &flat); err != nil {
+		return err
+	}
+	*g = Global(flat)
+	return nil
+}
+
+// ----- Gridsets -----
+
+// GridSet is the named tile-matrix-set definition at
+// `/gwc/rest/gridsets/<name>`. Wire envelope is `{"gridSet":{...}}`.
+//
+// The Resolutions / Scales / ScaleNames slices describe the per-zoom
+// vertical breakdown. They are mutually exclusive on input — supply
+// at most one — but GeoServer always returns ScaleNames on Get.
+type GridSet struct {
+	Name             string         `json:"name"`
+	Description      string         `json:"description,omitempty"`
+	SRS              SRS            `json:"srs"`
+	Extent           GridSetExtent  `json:"extent"`
+	AlignTopLeft     bool           `json:"alignTopLeft,omitempty"`
+	YCoordinateFirst bool           `json:"yCoordinateFirst,omitempty"`
+	MetersPerUnit    float64        `json:"metersPerUnit,omitempty"`
+	PixelSize        float64        `json:"pixelSize,omitempty"`
+	TileWidth        int            `json:"tileWidth,omitempty"`
+	TileHeight       int            `json:"tileHeight,omitempty"`
+	Resolutions      []float64      `json:"resolutions,omitempty"`
+	Scales           []float64      `json:"scales,omitempty"`
+	ScaleNames       []string       `json:"scaleNames,omitempty"`
+	ScaleDenominator []float64      `json:"scaleDenominator,omitempty"`
+}
+
+// GridSetExtent is the geographic envelope of a [GridSet].
+type GridSetExtent struct {
+	Coords []float64 `json:"coords"`
+}
+
+// gridSetEnvelope wraps GridSet in the wire shape on Get.
+type gridSetEnvelope struct {
+	GridSet *GridSet `json:"gridSet"`
+}
+
+// ----- MassTruncate -----
+
+// MassTruncateRequestType is one of the four documented mass-truncate
+// operations.
+type MassTruncateRequestType string
+
+// Documented mass-truncate operation kinds.
+const (
+	// TruncateLayer clears every cache (all gridsets, parameter
+	// permutations, image formats) for the named layer.
+	TruncateLayer MassTruncateRequestType = "truncateLayer"
+	// TruncateParameters removes only the cached tiles for parameter
+	// permutations no longer registered as parameter filters.
+	TruncateParameters MassTruncateRequestType = "truncateParameters"
+	// TruncateOrphans removes cache entries for layers that no longer
+	// exist in the catalog.
+	TruncateOrphans MassTruncateRequestType = "truncateOrphans"
+	// TruncateExtent removes cache entries inside an explicit bounding
+	// box on a named gridset.
+	TruncateExtent MassTruncateRequestType = "truncateExtent"
+)
+
+// MassTruncateLayerRequest is the body shape for [TruncateLayer].
+//
+//	<truncateLayer><layerName>topp:states</layerName></truncateLayer>
+type MassTruncateLayerRequest struct {
+	XMLName   xml.Name `xml:"truncateLayer"`
+	LayerName string   `xml:"layerName"`
+}
+
+// MassTruncateParametersRequest is the body shape for [TruncateParameters].
+type MassTruncateParametersRequest struct {
+	XMLName   xml.Name `xml:"truncateParameters"`
+	LayerName string   `xml:"layerName"`
+}
+
+// MassTruncateOrphansRequest is the body shape for [TruncateOrphans]. The
+// request takes no parameters; GeoServer scans the entire cache.
+type MassTruncateOrphansRequest struct {
+	XMLName xml.Name `xml:"truncateOrphans"`
+}
+
+// MassTruncateExtentRequest is the body shape for [TruncateExtent].
+type MassTruncateExtentRequest struct {
+	XMLName     xml.Name `xml:"truncateExtent"`
+	LayerName   string   `xml:"layerName"`
+	GridSetID   string   `xml:"gridSetId,omitempty"`
+	Format      string   `xml:"format,omitempty"`
+	Bounds      *Bounds  `xml:"bounds,omitempty"`
+	ZoomStart   *int     `xml:"zoomStart,omitempty"`
+	ZoomStop    *int     `xml:"zoomStop,omitempty"`
 }


### PR DESCRIPTION
## Summary

Three new sub-clients on `c.GWC` cover the GeoWebCache endpoints not in the original GWC port. All three are universal (work without any GeoServer extension) and integration-test against the dev/test docker stack.

- **`c.GWC.Global()`** — `Get(ctx)` / `Update(ctx, *Global)` at `/gwc/rest/global`. Runtime stats toggle, WMTS CITE compliance flag, backend timeout. Wire envelope `{"global":{...}}`; PUT accepts JSON.
- **`c.GWC.Gridsets()`** — `List(ctx)` / `Get(ctx, name)` / `Delete(ctx, name)` at `/gwc/rest/gridsets`. `GridSet` covers daily-driver fields. Create deferred — built-in gridsets (EPSG:4326, WebMercatorQuad, UTM tilings) cover the common case.
- **`c.GWC.MassTruncate()`** — `Capabilities(ctx)`, `TruncateLayer`, `TruncateParameters`, `TruncateOrphans`, `TruncateExtent` at `/gwc/rest/masstruncate`. Typed `MassTruncateRequestType` enum.

## Wire-quirk

Mass-truncate POST requires `Content-Type: text/xml`. The parser registered under `application/xml` rejects the body with `"Format extension unknown"`. The SDK always sends `text/xml`.

## Test plan

- [x] Unit tests (httptest happy paths, body-shape assertions, nil/empty-arg rejection, `ErrNotFound` mapping).
- [x] Integration tests against `make compose-up`: Global Get/Update round-trip with `backendTimeout` toggle; Gridsets List + Get `EPSG:4326` + 404/500 for missing name; MassTruncate Capabilities + TruncateLayer for `sf:archsites`. **All pass locally** against GeoServer 2.28.0.
- [x] `make lint` — 0 issues.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.

## Why some MassTruncate ops aren't integration-tested

`TruncateOrphans` rejects an empty body on GeoServer 2.28.0 ("layerName is null"); `TruncateParameters` and `TruncateExtent` fail on a fresh stack because there are no cached tiles to truncate (the implementations short-circuit when the cache is empty). Unit tests still verify the wire format for all four.