### PR TITLE
docs+test: lock in race-safety guarantee for v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,10 @@ Each service interface has a parallel `…WithContext` interface (e.g., `Workspa
 
 ## Concurrency
 
-- `*GeoServer` exported fields are **not safe for concurrent mutation.** Construct once with `New(...)` and treat as immutable.
-- Concurrent reads on the same instance are safe.
-- Don't add concurrency hardening (locks, atomic swaps) to v1 — that is a v2 redesign concern.
+- `*Client` is **immutable after `New(...)` returns.** All struct fields are private or pointers to sub-clients set once at construction and never reassigned. Concurrent use across goroutines is safe by design — no caller-side locking required.
+- Same posture for every sub-client (`workspaces.Client`, `datastores.Client`, etc.): they expose methods only, holding a single private `core Core` interface reference.
+- Don't introduce shared mutable state to `clientCore` or any sub-client (caches, counters, request-scoped buffers held as struct fields). If you need per-call state, allocate it inside the method. The race-proof guarantee is verified by `TestClient_ConcurrentRequests` running under `go test -race` in CI.
+- User-supplied transports (`WithHTTPClient`, `WithTransport`) are the caller's responsibility — if their `RoundTripper` mutates shared state, the race lives in their code, not ours.
 
 ## GeoServer version matrix
 

--- a/geoserver_concurrent_test.go
+++ b/geoserver_concurrent_test.go
@@ -1,0 +1,69 @@
+package geoserver_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	geoserver "github.com/hishamkaram/geoserver/v2"
+)
+
+// TestClient_ConcurrentRequests asserts that a single *Client is safe
+// to share across goroutines. Designed to fail under `go test -race`
+// if a future change introduces shared mutable state on Client,
+// clientCore, or any sub-client.
+func TestClient_ConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/rest/about/version":
+			_, _ = w.Write([]byte(`{"about":{"resource":[]}}`))
+		case "/rest/workspaces/topp":
+			_, _ = w.Write([]byte(`{"workspace":{"name":"topp","isolated":false}}`))
+		case "/rest/namespaces/topp":
+			_, _ = w.Write([]byte(`{"namespace":{"prefix":"topp","uri":"http://example.com/topp","isolated":false}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := geoserver.New(srv.URL, geoserver.WithBasicAuth("admin", "geoserver"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const goroutines = 50
+	const callsPer = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			ctx := context.Background()
+			for range callsPer {
+				if err := c.About.Ping(ctx); err != nil {
+					t.Errorf("Ping: %v", err)
+					return
+				}
+				if _, err := c.About.Version(ctx); err != nil {
+					t.Errorf("Version: %v", err)
+					return
+				}
+				if _, err := c.Workspaces.Get(ctx, "topp"); err != nil {
+					t.Errorf("Workspaces.Get: %v", err)
+					return
+				}
+				if _, err := c.Namespaces.Get(ctx, "topp"); err != nil {
+					t.Errorf("Namespaces.Get: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Adds `TestClient_ConcurrentRequests` (`geoserver_concurrent_test.go`) — a hermetic, `httptest`-based stress test that hammers a single `*Client` from 50 goroutines × 20 calls × 4 sub-client paths (`About.Ping`, `About.Version`, `Workspaces.Get`, `Namespaces.Get`). Runs under CI's existing `go test -race -short` and will fail if a future change reintroduces shared mutable state on `Client`, `clientCore`, or any sub-client.
- Refreshes `CLAUDE.md` Concurrency section. The guidance described the v1-era `*GeoServer` struct that no longer exists; the v2 client is `*Client` with private fields and a construction-then-immutable design. The new wording matches what the code actually does and references the test as the verification mechanism.

## Why

The user asked whether the project is race-proof. After fact-finding (zero `sync.*`/`atomic.*`/goroutines in non-test library code; round-trippers clone requests before mutating headers; closures capture auth credentials by value; `coreAdapter` holds an immutable `*clientCore` pointer), the answer is **yes by design** — but the guarantee was inferred from absence-of-mutation, never demonstrated under the race detector. This PR closes that gap with one cheap test (~2.5s wall-clock) so future regressions surface in CI.

No production code changes. No new dependencies. No locks added.

## Test plan

- [x] `go test -race -run TestClient_ConcurrentRequests .` passes locally
- [x] `make test-unit` (full suite under `-race -short`) passes
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [ ] CI green (Lint, Unit tests Go 1.25, govulncheck, Analyze Go, GeoServer 2.27.4, GeoServer 2.28.0)