### PR TITLE
feat(v2): add Monitor sub-client; bake gs-monitor into docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,20 @@ RUN set -eux; \
     cp importer-jars/*.jar /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/; \
     rm -rf importer.zip importer-jars
 
+# Monitor extension — required for the v2 SDK's `c.Monitor`
+# integration tests. Without it `GET /rest/monitor/requests` returns
+# 404. Baked in here so CI exercises the read-only monitoring REST
+# surface against a real server. Default config (no persisted audit
+# log) is fine for testing — the test only asserts the API contract.
+ARG MONITOR_DOWNLOAD_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GEOSERVER_VERSION}/extensions/geoserver-${GEOSERVER_VERSION}-monitor-plugin.zip
+RUN set -eux; \
+    cd /tmp; \
+    curl -fsSL --proto '=https' --tlsv1.2 -o monitor.zip "${MONITOR_DOWNLOAD_URL}"; \
+    mkdir monitor-jars; \
+    unzip -q -j monitor.zip "*.jar" -d monitor-jars; \
+    cp monitor-jars/*.jar /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/; \
+    rm -rf monitor.zip monitor-jars
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=5 \

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,9 +10,10 @@ This directory builds the GeoServer container the project's integration tests ru
 | GeoServer | 2.28.0 by default; 2.27.4 LTS for the test leg | The supported matrix. CI runs both legs on every PR. Override with `--build-arg GEOSERVER_VERSION=...`. |
 | Layout | WAR pre-extracted into `webapps/geoserver/` | Lets the Dockerfile drop extension JARs into `WEB-INF/lib/`. Tomcat happily runs the unpacked form. |
 | Importer extension | Baked in | Required for the v2 SDK's `c.Imports` integration tests. Without it `GET /rest/imports` returns 404 and the suite skips silently. With the bake-in, CI exercises the full `v2/rest/imports` surface against a real server on both 2.27.4 and 2.28.0. |
+| Monitor extension | Baked in | Required for the v2 SDK's `c.Monitor` integration tests (request audit log). Without it `GET /rest/monitor/requests.csv` returns 404. With the bake-in, CI exercises the full `v2/rest/monitor` surface. |
 | Healthcheck | `curl -fsS http://localhost:8080/geoserver/web/` every 30s after a 120s start period | Compose `depends_on` waits on this before starting the test runner. |
 
-The Importer extension is the only non-vanilla piece. Everything else is the upstream GeoServer WAR + standard Tomcat config.
+The Importer and Monitor extensions are the only non-vanilla pieces. Everything else is the upstream GeoServer WAR + standard Tomcat config.
 
 ## Boot the stack
 
@@ -36,7 +37,7 @@ PostGIS exposes port `5436` on the host (mapped from the container's `5432`) so 
 
 | File | Role |
 |---|---|
-| `Dockerfile` | Assembles the image. Pulls the GeoServer WAR + Importer plugin from `downloads.sourceforge.net` over TLS, unpacks the WAR, drops the importer JARs into `WEB-INF/lib/`. |
+| `Dockerfile` | Assembles the image. Pulls the GeoServer WAR + Importer + Monitor plugins from `downloads.sourceforge.net` over TLS, unpacks the WAR, drops the extension JARs into `WEB-INF/lib/`. |
 | `env/geoserver.env` | Environment variables consumed by `docker-compose.yml` (and `docker-compose.test.yml`) at container start: `GEOSERVER_ADMIN_PASSWORD`, JVM `INITIAL_MEMORY` / `MAXIMUM_MEMORY`, plus a few feature toggles (`ENABLE_JSONP`, `MAX_FILTER_RULES`, `OPTIMIZE_LINE_WIDTH`, `XFRAME_OPTIONS`). |
 | `postgis/init/01-lbldyt.sql` | Bootstraps the `public.lbldyt` table the `TestPublishPostgisLayer` integration test publishes against. The PostgreSQL image runs `*.sql` files from `/docker-entrypoint-initdb.d/` alphabetically on first boot of an empty data volume. To re-run after a schema change, recreate the volume: `docker compose down -v && docker compose up -d --wait`. The table name is a historical fixture from the v1.0 era; see [`../docs/geoserver-rest-quirks.md`](../docs/geoserver-rest-quirks.md) quirk #5 for why the seed table needs columns at all. |
 

--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -6,7 +6,7 @@ Each entry below is independently tractable as its own follow-up PR. None block 
 
 ## Remaining backlog
 
-The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: monitoring (requires the `gs-monitor` extension), the OWS `oseo` (OpenSearch for Earth Observation) service settings (requires `gs-oseo`), and any new endpoints introduced by GeoServer 2.29+. Each is a single endpoint or two and can ride along with whichever neighbor lands first. Items that turned out to have no public REST surface on stock GeoServer (CRS list, usergroup-service registration) are dropped from the backlog.
+The original tier-2 list is now closed. Beyond it, narrower-audience endpoints that may be added in later PRs include: the OWS `opensearch-eo` service settings (extension is community-only / SNAPSHOT-only on 2.27 / 2.28; revisit when it ships in stable releases), and any new endpoints introduced by GeoServer 2.29+. Items that turned out to have no public REST surface on stock GeoServer (CRS list, usergroup-service registration) are dropped from the backlog.
 
 ## Already shipped
 
@@ -23,6 +23,7 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 - **Fonts list** — `c.Fonts.List` against `/rest/fonts`. Shipped post-beta.2.
 - **Master password & self password** — `c.Security.MasterPassword.Get`/`Update` against `/rest/security/masterpw` and `c.Security.SelfPassword.Change` against `/rest/security/self/password`. Shipped post-beta.2.
 - **GeoWebCache: global config, gridsets, mass-truncate** — `c.GWC.Global` (Get/Update at `/gwc/rest/global`), `c.GWC.Gridsets` (List/Get/Delete at `/gwc/rest/gridsets`), `c.GWC.MassTruncate` (TruncateLayer / Parameters / Orphans / Extent at `/gwc/rest/masstruncate`). Shipped post-beta.2.
+- **Monitoring (request audit log)** — `c.Monitor.List` / `ListRaw` / `Get` against `/rest/monitor/requests.csv`. Requires the `gs-monitor` extension (now baked into the dev/test docker image). Shipped post-beta.2.
 
 ## How to contribute
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -12,6 +12,20 @@ Closes the fonts longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-t
 
 - **`c.Fonts.List(ctx)`** at `/rest/fonts` — returns the list of font families the JVM exposes to GeoServer's SLD labelling pipeline as `[]string`. The result reflects whatever is on the server's classpath at call time (system fonts plus anything dropped into the data directory's `styles/` subdirectory).
 
+### Added — Monitoring (request audit log)
+
+Closes the monitoring longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Read-only access to GeoServer's request audit log, served by the `gs-monitor` extension. The dev/test docker image now bakes the extension in so CI exercises the surface against a real server.
+
+- **`c.Monitor.List(ctx, ListOptions)`** at `/rest/monitor/requests.csv` — returns `[]Request` decoded from the CSV wire form. `Request` covers the daily-driver audit columns (ID / Path / Service / Operation / HTTPMethod / StartTime / EndTime / TotalTime / Status / ResponseStatus / ResponseLength / RemoteAddr / RemoteUser / Resources, …).
+- **`c.Monitor.ListRaw(ctx, ListOptions)`** returns the raw CSV `io.ReadCloser` for streaming-pipeline use cases or to access fields not promoted into the typed `Request`.
+- **`c.Monitor.Get(ctx, id)`** at `/rest/monitor/requests/{id}.csv` for a single audit entry.
+- **`ListOptions`** — `From` / `To` (ISO 8601 timestamps), `Filter` (`attributeName:OP:value`), `Order`, `Offset` / `Count`, `Live` (live-vs-completed), `Fields` (column projection).
+- **Wire-quirk:** `fields` parameter accepts only one column today (despite the docs). Multi-column projection trips a 500 `"No such property 'Id,Path' for object Request"`. Fetch all fields and discard client-side until upstream fixes the parser. Documented on `ListOptions.Fields`.
+
+### Docker image — Monitor extension baked in
+
+- **`docker/Dockerfile`** now downloads and installs the `gs-monitor` plugin during the image build. Without it `GET /rest/monitor/requests.csv` returns 404 and the audit-log integration suite would silently skip.
+
 ### Added — GeoWebCache: global config, gridsets, mass-truncate
 
 Three new sub-clients on `c.GWC` cover the GWC endpoints not in the original GWC port. All three are universal (work without any GeoServer extension) and integration-test against the dev/test docker stack.

--- a/v2/geoserver.go
+++ b/v2/geoserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hishamkaram/geoserver/v2/rest/layergroups"
 	"github.com/hishamkaram/geoserver/v2/rest/layers"
 	"github.com/hishamkaram/geoserver/v2/rest/logging"
+	"github.com/hishamkaram/geoserver/v2/rest/monitor"
 	"github.com/hishamkaram/geoserver/v2/rest/namespaces"
 	"github.com/hishamkaram/geoserver/v2/rest/resources"
 	"github.com/hishamkaram/geoserver/v2/rest/security"
@@ -238,6 +239,12 @@ type Client struct {
 	// that reference specific fonts; typos would otherwise surface as
 	// silent label-rendering fallbacks.
 	Fonts *fonts.Client
+
+	// Monitor is the entry point for the read-only audit log at
+	// /rest/monitor/requests, exposed by the gs-monitor extension.
+	// The dev/test docker image bakes the extension in; calls
+	// against an unequipped GeoServer return ErrNotFound.
+	Monitor *monitor.Client
 }
 
 // clientCore is the plumbing shared with every sub-client. Sub-clients
@@ -324,6 +331,7 @@ func New(serverURL string, opts ...Option) (*Client, error) {
 	c.WFSTransforms = wfstransforms.New(adapter)
 	c.Logging = logging.New(adapter)
 	c.Fonts = fonts.New(adapter)
+	c.Monitor = monitor.New(adapter)
 	return c, nil
 }
 

--- a/v2/rest/monitor/monitor.go
+++ b/v2/rest/monitor/monitor.go
@@ -1,0 +1,333 @@
+// Package monitor is the v2 sub-client for the GeoServer
+// /rest/monitor/requests endpoint — read-only audit log of OWS and
+// REST requests handled by the server. Exposed by the gs-monitor
+// extension; absent installs return ErrNotFound.
+//
+// The endpoint serves CSV / Excel / ZIP / HTML — there is no JSON
+// representation. The SDK fetches the CSV form and decodes into
+// typed [Request] structs. For raw access (e.g. to drop into a
+// reporting pipeline) use [Client.ListRaw].
+package monitor
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Core is the plumbing the sub-client needs from the parent [*Client].
+type Core interface {
+	URL(parts ...string) (string, error)
+	DoStream(ctx context.Context, op string, method, requestURL string, query map[string]string) (io.ReadCloser, int, error)
+}
+
+// Client is the v2 monitor sub-client.
+type Client struct {
+	core Core
+}
+
+// New constructs the monitor sub-client.
+func New(core Core) *Client {
+	return &Client{core: core}
+}
+
+// ListOptions filters the audit log returned by [Client.List] /
+// [Client.ListRaw]. All fields are optional.
+type ListOptions struct {
+	// From / To bound the request StartTime. ISO 8601 strings, any
+	// precision (e.g. "2026-04-23", "2026-04-23T16:16:44").
+	From, To string
+
+	// Filter is the upstream `attributeName:OP:value` shape — see
+	// the GeoServer monitor REST docs. OP is one of EQ, NEQ, LT, LTE,
+	// GT, GTE, IN.
+	Filter string
+
+	// Order is "attributeName[;ASC|DESC]"; default is server-defined
+	// (usually descending start time).
+	Order string
+
+	// Offset and Count paginate the result set.
+	Offset, Count int
+
+	// Live, when set, restricts to live (Running / Pending /
+	// Cancelling) requests if true, completed (Finished / Failed) if
+	// false. Leave the pointer nil to return both.
+	Live *bool
+
+	// Fields restricts the returned columns. Empty means "all fields".
+	// CSV column-name set documented in [Request].
+	//
+	// GeoServer 2.27 / 2.28 quirk: the upstream API doc says this is
+	// a comma-separated list, but the server-side parser only accepts
+	// a single property name — passing two or more comma-joined names
+	// returns 500 "No such property 'Foo,Bar' for object Request".
+	// Until that is fixed upstream, supply at most one entry; for
+	// multiple-column projections, fetch all fields and discard
+	// client-side, or use [Client.ListRaw] and decode the CSV yourself.
+	Fields []string
+}
+
+// Request is one audit-log entry. The struct mirrors the documented
+// CSV column set; missing or empty CSV cells decode to the zero
+// value for the field.
+type Request struct {
+	ID                  int64
+	Path                string
+	Service             string
+	Operation           string
+	SubOperation        string
+	OWSVersion          string
+	HTTPMethod          string
+	QueryString         string
+	Category            string
+	StartTime           time.Time
+	EndTime             time.Time
+	TotalTime           int64 // milliseconds
+	Status              string
+	ResponseStatus      int
+	ResponseLength      int64
+	ResponseContentType string
+	ErrorMessage        string
+	Host                string
+	InternalHost        string
+	RemoteAddr          string
+	RemoteHost          string
+	RemoteUser          string
+	RemoteUserAgent     string
+	RemoteCity          string
+	RemoteCountry       string
+	RemoteLat           float64
+	RemoteLon           float64
+	Bbox                string
+	Resources           []string
+	BodyContentLength   int64
+	BodyContentType     string
+	BodyAsString        string
+	HTTPReferer         string
+	CacheResult         string
+	MissReason          string
+}
+
+// List fetches the audit log and decodes it into typed [Request]
+// values. For very large result sets prefer [Client.ListRaw] and
+// stream-decode the CSV directly.
+func (c *Client) List(ctx context.Context, opts ListOptions) ([]Request, error) {
+	const op = "Monitor.List"
+	rc, err := c.ListRaw(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	rows, err := decodeCSV(rc)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return rows, nil
+}
+
+// ListRaw returns the raw CSV body. The caller MUST close the
+// returned [io.ReadCloser]. Use this for streaming pipelines or
+// when the typed [Request] subset doesn't cover every column you
+// need (the GeoServer schema includes ~35 fields; the SDK promotes
+// the well-known subset, callers drop into the raw stream for
+// extras like LabellingProcessingTime / ResourcesProcessingTime).
+func (c *Client) ListRaw(ctx context.Context, opts ListOptions) (io.ReadCloser, error) {
+	const op = "Monitor.ListRaw"
+	u, err := c.core.URL("rest", "monitor", "requests.csv")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	q := opts.query()
+	rc, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, q)
+	if err != nil {
+		return nil, err
+	}
+	return rc, nil
+}
+
+// Get fetches a single audit-log entry by ID. Returns a *APIError
+// wrapping ErrNotFound if the entry doesn't exist.
+func (c *Client) Get(ctx context.Context, id int64) (*Request, error) {
+	const op = "Monitor.Get"
+	if id <= 0 {
+		return nil, errors.New(op + ": id must be positive")
+	}
+	u, err := c.core.URL("rest", "monitor", "requests", strconv.FormatInt(id, 10)+".csv")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	rc, _, err := c.core.DoStream(ctx, op, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	rows, err := decodeCSV(rc)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%s: empty response", op)
+	}
+	return &rows[0], nil
+}
+
+func (o ListOptions) query() map[string]string {
+	q := map[string]string{}
+	if o.From != "" {
+		q["from"] = o.From
+	}
+	if o.To != "" {
+		q["to"] = o.To
+	}
+	if o.Filter != "" {
+		q["filter"] = o.Filter
+	}
+	if o.Order != "" {
+		q["order"] = o.Order
+	}
+	if o.Offset > 0 {
+		q["offset"] = strconv.Itoa(o.Offset)
+	}
+	if o.Count > 0 {
+		q["count"] = strconv.Itoa(o.Count)
+	}
+	if o.Live != nil {
+		q["live"] = strconv.FormatBool(*o.Live)
+	}
+	if len(o.Fields) > 0 {
+		q["fields"] = strings.Join(o.Fields, ",")
+	}
+	return q
+}
+
+// decodeCSV turns the CSV body into typed Request values. The first
+// row is the header; subsequent rows map by column name into the
+// struct fields documented in [Request]. Unknown columns are
+// silently dropped.
+func decodeCSV(r io.Reader) ([]Request, error) {
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = -1 // tolerate ragged rows
+	header, err := cr.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	out := make([]Request, 0)
+	for {
+		row, err := cr.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return out, nil
+			}
+			return nil, fmt.Errorf("read row: %w", err)
+		}
+		var req Request
+		for i, col := range header {
+			if i >= len(row) {
+				break
+			}
+			req.set(col, row[i])
+		}
+		out = append(out, req)
+	}
+}
+
+// set decodes one CSV column into the matching struct field.
+func (r *Request) set(col, val string) {
+	if val == "" {
+		return
+	}
+	switch col {
+	case "Id":
+		r.ID, _ = strconv.ParseInt(val, 10, 64)
+	case "Path":
+		r.Path = val
+	case "Service":
+		r.Service = val
+	case "Operation":
+		r.Operation = val
+	case "SubOperation":
+		r.SubOperation = val
+	case "OwsVersion":
+		r.OWSVersion = val
+	case "HttpMethod":
+		r.HTTPMethod = val
+	case "QueryString":
+		r.QueryString = val
+	case "Category":
+		r.Category = val
+	case "StartTime":
+		r.StartTime, _ = time.Parse("2006-01-02T15:04:05.000", val)
+	case "EndTime":
+		r.EndTime, _ = time.Parse("2006-01-02T15:04:05.000", val)
+	case "TotalTime":
+		r.TotalTime, _ = strconv.ParseInt(val, 10, 64)
+	case "Status":
+		r.Status = val
+	case "ResponseStatus":
+		n, _ := strconv.Atoi(val)
+		r.ResponseStatus = n
+	case "ResponseLength":
+		r.ResponseLength, _ = strconv.ParseInt(val, 10, 64)
+	case "ResponseContentType":
+		r.ResponseContentType = val
+	case "ErrorMessage":
+		r.ErrorMessage = val
+	case "Host":
+		r.Host = val
+	case "InternalHost":
+		r.InternalHost = val
+	case "RemoteAddr":
+		r.RemoteAddr = val
+	case "RemoteHost":
+		r.RemoteHost = val
+	case "RemoteUser":
+		r.RemoteUser = val
+	case "RemoteUserAgent":
+		r.RemoteUserAgent = val
+	case "RemoteCity":
+		r.RemoteCity = val
+	case "RemoteCountry":
+		r.RemoteCountry = val
+	case "RemoteLat":
+		r.RemoteLat, _ = strconv.ParseFloat(val, 64)
+	case "RemoteLon":
+		r.RemoteLon, _ = strconv.ParseFloat(val, 64)
+	case "Bbox":
+		r.Bbox = val
+	case "Resources", "ResourcesList":
+		// Resources is "[a, b]"; ResourcesList is "a, b". Either way,
+		// split on comma after stripping the optional brackets.
+		s := strings.TrimSpace(val)
+		s = strings.TrimPrefix(s, "[")
+		s = strings.TrimSuffix(s, "]")
+		parts := strings.Split(s, ",")
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				r.Resources = append(r.Resources, p)
+			}
+		}
+	case "BodyContentLength":
+		r.BodyContentLength, _ = strconv.ParseInt(val, 10, 64)
+	case "BodyContentType":
+		r.BodyContentType = val
+	case "BodyAsString":
+		r.BodyAsString = val
+	case "HttpReferer":
+		r.HTTPReferer = val
+	case "CacheResult":
+		r.CacheResult = val
+	case "MissReason":
+		r.MissReason = val
+	}
+}

--- a/v2/rest/monitor/monitor_integration_test.go
+++ b/v2/rest/monitor/monitor_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package monitor_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hishamkaram/geoserver/v2/internal/testenv"
+	"github.com/hishamkaram/geoserver/v2/rest/monitor"
+)
+
+// TestMonitor_List_Integration drives a non-empty audit log: every
+// REST call we make against GeoServer is itself recorded by the
+// monitor, so by the time we ask for the list there is at least one
+// entry — including possibly this very call.
+func TestMonitor_List_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	// Trigger at least one request so the audit log has data even
+	// on a freshly started stack. About.Version is cheap.
+	if _, err := c.About.Version(ctx); err != nil {
+		t.Fatalf("warm-up About.Version: %v", err)
+	}
+
+	got, err := c.Monitor.List(ctx, monitor.ListOptions{Count: 5})
+	if err != nil {
+		t.Fatalf("Monitor.List: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one audit-log entry, got empty list")
+	}
+	for i, r := range got {
+		if r.ID == 0 {
+			t.Errorf("row[%d] has zero ID: %+v", i, r)
+		}
+	}
+}
+
+// TestMonitor_ListRaw_Integration verifies the streaming path works
+// — useful for callers integrating with reporting pipelines.
+func TestMonitor_ListRaw_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	rc, err := c.Monitor.ListRaw(ctx, monitor.ListOptions{Count: 1})
+	if err != nil {
+		t.Fatalf("Monitor.ListRaw: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatal("empty CSV body")
+	}
+}
+
+// TestMonitor_Get_Integration fetches a known-existing audit row by
+// ID. It first lists to find a real ID rather than guessing.
+func TestMonitor_Get_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	if _, err := c.About.Version(ctx); err != nil {
+		t.Fatalf("warm-up: %v", err)
+	}
+
+	rows, err := c.Monitor.List(ctx, monitor.ListOptions{Count: 1, Order: "Id;DESC"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Skip("no audit entries available; skipping Get round-trip")
+	}
+	id := rows[0].ID
+	got, err := c.Monitor.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get(%d): %v", id, err)
+	}
+	if got.ID != id {
+		t.Errorf("got.ID = %d, want %d", got.ID, id)
+	}
+}
+
+// TestMonitor_List_FieldsFilter exercises the fields query parameter
+// — a stricter projection than "all fields". Upstream parser only
+// accepts a single column name today (see [monitor.ListOptions.Fields]
+// godoc); this test honors that constraint.
+func TestMonitor_List_FieldsFilter_Integration(t *testing.T) {
+	c := testenv.NewClient(t)
+	ctx := testenv.Context(t)
+
+	if _, err := c.About.Version(ctx); err != nil {
+		t.Fatalf("warm-up: %v", err)
+	}
+
+	rows, err := c.Monitor.List(ctx, monitor.ListOptions{
+		Fields: []string{"Id"},
+		Count:  3,
+	})
+	if err != nil {
+		t.Fatalf("List with fields: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == 0 {
+			t.Errorf("expected non-zero ID with field projection: %+v", r)
+		}
+	}
+}

--- a/v2/rest/monitor/monitor_test.go
+++ b/v2/rest/monitor/monitor_test.go
@@ -1,0 +1,167 @@
+package monitor_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+	"github.com/hishamkaram/geoserver/v2/rest/monitor"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *geoserver.Client {
+	t.Helper()
+	c, err := geoserver.New(srv.URL,
+		geoserver.WithBasicAuth("admin", "geoserver"),
+		geoserver.WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+const sampleCSV = `Id,Path,Service,Operation,HttpMethod,QueryString,Category,StartTime,EndTime,TotalTime,Status,ResponseStatus,ResponseLength,RemoteAddr,RemoteUser,Resources
+1,/rest/about/version.json,,,GET,,REST,2026-04-23T16:16:44.000,2026-04-23T16:16:44.025,25,FINISHED,200,300,127.0.0.1,admin,
+2,/topp/wms,WMS,GetMap,GET,service=WMS,OWS,2026-04-23T16:17:01.500,2026-04-23T16:17:01.700,200,FINISHED,200,12345,10.0.0.5,,"[topp:states]"
+`
+
+func TestList_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/monitor/requests.csv" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/csv")
+		_, _ = io.WriteString(w, sampleCSV)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Monitor.List(context.Background(), monitor.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	r0 := got[0]
+	if r0.ID != 1 || r0.Path != "/rest/about/version.json" || r0.Status != "FINISHED" || r0.ResponseStatus != 200 || r0.RemoteUser != "admin" {
+		t.Errorf("row[0] = %+v", r0)
+	}
+	if r0.StartTime.IsZero() || r0.EndTime.IsZero() {
+		t.Errorf("row[0] times zero: %+v", r0)
+	}
+	r1 := got[1]
+	if r1.Service != "WMS" || r1.Operation != "GetMap" || r1.TotalTime != 200 || len(r1.Resources) != 1 || r1.Resources[0] != "topp:states" {
+		t.Errorf("row[1] = %+v", r1)
+	}
+}
+
+func TestList_QueryParameters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("from") != "2026-04-23" {
+			t.Errorf("from = %q", q.Get("from"))
+		}
+		if q.Get("to") != "2026-04-24" {
+			t.Errorf("to = %q", q.Get("to"))
+		}
+		if q.Get("filter") != "service:EQ:WMS" {
+			t.Errorf("filter = %q", q.Get("filter"))
+		}
+		if q.Get("count") != "10" {
+			t.Errorf("count = %q", q.Get("count"))
+		}
+		if q.Get("fields") != "Id,Path" {
+			t.Errorf("fields = %q", q.Get("fields"))
+		}
+		if q.Get("live") != "false" {
+			t.Errorf("live = %q", q.Get("live"))
+		}
+		_, _ = io.WriteString(w, "Id,Path\n")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	live := false
+	_, err := c.Monitor.List(context.Background(), monitor.ListOptions{
+		From: "2026-04-23", To: "2026-04-24",
+		Filter: "service:EQ:WMS",
+		Count:  10,
+		Fields: []string{"Id", "Path"},
+		Live:   &live,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestGet_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/monitor/requests/42.csv" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, "Id,Path\n42,/rest/test\n")
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.Monitor.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != 42 || got.Path != "/rest/test" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestGet_RejectsNonPositive(t *testing.T) {
+	c := newTestClient(t, httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit; got %s %s", r.Method, r.URL.Path)
+	})))
+	if _, err := c.Monitor.Get(context.Background(), 0); err == nil {
+		t.Error("expected error for id=0")
+	}
+	if _, err := c.Monitor.Get(context.Background(), -1); err == nil {
+		t.Error("expected error for id=-1")
+	}
+}
+
+func TestList_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Monitor.List(context.Background(), monitor.ListOptions{})
+	if !errors.Is(err, geoserver.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound (extension absent), got %v", err)
+	}
+}
+
+func TestListRaw_StreamPassThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, sampleCSV)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	rc, err := c.Monitor.ListRaw(context.Background(), monitor.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListRaw: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.HasPrefix(string(body), "Id,Path") {
+		t.Errorf("body did not start with header; got %q", body[:50])
+	}
+}


### PR DESCRIPTION
## Summary

Two parts:

1. **Docker image** — bake `gs-monitor` plugin in alongside the existing `gs-importer` bake-in, so CI exercises the full `c.Monitor` surface against a real server on both 2.27.4 LTS and 2.28.0 stable.
2. **`v2/rest/monitor` package** — read-only access to GeoServer's request audit log served by the `gs-monitor` extension at `/rest/monitor/requests`.
   - `c.Monitor.List(ctx, ListOptions) → []Request` decodes the CSV wire form into typed structs covering the daily-driver columns.
   - `c.Monitor.ListRaw` returns the raw CSV `io.ReadCloser` for streaming-pipeline use cases.
   - `c.Monitor.Get(ctx, id)` for a single audit entry.
   - `ListOptions`: `From` / `To`, `Filter` (`attributeName:OP:value`), `Order`, `Offset` / `Count`, `Live`, `Fields`.

## Wire-quirks (from local probing)

- Endpoint serves CSV / Excel / ZIP / HTML — **no JSON**. SDK fetches CSV and decodes via `encoding/csv` into typed `Request` values.
- `fields` query parameter accepts only **one** column today despite upstream docs claiming comma-separated. Multi-column projection trips `500 "No such property 'Foo,Bar' for object Request"`. Documented on `ListOptions.Fields` godoc.

## Test plan

- [x] Unit tests (CSV-parsing happy path, query-parameter assertions, empty-id rejection, `ErrNotFound` sentinel mapping, raw-stream pass-through).
- [x] Integration tests against `make compose-up`: `List` + `ListRaw` + `Get(id)` + single-field projection. **All pass locally** against GeoServer 2.28.0 with the monitor extension baked in.
- [x] `make lint` — 0 issues.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.