### PR TITLE
chore: scorecard hardening (scorecard.yml + SHA-pinned actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.25"
           check-latest: true
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.12.1
           args: --timeout=5m
@@ -39,8 +39,8 @@ jobs:
       matrix:
         go: ["1.25"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
@@ -54,13 +54,13 @@ jobs:
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -n 1
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-go${{ matrix.go }}
           path: coverage.out
           retention-days: 14
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695  # v5.5.4
         with:
           files: ./coverage.out
           flags: v2
@@ -71,8 +71,8 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.25"
           check-latest: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,23 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.25"
           check-latest: true
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
         with:
           languages: go
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
         with:
           category: /language:go

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,9 +51,9 @@ jobs:
       GEOSERVER_USER: admin
       GEOSERVER_PASS: geoserver
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.25"
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.25"
           check-latest: true
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           body_path: /tmp/release-notes.md
           generate_release_notes: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: Scorecard supply-chain security
+
+# Runs the OpenSSF Scorecard analysis on every push to master and once a
+# week. Publishes results to api.scorecard.dev (which deps.dev pulls from)
+# and uploads a SARIF report into the Security tab.
+#
+# Without this workflow, scorecard.dev only re-scans periodically (and as
+# of 2026-04-27 had stale data from a 2023 commit). With this workflow,
+# the score reflects current master HEAD on every push.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "37 4 * * 1"  # Mondays 04:37 UTC
+  push:
+    branches: [master]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF
+      id-token: write          # OIDC for publish_results: true (v2 requirement)
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+          # To enable the Branch-Protection check, create a fine-grained
+          # PAT with `repo > Administration: read` and store it as the
+          # SCORECARD_TOKEN secret, then uncomment the line below. See:
+          # https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Raises the OpenSSF Scorecard composite from **2.1 → ~6.8–7.5** (expected). The current score reflects a 2026-04-27 scan against commit `b9ff6dde` (Feb 2023, before the v1 revival), when master genuinely had no workflows, no SECURITY.md, and no commits in 90 days. 73 commits have landed since.

This PR addresses the gaps that don't auto-correct from a fresh rescan:

### Changes

- **`.github/workflows/scorecard.yml` (NEW):** runs `ossf/scorecard-action` on every push to master + weekly schedule. `publish_results: true` POSTs results to `api.scorecard.dev` (which deps.dev pulls from) via OIDC. SARIF uploads to the Security tab.
- **All 23 GitHub Action references** in `.github/workflows/` are pinned to immutable SHA-1, with a trailing version comment so Dependabot's `github-actions` ecosystem (already the `gha` group in `.github/dependabot.yml`) auto-bumps both the SHA and the comment when upstream releases.
- **Repo-level default workflow permissions** flipped from `write` to `read` via `gh api PUT` (admin step done outside the PR; verified post-merge). Each workflow already declares its own `permissions:` block, so this default change does not break CI.

### Expected check movement (after merge + 24-48h)

| Check | Before | After | How |
|---|---|---|---|
| Maintained | 0 | 10 | rescan |
| Dangerous-Workflow | -1 | 10 | rescan (workflows now exist) |
| Token-Permissions | -1 | 9-10 | rescan + repo default flipped |
| SAST | 0 | 7-10 | rescan (codeql.yml exists) |
| Security-Policy | 0 | 6-10 | rescan (SECURITY.md exists) |
| Pinned-Dependencies | 0 | 10 | this PR |
| Signed-Releases | -1 | 3-8 | rescan (releases exist) |
| Branch-Protection | -1 | -1 (without PAT) / 6 (with PAT) | needs fine-grained PAT |
| Code-Review | 0 | 0-1 | solo maintainer; can't fix |
| Packaging | -1 | -1 (likely) | unscoreable for Go libs |

### Stretch goal documented in scorecard.yml

A fine-grained PAT with `repo > Administration: read` permission, stored as `SCORECARD_TOKEN`, would unlock Branch-Protection (default `GITHUB_TOKEN` can't read classic branch protection rules per the upstream error message). Optional; the maintainer opts in by uncommenting the `repo_token:` line.

## Test plan

- [x] `make lint` — 0 issues.
- [x] `go build ./...` — clean.
- [x] `go test -race -short ./...` — all unit tests pass.
- [x] All 5 workflow YAML files parse (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Repo-level default permission flipped — verified `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.

## Out of scope (separate PRs / user actions)

- SLSA provenance in `release.yml` — substantive refactor.
- CII Best Practices badge — manual signup at `bestpractices.coreinfrastructure.org`.
- Required-PR-review on master — solo-maintainer constraint.
- `FuzzBuildURL` — landing as a separate PR (different concern: code change vs workflow YAML).