### PR TITLE
chore(v2): graduate to v2.0.0-beta.3; document XSLT extension status

### DIFF
--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -1,6 +1,6 @@
 # v2 — tier-2 gap-analysis backlog
 
-The v2 client closes every "everyone needs it" REST API surface plus the original tier-2 backlog as of `v2.0.0-beta.2` (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the **complete shipped tier-2 surface** plus the leftover narrow-audience endpoints not on the original list — each tractable as its own follow-up PR.
+The v2 client closes every "everyone needs it" REST API surface, the original tier-2 backlog, and the longer-tail surfaces (fonts, password rotation, GWC additions, monitoring) as of `v2.0.0-beta.3` (see [`../v2/CHANGELOG.md`](../v2/CHANGELOG.md)). What's documented here is the **complete shipped surface** plus the few extension-gated endpoints whose extensions aren't packaged in stable releases for 2.27 / 2.28.
 
 Each entry below is independently tractable as its own follow-up PR. None block `v2.0.0`. Each is grounded in the official GeoServer REST docs (`https://docs.geoserver.org/latest/en/user/rest/`) and reuses the existing v2 plumbing (`internal/transport.BuildURL`, `transport.DoJSON` / `DoXML` / `DoRaw`, the per-resource `Core` interface, the `*Client → InWorkspace(ws) → *WorkspaceClient` scoping pattern). PRs welcome — open an issue first if the work touches a new wire-format quirk so the design conversation can happen in public.
 

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.0.0-beta.3] — 2026-05-04
+
+Third beta. Adds four longer-tail surfaces on top of beta.2's tier-2-complete state — fonts, master/self password rotation, GWC global config + gridsets + mass-truncate, and the monitoring (request audit log) extension. The dev/test docker image now bakes the `gs-monitor` plugin in alongside `gs-importer` so CI exercises the full audit-log surface against real GeoServer 2.27.4 LTS and 2.28.0 stable. No breaking changes from `beta.2`; existing callers can `go get @v2.0.0-beta.3` and recompile. Public API stays frozen for review through the beta line.
+
+### Documented — WFS XSLT transforms (`c.WFSTransforms`) extension status
+
+The `gs-xslt-wfs` extension that the beta.2 `c.WFSTransforms` surface targets was removed from upstream GeoServer in 2.24 and is NOT shipped — neither in stable nor in community / SNAPSHOT channels — for any 2.24+ release, including the supported 2.27 LTS and 2.28 stable lines. The upstream OpenAPI YAML still documents the surface. The package godoc now flags this clearly: the surface is preserved for custom builds and pre-2.24 deployments only; CI verifies the "extension absent → ErrNotFound" path.
+
 ### Added — Fonts list
 
 Closes the fonts longer-tail item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Sanity-check before publishing styles that reference specific fonts — typos would otherwise surface as silent label-rendering fallbacks.

