### PR TITLE
chore(ci): tighten Token-Permissions + Pinned-Dependencies (Scorecard 7.6 → ~8.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,5 @@ jobs:
           cache: true
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,16 +8,17 @@ on:
   schedule:
     - cron: "27 4 * * 1"
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: read-all
 
 jobs:
   analyze:
     name: Analyze (Go)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # softprops/action-gh-release needs this to publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@
 # target and is tracked separately for v2 of this client library.
 
 ARG TOMCAT_TAG=9-jdk17-temurin
-FROM tomcat:${TOMCAT_TAG}
+ARG TOMCAT_DIGEST=sha256:57536fa59652ece9df8d744749fa5a424136388f2eb934ddc8741918a51afd56
+FROM tomcat:${TOMCAT_TAG}@${TOMCAT_DIGEST}
 
 LABEL maintainer="Hesham Karm<hishamwaleedkaram@gmail.com>"
 


### PR DESCRIPTION
## Summary

Follow-up after the 2026-05-04 fresh Scorecard run lifted the composite from **2.1 → 7.6** but flagged two specific remaining gaps:

### Token-Permissions: 0 (workflow-level writes are a hard penalty)

```
Warn: topLevel 'security-events' permission set to 'write': .github/workflows/codeql.yml:14
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release.yml:9
```

Both moved to job-level:
- `codeql.yml`: top-level → `read-all`; `security-events: write` on the `analyze` job.
- `release.yml`: top-level → `read-all`; `contents: write` on the `release` job (with a comment noting `softprops/action-gh-release` needs it).

### Pinned-Dependencies: 7 (two unpinned items)

```
Warn: containerImage not pinned by hash: docker/Dockerfile:9: pin your Docker image by updating tomcat:9-jdk17-temurin to tomcat:9-jdk17-temurin@sha256:57536fa...
Warn: goCommand not pinned by hash: .github/workflows/ci.yml:82
```

- `docker/Dockerfile`: pinned to the digest Scorecard explicitly suggested. Kept `TOMCAT_TAG` arg alongside a new `TOMCAT_DIGEST` arg so future updates bump both.
- `ci.yml`: `go install golang.org/x/vuln/cmd/govulncheck@latest` → `@v1.1.4` (current latest stable; Dependabot's `gomod` ecosystem will bump it on new releases).

## Test plan

- [x] `make lint` — 0 issues.
- [x] `go build ./...`, `go test -race -short ./...` — clean.
- [x] `docker compose build geoserver` — succeeds against the pinned digest.
- [x] CI must pass on both 2.27.4 LTS and 2.28.0 stable before squash-merge.

## Expected score after this PR

Composite **7.6 → ~8.7** (Token-Permissions 0 → 8-10, Pinned-Dependencies 7 → 10).