### PR TITLE
chore(v2): graduate to v2.0.0 (final stable)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-05-04
+
+First stable release. The public API has been frozen for review since `beta.1`; there are no surface changes between `beta.3` and `2.0.0`. The module path remains `github.com/hishamkaram/geoserver/v2` and will not change in v2.x.
+
+The full feature set is described under earlier `[2.0.0-alpha.*]` and `[2.0.0-beta.*]` stanzas below — every "everyone needs it" REST surface, the original tier-2 backlog, and four longer-tail surfaces (fonts, master + self password rotation, GWC additions, monitoring with the `gs-monitor` extension baked into the dev/test docker image).
+
+Existing callers on `beta.3` can `go get @v2.0.0` and recompile without changes.
+
 ## [2.0.0-beta.3] — 2026-05-04
 
 Third beta. Adds four longer-tail surfaces on top of beta.2's tier-2-complete state — fonts, master/self password rotation, GWC global config + gridsets + mass-truncate, and the monitoring (request audit log) extension. The dev/test docker image now bakes the `gs-monitor` plugin in alongside `gs-importer` so CI exercises the full audit-log surface against real GeoServer 2.27.4 LTS and 2.28.0 stable. No breaking changes from `beta.2`; existing callers can `go get @v2.0.0-beta.3` and recompile. Public API stays frozen for review through the beta line.

--- a/v2/README.md
+++ b/v2/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/github/license/hishamkaram/geoserver.svg)](../LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/hishamkaram/geoserver?include_prereleases&sort=semver)](https://github.com/hishamkaram/geoserver/releases)
 
-> 🧪 **`v2.0.0-beta.3` is published — public API frozen for review.** v2 covers the gap-analysis plan's "everyone needs it" surface, every tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md), plus four longer-tail surfaces (fonts, password rotation, GWC additions, monitoring). Coverage at `master`:
+> 🚀 **`v2.0.0` is published — first stable release.** v2 covers the gap-analysis plan's "everyone needs it" surface, every tier-2 item from [`../docs/v2-tier2-gaps.md`](../docs/v2-tier2-gaps.md), plus four longer-tail surfaces (fonts, password rotation, GWC additions, monitoring). Public API is locked; no breaking changes will land in v2.x. Coverage:
 >
 > - **Catalog**: workspaces, datastores, feature types, coverage stores, coverages, layers (incl. add-style sub-resource), layer groups, styles, namespaces. **Fonts**: `c.Fonts.List` (JVM-exposed font families).
 > - **Settings**: global `c.Settings` + per-service `c.Services.WMS()`/`WFS()`/`WCS()`/`WMTS()` (global + per-workspace overrides).
@@ -20,7 +20,7 @@
 > - **Importer extension**: `c.Imports` (sessions + tasks). The dev/test docker image bakes the plugin in for CI integration coverage.
 > - **OWS**: `c.WMS` / `c.WFS` / `c.WCS` GetCapabilities; WFS `DescribeFeatureType`; WCS `DescribeCoverage`. **WFS XSLT transforms**: `c.WFSTransforms` — surface preserved for legacy / custom builds; the `gs-xslt-wfs` extension was removed from upstream in 2.24 and is not shipped for 2.27 / 2.28.
 >
-> Surface is locked — breaking changes will not land in subsequent betas without a strong reason. v1.x remains the recommended import for production code.
+> Surface is locked — no breaking changes will land in v2.x. v1.x is end-of-feature; security patches only on the `release/v1` branch (post-restructure). New integrations should target v2.
 
 This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags).
 
@@ -37,14 +37,14 @@ This module ships with its own `go.mod` at `/v2/`; v1 and v2 release independent
 ## Install
 
 ```bash
-go get github.com/hishamkaram/geoserver/v2@v2.0.0-beta.3
+go get github.com/hishamkaram/geoserver/v2@v2.0.0
 ```
 
 ```go
 import geoserver "github.com/hishamkaram/geoserver/v2"
 ```
 
-> v2 is a separate Go module under `/v2/`; v1 and v2 release independently. Public API may still refine before `v2.0.0` based on early-adopter feedback. For stable production use today, stay on the [v1 line](../README.md).
+> v2 is a separate Go module under `/v2/`; v1 and v2 release independently (`v1.x.y` / `v2.x.y` tags). v2 is the recommended line for new integrations.
 
 Requirements: Go 1.25+. Tested against GeoServer 2.27.4 LTS and 2.28.0 stable on every PR.
 

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -14,14 +14,12 @@
 // extension (batch ingest), and the OWS read-only trio
 // (GetCapabilities + DescribeFeatureType + DescribeCoverage).
 //
-// Public API is frozen for review through the v2.0.0-beta.* line —
-// breaking changes will not land without a strong reason. The latest
-// published preview tag is on the v2.0.0-beta.* line; see the v2 README
-// for the current pin. Until v2 reaches v2.0.0, the v1 line remains
-// the recommended import for production:
+// Public API is stable as of v2.0.0 — no breaking changes will land
+// in v2.x. v2 is the recommended line for new integrations; v1 is
+// end-of-feature on the release/v1 branch (security patches only):
 //
-//	import "github.com/hishamkaram/geoserver"        // v1: stable, full surface
-//	import "github.com/hishamkaram/geoserver/v2"     // v2: preview
+//	import "github.com/hishamkaram/geoserver/v2"     // v2: stable
+//	import "github.com/hishamkaram/geoserver"        // v1: end-of-feature
 //
 // See ../ROADMAP.md for the v2 milestones and ../docs/migration-v1-to-v2.md
 // for the v1 → v2 migration guide.


### PR DESCRIPTION
## Summary

First stable release of v2. Public API has been frozen for review since `beta.1`; no surface changes between `beta.3` and `2.0.0`. Module path remains `github.com/hishamkaram/geoserver/v2` and will not change in v2.x.

- `v2/CHANGELOG.md`: graduate `[Unreleased]` → `[2.0.0]` dated 2026-05-04.
- `v2/README.md`: bump install pin to `@v2.0.0`; banner from "frozen for review" to "first stable release"; soften the v1 callout (v1 is end-of-feature; v2 is the recommended line).
- `v2/doc.go`: refresh status block.

The repo restructure (promote v2 to root, archive v1 to `release/v1`) follows in a separate PR; this tag rides the proven `/v2/` subdirectory release path that `beta.{1,2,3}` already exercised.

## Test plan

- [x] `make lint` — 0 issues.
- [x] `cd v2 && go test -race -short ./...` — all unit tests pass.
- [x] `cd v2 && go test -tags=integration -timeout=15m ./...` — full integration suite passes locally against GeoServer 2.28.0.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.
- [x] After merge, tag annotated `v2.0.0` from master HEAD; `release.yml` auto-publishes the GitHub release with the `[2.0.0]` stanza body.