--- a/v2/README.md
+++ b/v2/README.md
@@ -6,21 +6,21 @@
 [![License: MIT](https://img.shields.io/github/license/hishamkaram/geoserver.svg)](../LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/hishamkaram/geoserver?include_prereleases&sort=semver)](https://github.com/hishamkaram/geoserver/releases)
 
-> 🧪 **`v2.0.0-beta.2` is published — public API frozen for review; the original tier-2 backlog is closed.** v2 covers the gap-analysis plan's "everyone needs it" surface plus every tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md). Coverage at `master`:
+> 🧪 **`v2.0.0-beta.3` is published — public API frozen for review.** v2 covers the gap-analysis plan's "everyone needs it" surface, every tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md), plus four longer-tail surfaces (fonts, password rotation, GWC additions, monitoring). Coverage at `master`:
 >
-> - **Catalog**: workspaces, datastores, feature types, coverage stores, coverages, layers (incl. add-style sub-resource), layer groups, styles, namespaces.
+> - **Catalog**: workspaces, datastores, feature types, coverage stores, coverages, layers (incl. add-style sub-resource), layer groups, styles, namespaces. **Fonts**: `c.Fonts.List` (JVM-exposed font families).
 > - **Settings**: global `c.Settings` + per-service `c.Services.WMS()`/`WFS()`/`WCS()`/`WMTS()` (global + per-workspace overrides).
-> - **System**: `c.System.Reload` and `ResetCache`. **About**: ping, version, manifests, system status. **Logging**: `c.Logging.Get`/`Update` for runtime log-level changes.
-> - **Security**: users, groups, roles, role-user assignment + ACL `Layers()`/`Services()`/`REST()`/`Catalog()` + auth providers / filters / filter chains + URL checks (SSRF allow-list).
+> - **System**: `c.System.Reload` and `ResetCache`. **About**: ping, version, manifests, system status. **Logging**: `c.Logging.Get`/`Update` for runtime log-level changes. **Monitoring** (`gs-monitor` ext baked into dev/test image): `c.Monitor.List`/`ListRaw`/`Get` for the request audit log.
+> - **Security**: users, groups, roles, role-user assignment + ACL `Layers()`/`Services()`/`REST()`/`Catalog()` + auth providers / filters / filter chains + URL checks (SSRF allow-list) + `c.Security.MasterPassword` (keystore) + `c.Security.SelfPassword` (auth'd user rotation).
 > - **Resources**: `c.Resources` Get / List / Stat / Exists / Put / Move / Copy / Delete against `/rest/resource/{path}` — read or write any file in the data dir. **Templates (FTL)**: `c.Templates` global + six fluent scopes.
 > - **File-upload publishing**: `c.Datastores.UploadFile` (Shapefile / GeoPackage / external) and `c.CoverageStores.UploadFile` + `HarvestGranule` (GeoTIFF / ImageMosaic / mosaic granules).
 > - **Mosaic granules**: `c.Coverages.InWorkspace(ws).InCoverageStore(cs).Granules(cov)` — Schema / List / Get / Delete / DeleteByFilter for image-mosaic / structured coverages.
 > - **Cascaded stores + layers**: `c.WMSStores` / `c.WMSLayers` / `c.WMTSStores` / `c.WMTSLayers` for federation / proxy setups.
-> - **GeoWebCache**: `c.GWC.Layers()` (cache config), `Seed()` (seed/reseed/truncate), `DiskQuota()`.
+> - **GeoWebCache**: `c.GWC.Layers()` (cache config), `Seed()` (seed/reseed/truncate), `DiskQuota()`, `Global()` (singleton config), `Gridsets()` (named tile-matrix sets), `MassTruncate()` (bulk cache invalidation).
 > - **Importer extension**: `c.Imports` (sessions + tasks). The dev/test docker image bakes the plugin in for CI integration coverage.
-> - **OWS**: `c.WMS` / `c.WFS` / `c.WCS` GetCapabilities; WFS `DescribeFeatureType`; WCS `DescribeCoverage`. **WFS XSLT transforms**: `c.WFSTransforms` (requires the `gs-xslt-wfs` extension).
+> - **OWS**: `c.WMS` / `c.WFS` / `c.WCS` GetCapabilities; WFS `DescribeFeatureType`; WCS `DescribeCoverage`. **WFS XSLT transforms**: `c.WFSTransforms` — surface preserved for legacy / custom builds; the `gs-xslt-wfs` extension was removed from upstream in 2.24 and is not shipped for 2.27 / 2.28.
 >
-> Surface is locked — breaking changes will not land in subsequent betas without a strong reason. v1.x remains the recommended import for production code. Longer-tail endpoints (CRS list, fonts, monitoring, master password, OSEO settings, etc. — see [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md)) can be added without breaking shape.
+> Surface is locked — breaking changes will not land in subsequent betas without a strong reason. v1.x remains the recommended import for production code.
 
 This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).
 
@@ -37,7 +37,7 @@ This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independent
 ## Install
 
 ```bash
-go get github.com/hishamkaram/geoserver/v2@v2.0.0-beta.2
+go get github.com/hishamkaram/geoserver/v2@v2.0.0-beta.3
 ```
 
 ```go
@@ -202,7 +202,7 @@ Run any with `go run ./v2/examples/<name>` against a `make compose-up` stack, or
 | ACL — service / REST / catalog rules | partial | **ported** in v2 (`c.ACL.Services()`, `c.ACL.REST()`, `c.ACL.Catalog()`) — REST DELETE has documented firewall caveat |
 | Resource API (data-dir byte-stream access) | (none) | **new** in v2 (`c.Resources` Get/List/Stat/Exists/Put/Move/Copy/Delete) |
 | File-upload publishing on stores | (none) | **new** in v2 (`c.Datastores.UploadFile`, `c.CoverageStores.UploadFile` / `HarvestGranule`) |
-| GeoWebCache (cache config + seed + diskquota) | (none) | **new** in v2 (`c.GWC.Layers()`, `Seed()`, `DiskQuota()`) |
+| GeoWebCache (cache config + seed + diskquota) | (none) | **new** in v2 (`c.GWC.Layers()`, `Seed()`, `DiskQuota()`, `Global()`, `Gridsets()`, `MassTruncate()`) |
 | Importer extension (batch ingest) | (none) | **new** in v2 (`c.Imports`; dev/test docker image bakes the plugin in) |
 | WMS GetCapabilities | full | **ported** (`c.WMS.GetCapabilities` + `InWorkspace`) |
 | WFS GetCapabilities + DescribeFeatureType | (none — WMS only) | **new** in v2 (`c.WFS.GetCapabilities`, `DescribeFeatureType`) |
@@ -212,11 +212,14 @@ Run any with `go run ./v2/examples/<name>` against a `make compose-up` stack, or
 | Auth providers / filters / chains | (none) | **new** in v2 (`c.Security.AuthProviders`, `AuthFilters`, `FilterChains`) |
 | URL checks (SSRF allow-list) | (none) | **new** in v2 (`c.URLChecks`) |
 | Cascaded WMS / WMTS stores + layers | (none) | **new** in v2 (`c.WMSStores`, `c.WMSLayers`, `c.WMTSStores`, `c.WMTSLayers`) |
-| WFS XSLT transforms | (none) | **new** in v2 (`c.WFSTransforms`; requires the `gs-xslt-wfs` extension on the server) |
+| WFS XSLT transforms | (none) | **new** in v2 (`c.WFSTransforms`) — surface preserved for legacy / custom builds; the `gs-xslt-wfs` extension was removed from upstream in 2.24 and is not shipped for 2.27 / 2.28 |
 | About — manifests + system status | (none) | **new** in v2 (`c.About.Manifests`, `c.About.SystemStatus`) |
 | Logging (runtime log-level config) | (none) | **new** in v2 (`c.Logging.Get` / `Update`) |
+| Fonts list | (none) | **new** in v2 (`c.Fonts.List`) |
+| Master password & self password | (none) | **new** in v2 (`c.Security.MasterPassword.Get`/`Update`, `c.Security.SelfPassword.Change`) |
+| Monitoring (request audit log) | (none) | **new** in v2 (`c.Monitor.List`/`ListRaw`/`Get`; dev/test docker image bakes the `gs-monitor` plugin in) |
 
-See [`../ROADMAP.md`](../ROADMAP.md) for the milestone checklist. The original tier-2 gap-analysis backlog is closed; remaining longer-tail endpoints (CRS list, fonts, monitoring, master password, OSEO settings, individual filter-chain editing) are tracked in [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md) — each tractable as its own follow-up PR.
+See [`../ROADMAP.md`](../ROADMAP.md) for the milestone checklist. The original tier-2 gap-analysis backlog is closed and the longer-tail surfaces above are also done; remaining longer-tail endpoints (`opensearch-eo` is community / SNAPSHOT-only on 2.27 / 2.28; revisit when stable) are tracked in [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md).
 
 ## Contributing to v2
 

--- a/v2/rest/wfstransforms/wfstransforms.go
+++ b/v2/rest/wfstransforms/wfstransforms.go
@@ -3,9 +3,32 @@
 //
 // Transforms let WFS-T producers register XSLT files that re-shape
 // GetFeature output into custom formats (HTML reports, KML,
-// site-specific XML schemas, etc.). The endpoint is part of the
-// `gs-xslt-wfs` extension and is NOT installed in default GeoServer
-// distributions — calls against an unequipped server return 404.
+// site-specific XML schemas, etc.).
+//
+// # Extension status
+//
+// The endpoint was originally part of the `gs-xslt-wfs` extension.
+// That extension was removed from upstream GeoServer in 2.24 and is
+// NOT shipped — neither in stable nor in community / SNAPSHOT
+// channels — for any 2.24+ release, including the supported 2.27 LTS
+// and 2.28 stable lines. The upstream OpenAPI YAML still documents
+// the surface, but a fresh install of any supported GeoServer
+// version returns 404 for every method on this client.
+//
+// This package is preserved for:
+//   - Custom GeoServer builds that re-introduce the xslt-wfs module.
+//   - Pre-2.24 deployments that still ship the extension.
+//   - Forward-compatibility if the upstream module is restored.
+//
+// The unit tests verify the wire format (POST envelope, body
+// encoding, header handling) without requiring the extension. The
+// integration test asserts only the "extension absent → ErrNotFound"
+// path against the standard dev/test docker image; for a full CRUD
+// round-trip against a custom-built server with the extension
+// reinstated, set GEOSERVER_HAS_XSLT_WFS=1 when running
+// integration tests.
+//
+// # Surface
 //
 // The flow is two-step:
 //
@@ -18,7 +41,8 @@
 //
 // Or, in a single shot, [Client.CreateWithXSLT] POSTs the XSLT
 // body directly with the metadata fields encoded as query
-// parameters. Either is supported by the upstream API.
+// parameters. Either is supported by the upstream API (when the
+// extension is present).
 package wfstransforms
 
 import (


### PR DESCRIPTION
## Summary

- Third beta. Adds four longer-tail surfaces on top of beta.2's tier-2-complete state — Fonts, MasterPassword + SelfPassword, GWC additions (Global / Gridsets / MassTruncate), and Monitor (request audit log).
- Dev/test docker image now bakes `gs-monitor` in alongside `gs-importer`. CI exercises the full audit-log surface against real GeoServer 2.27.4 LTS and 2.28.0 stable.
- Documents the `c.WFSTransforms` extension status: the `gs-xslt-wfs` extension was removed from upstream GeoServer in 2.24 and is **not shipped** — stable, ext, or community / SNAPSHOT — for any 2.24+ release, including the supported 2.27 LTS and 2.28 stable lines. The surface is preserved for custom builds and pre-2.24 deployments only.

No breaking changes from `beta.2`. Existing callers can `go get @v2.0.0-beta.3` and recompile.

## Changes

- `v2/CHANGELOG.md`: graduate `[Unreleased]` → `[2.0.0-beta.3]` dated 2026-05-04.
- `v2/README.md`: bump install pin; refresh banner + resource-status table for the four new sub-clients; soften the WFS XSLT row to flag legacy / custom-build status.
- `v2/rest/wfstransforms/wfstransforms.go`: expanded godoc with a `# Extension status` section.
- `docs/v2-tier2-gaps.md`: refreshed intro to reflect the longer-tail surfaces are now done.

## Test plan

- [x] `make lint` — 0 issues.
- [x] `cd v2 && go test ./...` — all v2 unit tests pass.
- [x] `cd v2 && go test -tags=integration ./...` — full integration suite passes locally against GeoServer 2.28.0.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.
- [x] Tag `v2.0.0-beta.3` against the resulting master commit after merge.