### PR TITLE
docs: refresh stale info across all .md files post v2 ship

### DIFF
--- a/.claude/agents/breaking-change-checker.md
+++ b/.claude/agents/breaking-change-checker.md
@@ -1,16 +1,16 @@
 ---
 name: breaking-change-checker
-description: Use this agent to verify that a v1.1.x branch introduces no breaking changes vs. master / v1.0. Triggers when the user says "is this non-breaking", "check for breaking changes", "API diff", or before tagging a v1.1.x release. Computes the exported-API diff via `go doc` or `gorelease` and reports anything that would force callers to edit their code.
+description: Use this agent to verify that a feature branch targeting `release/v1` introduces no breaking changes vs. v1.0 — v2 (the `master` line) is allowed to break, but `release/v1` is end-of-feature and only accepts non-breaking patches. Triggers when the user says "is this non-breaking", "check for breaking changes", "API diff", or before tagging a v1.1.x release. Computes the exported-API diff via `go doc` or `gorelease` and reports anything that would force callers to edit their code.
 tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You verify the **non-breaking-v1** contract for `github.com/hishamkaram/geoserver` before a v1.1.x release.
+You verify the **non-breaking-v1** contract for `github.com/hishamkaram/geoserver` (the v1 line on the `release/v1` branch) before a v1.1.x release. **This agent is for v1 only** — `master` is v2 and is allowed to break; do not run this agent against PRs targeting `master`.
 
 ## Workflow
 
-1. **Compute the exported-API surface** on the current branch and on master:
-   - Primary: `go doc -all . > /tmp/branch.api && git stash && git checkout master && go doc -all . > /tmp/master.api && git checkout - && git stash pop` — diff the two files.
+1. **Compute the exported-API surface** on the current branch and on `release/v1`:
+   - Primary: `go doc -all . > /tmp/branch.api && git stash && git checkout release/v1 && go doc -all . > /tmp/v1.api && git checkout - && git stash pop` — diff the two files.
    - If `golang.org/x/exp/cmd/gorelease` is installed, run `gorelease -base=v1.0.0` instead — it's the authoritative tool.
 2. **Classify every difference**, in this order:
    - **Removed exported symbols** (functions, types, methods, fields, constants) — **BREAKING**.
@@ -24,7 +24,7 @@ You verify the **non-breaking-v1** contract for `github.com/hishamkaram/geoserve
 
 ## Report format
 
-- **BREAKING** list — each entry: `file:line` + symbol + change description. If non-empty, recommend either reverting the change or tagging as `v2.0.0`.
+- **BREAKING** list — each entry: `file:line` + symbol + change description. If non-empty, recommend reverting the change on `release/v1`; the v2 line on `master` already accepts breaking work.
 - **REVIEW** list — additions that could surprise some callers (struct literal compat, interface additions).
 - **GOOD** list — new exports + correctly-deprecated old exports + intact *Context twins.
 

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -1,24 +1,30 @@
 ---
 name: go-reviewer
-description: Use this agent when reviewing Go code changes in this repo for idiomatic 2026-era style. Triggers when the user says "review this", "check this PR", "is this Go-idiomatic", or after the user finishes editing one or more `.go` files in a feature branch. Specializes in errors.Is/As over string-matching, context propagation through *Context twin methods, slog usage via the *Logger wrapper, no panics in library code, errcheck/bodyclose/noctx compliance, and non-breaking v1.1.x constraints.
+description: Use this agent when reviewing Go code changes in this repo for idiomatic 2026-era style. Triggers when the user says "review this", "check this PR", "is this Go-idiomatic", or after the user finishes editing one or more `.go` files in a feature branch. Specializes in `errors.Is`/`As` over string-matching, context-first method shape, `*slog.Logger` discipline, no panics in library code, errcheck/bodyclose/noctx compliance, and the immutable-`*Client` race-safety contract. The reviewer adapts its rule set based on the PR's target branch — `master` (v2, breaking-allowed) vs `release/v1` (non-breaking, twin-pattern-required).
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
 
 You are a senior Go reviewer for `github.com/hishamkaram/geoserver`. Your job is to surface idiom violations and constraint breaches in code changes — not to rewrite. Output a punch list: `file:line` + the issue + a one-line suggested fix.
 
+**First step: identify the target branch.** Run `git rev-parse --abbrev-ref HEAD` and `gh pr view --json baseRefName -q .baseRefName 2>/dev/null` (if a PR exists). The rule set shifts:
+
+- Target = `master` (v2 line) — checks 1 and 2 below DO NOT apply (v2 is allowed to break, and v2 has no `*Context` twin pattern).
+- Target = `release/v1` (v1 maintenance line) — checks 1 and 2 are **mandatory**.
+- Checks 3 onward apply to both, with one substitution: rules that mention v1-specific symbols (`*GeoServer`, `*Logger` wrapper, `g.DoRequestContext`, `g.ParseURL`, `*Error`) apply on `release/v1`; their v2 counterparts (`*Client` + sub-clients, `*slog.Logger` directly, `coreAdapter.Do`, `transport.BuildURL`, `*APIError`) apply on `master`.
+
 Always check, in this order:
 
-1. **Non-breaking v1.1.x discipline** — no exported function / type / method / field / constant removed; no signature change to existing exports; deprecations use `// Deprecated:` + a sibling that delegates. If a public API is renamed or has parameters reshuffled, flag as **BREAKING**.
-2. ***Context twin pattern** — every new exported method on `*GeoServer` must have a sibling `…Context(ctx context.Context, ...)`. The non-context form delegates with `context.Background()`. Reference: `workspaces.go:16-38,57-79`.
-3. **Errors** — wrap with `%w`; map status codes to the sentinels in `errors.go` (`ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, `ErrConflict`, `ErrBadRequest`, `ErrMethodNotAllowed`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`); never compare error strings — `errors.Is(err, ErrNotFound)` is the test.
-4. **Logging** — use `g.logger.Errorf/Warnf/Infof/Debugf` (printf) or the bare-string `Error/Warn/Info/Debug` variants. Don't add direct `slog.*` calls in library code; the `*Logger` wrapper exists deliberately.
+1. **(release/v1 only) Non-breaking v1.1.x discipline** — no exported function / type / method / field / constant removed; no signature change to existing exports; deprecations use `// Deprecated:` + a sibling that delegates. If a public API is renamed or has parameters reshuffled, flag as **BREAKING**.
+2. **(release/v1 only) `*Context` twin pattern** — every new exported method on `*GeoServer` must have a sibling `…Context(ctx context.Context, ...)`. The non-context form delegates with `context.Background()`. Reference on `release/v1`: `workspaces.go:16-38,57-79`.
+3. **Errors** — wrap with `%w`; map status codes to the sentinels in `errors.go`; never compare error strings — `errors.Is(err, ErrNotFound)` is the test. On `master`, errors surface as `*APIError`; on `release/v1`, as `*Error`.
+4. **Logging** — on `master`, use `*slog.Logger` directly via the configured `c.core.logger`; do NOT reintroduce a `*Logger` wrapper. On `release/v1`, use the existing `g.logger.Errorf/Warnf/Infof/Debugf` (printf) or bare `Error/Warn/Info/Debug` variants — the wrapper exists there for v1.0 source-compat.
 5. **Panics** — none in library code. Tests may use `t.Fatalf` freely. If you see `panic()` outside `_test.go`, flag it.
-6. **HTTP** — every request goes through `g.DoRequestContext` (in `utils.go`); never call `http.Client.Do` directly outside `utils.go`. URL building uses `g.ParseURL(parts...)` (per-segment path-escaped), never `fmt.Sprintf("%srest/%s...", ...)`.
+6. **HTTP & URLs** — on `master`, every request goes through `coreAdapter.Do` (`geoserver.go:429`) which delegates to `transport.DoJSON / DoXML / DoRaw / DoStream` in `internal/transport/transport.go`; URL building uses `coreAdapter.URL(parts...)` (`geoserver.go:422`) → `transport.BuildURL` in `internal/transport/url.go`. Never `http.Client.Do` directly outside `internal/transport/`. Never `fmt.Sprintf` REST paths. On `release/v1`, the equivalents are `g.DoRequestContext` in `utils.go` and `g.ParseURL`.
 7. **Lint compliance** — flag patterns that `golangci-lint` would reject under the project's `.golangci.yml` (`errcheck`, `bodyclose`, `noctx`, `errorlint`, `gosec`). Bias toward warnings the linter has historically missed (e.g., ignored `defer` errors, missing `ctx` propagation in callees).
-8. **Concurrency** — `*GeoServer` is not concurrent-safe for mutation. If you see fields being mutated post-construction, flag as needs-v2.
+8. **Concurrency** — on `master`, `*Client` and every sub-client are immutable after construction; flag any post-construction mutation of struct fields as a race risk and recommend reworking. On `release/v1`, `*GeoServer` exported fields are documented as not safe for mutation; flag mutating writes outside the constructor / option-application path.
 9. **Test coverage** — new exported methods need a corresponding `*_unit_test.go` (httptest-based) entry. Behavioral changes also need an integration test entry.
 
-Bash use: read-only intent. Use `git diff master...HEAD`, `git diff --stat`, and `grep -n` to find what changed and where. Don't run `go test`, `go build`, or any side-effecting command.
+Bash use: read-only intent. Use `git diff <base>...HEAD` (where `<base>` is whichever of `master` or `release/v1` the PR targets), `git diff --stat`, and `grep -n` to find what changed and where. Don't run `go test`, `go build`, or any side-effecting command.
 
 When you finish, sort findings by severity (**BREAKING** > **ERROR** > **WARNING** > **NIT**) and report under 200 words unless explicitly asked for more. Cite `file:line` for everything.

--- a/.claude/agents/integration-runner.md
+++ b/.claude/agents/integration-runner.md
@@ -1,6 +1,6 @@
 ---
 name: integration-runner
-description: Use this agent to boot the docker-compose stack and run the integration test suite, dumping logs on failure. Triggers when the user says "run integration tests", "run the integration suite", "test against GeoServer", or after a change touching service files (workspaces.go, datastores.go, styles.go, etc.) that needs end-to-end verification. Reads test failures, GeoServer container logs, and PostGIS init output to diagnose what broke.
+description: Use this agent to boot the docker-compose stack and run the integration test suite, dumping logs on failure. Triggers when the user says "run integration tests", "run the integration suite", "test against GeoServer", or after a change touching resource clients under `rest/` (e.g. `rest/workspaces/`, `rest/datastores/`, `rest/styles/`) that needs end-to-end verification. Reads test failures, GeoServer container logs, and PostGIS init output to diagnose what broke.
 tools: Bash, Read, Grep
 model: sonnet
 ---

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,9 +1,9 @@
 ---
-description: Pre-release verification for a v1.1.x tag. Runs the local-runnable subset of CI gates — vet, lint, govulncheck, unit tests on the active Go toolchain — plus a dry-run of the breaking-change-checker subagent. Does NOT run the full CI matrix (Go 1.23 + 1.25 + integration). Does NOT tag or push. Reports a go/no-go per gate.
+description: Pre-release verification for a v1.1.x tag on the `release/v1` branch (the v1 maintenance line). Runs the local-runnable subset of CI gates — vet, lint, govulncheck, unit tests on the active Go toolchain — plus a dry-run of the breaking-change-checker subagent against `release/v1`. Does NOT run the full CI matrix (Go 1.23 + 1.25 + integration). Does NOT tag or push. Reports a go/no-go per gate. **For v2 releases on `master`, this command does not apply** — v2 ships via a separate process.
 allowed-tools: Bash(make vet) Bash(make lint) Bash(make vuln) Bash(make test-unit) Bash(go version) Bash(go env:*) Read Grep
 ---
 
-Verify the current branch is ready to tag as the next v1.1.x release.
+Verify the current branch is ready to tag as the next v1.1.x release. **Pre-flight:** confirm the current branch is `release/v1` or descends from it — `git merge-base --is-ancestor release/v1 HEAD`. If not, abort with NO-GO and tell the user this command is for the v1 maintenance line; v2 releases on `master` ship via a different process.
 
 ## Gates (each runs even if a previous one failed; aggregate go/no-go at the end)
 
@@ -11,7 +11,7 @@ Verify the current branch is ready to tag as the next v1.1.x release.
 2. **`make lint`** — `golangci-lint run`. Must be clean.
 3. **`make vuln`** — `govulncheck ./...`. Must be clean, OR document any accepted advisories in the report.
 4. **`make test-unit`** — unit tests with `-race`. Must be green. Note: this runs against the **active Go toolchain only** — the full CI matrix (1.23 + 1.25) requires GitHub Actions.
-5. **Breaking-change check** — invoke the `breaking-change-checker` subagent against `master`. Must produce zero **BREAKING** findings.
+5. **Breaking-change check** — invoke the `breaking-change-checker` subagent against `release/v1`. Must produce zero **BREAKING** findings.
 6. **CHANGELOG sanity** — `grep -nE '^## \[1\.1\.' CHANGELOG.md` should show a stanza for the next version (or the most recent unreleased one). If the stanza is missing or empty, flag NO-GO.
 
 ## Report format

--- a/.claude/skills/add-context-twin/SKILL.md
+++ b/.claude/skills/add-context-twin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Adds a Context-aware sibling method to a GeoServer client method, following the established v1.1 pattern. Use when adding a new exported method on *GeoServer or porting an old method that lacks a *Context variant. Outputs the full code shape (non-context wrapper + Context impl + interface entry + unit test stub) for the caller to apply.
+description: Adds a Context-aware sibling method to a GeoServer client method, following the established v1.1 pattern. Use ONLY when patching the `release/v1` branch (the v1 maintenance line) and adding a new exported method on `*GeoServer` or porting an old method that lacks a `*Context` variant. **Do not use on `master`** — v2 is context-first natively (every method already takes `ctx` first; there are no twins). Outputs the full code shape (non-context wrapper + Context impl + interface entry + unit test stub) for the caller to apply.
 argument-hint: [method-name] [resource-file]
 disable-model-invocation: true
 ---
@@ -17,7 +17,9 @@ This skill is manually invoked because it expects arguments. Run as:
 
 ## What this skill does
 
-Generates the four pieces every new `*GeoServer` method needs to comply with the v1.1.x *Context twin pattern. Read the canonical reference at `workspaces.go:16-38,57-79` (the `CreateWorkspace` / `CreateWorkspaceContext` pair) before applying.
+Generates the four pieces every new `*GeoServer` method needs to comply with the v1.1.x `*Context` twin pattern on the `release/v1` branch. Read the canonical reference at `workspaces.go:16-38,57-79` on `release/v1` (the `CreateWorkspace` / `CreateWorkspaceContext` pair) before applying.
+
+**Pre-flight:** confirm the working branch descends from `release/v1` — `git merge-base --is-ancestor release/v1 HEAD`. If the branch targets `master`, abort: v2 has no twin pattern and a new `*Context` method on `master` is wrong.
 
 ## 1. The non-context wrapper
 

--- a/.claude/skills/geoserver-rest-quirks/SKILL.md
+++ b/.claude/skills/geoserver-rest-quirks/SKILL.md
@@ -12,56 +12,55 @@ This is reference material. Each quirk lists the symptom, the root cause as unde
 - **Symptom:** GeoServer 2.28 returns `500 "No such style handler: format = application/json"` if you send `Accept: application/json`.
 - **Root cause:** GeoServer dispatches on the Accept header looking for a "style format handler" that matches that media type. There is no JSON style handler, so it 500s.
 - **Workaround:** Send `Accept: "*/*"` to disable the dispatch and route to the metadata-creation path. The body's `Content-Type` should also be `application/json; charset=utf-8` — bare `application/json` 500s in some older 2.x versions.
-- **Where:** `styles.go:178-186` (`CreateStyleContext`).
+- **Where:** `rest/styles/styles.go:141-173` (`Create` — workspace-scoped branch sets `accept = "*/*"`).
 
 ## 2. Empty styles collection comes back as `{"styles":""}` (bare string)
 
 - **Symptom:** `GetStyles` against a fresh / empty workspace fails to unmarshal because GeoServer returns a JSON object whose `styles` field is the empty string instead of an object.
 - **Workaround:** Decode into `json.RawMessage` first; branch on the first byte (`'"'` ⇒ empty list; `'{'` ⇒ decode as `{"style": [...]}`).
-- **Where:** `styles.go:93-104` (`GetStylesContext`).
+- **Where:** `rest/styles/styles.go:85` (`json.RawMessage` decode tolerates the empty-string shape).
 
 ## 3. `LayerGroup.styles.style` is a mixed `[string|object]` array
 
 - **Symptom:** `GET /layergroups/{name}` for any layer group with default-styled members produces `"styles": {"style": ["", "", {...}, ""]}` — string entries (often empty) interspersed with style objects. Standard JSON decoder errors with `cannot unmarshal string into Go struct field LayerGroupStyles.style`.
 - **Workaround:** Custom `UnmarshalJSON` on `LayerGroupStyles` that decodes the inner `style` array via `[]json.RawMessage`, then per-element handles `'"'` (string) vs `'{'` (object) and produces `[]*Resource`. String entries are stored as `&Resource{Name: stringValue}` to preserve the `[]*Resource` field type.
-- **Where:** `layergroups.go` `LayerGroupStyles.UnmarshalJSON`.
+- **Where:** `rest/layergroups/types.go:108` (`Styles.UnmarshalJSON`); the same trick handles the mixed `Published` shape at `rest/layergroups/types.go:60`.
 
 ## 4. POST style endpoints need explicit `; charset=utf-8`
 
 - **Symptom:** Bare `Content-Type: application/json` 500s in some 2.x versions.
 - **Workaround:** Send `Content-Type: application/json; charset=utf-8`.
-- **Where:** Same site as quirk #1 — `styles.go:189` (`DataType: jsonType + "; charset=utf-8"`).
+- **Where:** Same site as quirk #1 — `rest/styles/styles.go:173` (the body Content-Type is set to `"application/json; charset=utf-8"`).
 
 ## 5. PostGIS publish requires the table to exist with attributes
 
 - **Symptom:** `POST /workspaces/{ws}/datastores/{ds}/featuretypes` returns `400 "no attributes"` if the named table is empty or doesn't exist.
 - **Workaround:** Tests bootstrap a real PostGIS table via `docker/postgis/init/01-lbldyt.sql` (creates `public.lbldyt(gid, name, label, geom)` with sample rows + GIST index). Production callers must ensure their target table exists.
-- **Where:** `docker/postgis/init/01-lbldyt.sql`; tested in `layers_test.go` (integration).
+- **Where:** `docker/postgis/init/01-lbldyt.sql`; tested in `rest/featuretypes/featuretypes_integration_test.go`.
 
-## 6. `Settings.contact` is `interface{}` in v1
+## 6. `Settings.contact` returns the empty string when absent
 
-- **Symptom:** Type assertions on `Settings.Contact` panic in v1.0; in v1.1 they return zero values silently.
-- **Root cause:** v1.0 modeled the contact subdocument loosely. `Contact` *type* is defined in `settings.go:15` but never wired up; the field is `interface{}` (`settings.go:27`).
-- **Workaround:** Don't trust the field type for new code. v2 will make this concrete.
-- **Where:** `settings.go:27`.
+- **Symptom:** `GET /rest/settings` on a freshly initialized GeoServer returns `"contact": ""` (bare string) instead of an empty object. Standard JSON decoding into a `*Contact` field fails with `cannot unmarshal string into Go struct field`.
+- **Workaround:** `*Contact` ships a custom `UnmarshalJSON` that treats the empty-string and absent-field cases as a zero-value `Contact`, and decodes into the struct otherwise.
+- **Where:** `rest/settings/types.go` (`Contact.UnmarshalJSON`); regression-guarded by `rest/settings/settings_test.go:32` (`TestContact_UnmarshalEmptyString`).
 
 ## 7. Pagination drift across versions
 
 - **Symptom:** `GET /rest/layers` and `GET /rest/styles` paginate via `?startIndex=&count=` on GeoServer 2.18+ but return everything on older versions.
-- **Workaround:** Send pagination params and tolerate them being ignored on older servers. v2 wraps this in `iter.Seq2[T, error]` with single-page fallback.
-- **Where:** Not currently mitigated in v1; documented for awareness.
+- **Workaround:** Send pagination params and tolerate them being ignored on older servers. The client wraps this in `iter.Seq2[T, error]` with single-page fallback so callers iterate uniformly across versions.
+- **Where:** `rest/styles/styles.go:104` (`Client.Iter`), `rest/layers/layers.go:83` (`WorkspaceClient.Iter`).
 
-## 8. `ParseURL` must escape per segment, not the whole path
+## 8. URL building must escape per segment, not the whole path
 
-- **Symptom:** Workspace / layer names with spaces, slashes, or non-ASCII characters produced malformed URLs in v1.0.
-- **Workaround:** `g.ParseURL(parts...)` applies `url.PathEscape` to each segment before `path.Join`. Use multi-arg `ParseURL("rest", "workspaces", ws, "styles")` instead of `fmt.Sprintf("%srest/%s/styles", server, ws)`.
-- **Where:** `utils.go` `ParseURL`.
+- **Symptom:** Workspace / layer names with spaces, slashes, or non-ASCII characters produce malformed URLs if a caller `fmt.Sprintf`s the path together. Literal `*` wildcards in ACL rule strings are rejected by GeoServer's `StrictHttpFirewall` if double-encoded.
+- **Workaround:** `transport.BuildURL(base, parts)` applies `url.PathEscape` to each segment before joining and preserves the encoding through `(*url.URL).String()` by setting `RawPath` alongside `Path`. Sub-clients reach it through `coreAdapter.URL(parts...)` (`geoserver.go:422`); never `fmt.Sprintf` REST paths.
+- **Where:** `internal/transport/url.go` (`BuildURL`); regression-guarded by `internal/transport/url_test.go`.
 
 ## 9. Empty `wfs:FeatureType` lists in capabilities
 
 - **Symptom:** Older GeoServer versions emit `<FeatureTypeList></FeatureTypeList>` (empty) while newer ones omit the element entirely.
-- **Workaround:** XML parser treats both as empty list; no caller-visible difference. WMS capabilities parser uses `wms.ParseCapabilitiesE` which returns `(*Capabilities, error)` — prefer it over the deprecated `ParseCapabilities` that swallowed errors.
-- **Where:** `wms/wms.go` `ParseCapabilitiesE`.
+- **Workaround:** The WFS capabilities XML decoder treats both as an empty `FeatureTypeList`; no caller-visible difference. The WMS side does the same for empty `Layer` lists.
+- **Where:** `ows/wfs/types.go:106` (`FeatureTypeList`); `ows/wms/wms.go:114` (`ParseCapabilities`) returns `(*Capabilities, error)`.
 
 ---
 
@@ -69,4 +68,4 @@ This is reference material. Each quirk lists the symptom, the root cause as unde
 
 - Implementing a new REST resource client — scan the list before writing the request to avoid re-discovering quirk 1, 4, or 8.
 - Debugging an integration-test failure with `unmarshal` or `5xx` in the message.
-- Reading a PR that touches `styles.go`, `layergroups.go`, or `utils.go` `ParseURL` — verify the quirk-handling code wasn't naively "simplified" away.
+- Reading a PR that touches `rest/styles/`, `rest/layergroups/`, or `internal/transport/url.go` — verify the quirk-handling code wasn't naively "simplified" away.

--- a/.claude/skills/non-breaking-v1/SKILL.md
+++ b/.claude/skills/non-breaking-v1/SKILL.md
@@ -1,21 +1,23 @@
 ---
-description: Verifies that a change preserves the v1.1.x non-breaking contract. Run before opening a PR to master or before tagging a v1.1.x release. Walks through the exported-API surface, *Context twin pattern, deprecation discipline, and concurrency constraints.
+description: Verifies that a change preserves the v1.1.x non-breaking contract. Run before opening a PR to `release/v1` or before tagging a v1.1.x release. Walks through the exported-API surface, *Context twin pattern, deprecation discipline, and concurrency constraints. **For v2 PRs targeting `master`, this skill does not apply** — v2 is allowed to break.
 disable-model-invocation: true
 allowed-tools: Bash(git diff:*) Bash(git log:*) Bash(go doc:*) Bash(grep:*) Read Grep Glob
 ---
 
 # Non-breaking v1.1.x checklist
 
-Run this before opening a PR to `master` or before tagging a v1.1.x release. The contract: **a caller pinned to v1.0 must be able to upgrade to v1.1.x by changing only their `go.mod` version and running `go mod tidy`. No source edits.**
+Run this before opening a PR to `release/v1` or before tagging a v1.1.x release. The contract: **a caller pinned to v1.0 must be able to upgrade to v1.1.x by changing only their `go.mod` version and running `go mod tidy`. No source edits.**
+
+`master` is v2 and does not honor this contract — do not run this skill against PRs targeting `master`.
 
 This skill is manually-invoked (`/non-breaking-v1`) — Claude won't auto-trigger it because the workflow has timing implications (run it at PR / release time, not mid-edit).
 
 ## Steps
 
-### 1. Compute exported-API diff against `master`
+### 1. Compute exported-API diff against `release/v1`
 
 ```
-git diff master...HEAD -- '*.go' ':!*_test.go' | grep -E '^[-+](func|type|var|const)' || echo "no exported diffs"
+git diff release/v1...HEAD -- '*.go' ':!*_test.go' | grep -E '^[-+](func|type|var|const)' || echo "no exported diffs"
 ```
 
 If `gorelease` is available, prefer the authoritative tool:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,10 @@
 
 ## Type of change
 
-- [ ] Bug fix (non-breaking)
-- [ ] New feature (non-breaking, additive)
-- [ ] Breaking change (must target `v2`, not `master`)
+- [ ] Bug fix
+- [ ] New feature (additive)
+- [ ] Breaking change (targets `master` — v2 line)
+- [ ] v1 security fix (must target `release/v1`, non-breaking)
 - [ ] Documentation only
 - [ ] Build / CI / chore
 
@@ -21,7 +22,7 @@
 - [ ] I added or updated unit tests for the change
 - [ ] I updated the CHANGELOG entry under `## [Unreleased]` if user-visible
 - [ ] I did not add new runtime dependencies (or I justified why in the description)
-- [ ] My change preserves backward compatibility (or this PR targets `v2`)
+- [ ] If this PR targets `release/v1`, my change preserves backward compatibility (deprecate via `// Deprecated:` and add a sibling rather than changing signatures); breaking changes belong on `master` (v2)
 
 ## Related issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ If you need a no-context entry point in caller code, use `context.Background()` 
 ## Common GeoServer REST quirks (cross-reference)
 
 - Workspace-scoped `POST /workspaces/{ws}/styles` requires `Accept: */*`, not `application/json` — see `rest/styles/styles.go`.
-- Empty styles collection comes back as `{"styles":""}` (bare string, not object) — see `rest/styles/styles.go:75,91`.
+- Empty styles collection comes back as `{"styles":""}` (bare string, not object) — `json.RawMessage` decode at `rest/styles/styles.go:85` tolerates both shapes.
 - `LayerGroup.styles.style` is a mixed `[string|object]` array — custom `UnmarshalJSON` in `rest/layergroups/types.go:97-108`. The `Published` type has the same shape — `rest/layergroups/types.go:57-60`.
 - Full quirk reference: `/skill geoserver-rest-quirks` or read `.claude/skills/geoserver-rest-quirks/SKILL.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,32 +48,34 @@ See [`docker/README.md`](docker/README.md) for what's in the image (Importer ext
 
 ## Pull requests
 
-1. **Branch from `master`.** Use a short descriptive name (`fix/url-escape`, `feat/context-methods`). Never commit directly to `master`.
+1. **Pick the right base branch.** Most PRs branch from `master` (the v2 main line). Security patches for v1 branch from `release/v1` and must remain non-breaking — see point 6. Use a short descriptive name (`fix/url-escape`, `feat/coverage-iter`). Never commit directly to either branch.
 2. **One concern per PR.** Smaller PRs review faster.
 3. **Conventional Commits.** Commit messages follow [Conventional Commits 1.0](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, `build:`, `ci:`). The CHANGELOG is generated from these.
 4. **Tests are mandatory.** New code needs unit tests (`*_unit_test.go`, `httptest`-based). Behavioral changes also need an integration test entry. **Integration tests run on every PR** against both GeoServer 2.27.4 LTS and 2.28.0 stable — both legs must pass.
 5. **Lint clean.** `make lint` must pass with zero warnings.
-6. **Backward compatibility.** v1.x is non-breaking. If your change requires breaking a public symbol, open a discussion first — it likely belongs in v2.
+6. **Backward compatibility depends on the target branch.** PRs against `master` (v2) MAY introduce breaking changes — v2 is the active line and a major-version bump is the natural home for them; flag them clearly in the description. PRs against `release/v1` MUST be non-breaking: deprecate via `// Deprecated:` and add a sibling rather than changing signatures.
 7. **No new runtime dependencies** without prior discussion. Test-only deps are fine.
 8. **All CI checks must pass before merge.** The required gates on every PR: `Lint`, `Unit tests (Go 1.25)`, `govulncheck`, `Analyze (Go)` (CodeQL), `GeoServer 2.27.4`, `GeoServer 2.28.0`. Don't merge with any check red, pending, or skipped.
-9. **Squash merge.** PRs are squash-merged into `master` so each merge produces exactly one commit on the trunk and the CHANGELOG stays clean. Don't use rebase- or merge-commit strategies.
+9. **Squash merge.** PRs are squash-merged into the target branch so each merge produces exactly one commit on the trunk and the CHANGELOG stays clean. Don't use rebase- or merge-commit strategies.
 
 ## Project layout
 
+The `master` branch is v2 (`github.com/hishamkaram/geoserver/v2`). The v1 line lives on `release/v1` and is end-of-feature (security fixes only); its layout is documented in CONTRIBUTING.md on that branch.
+
 ```
 .
-├── *.go                       # v1 public API (one file per resource)
-├── wms/                       # WMS XML types (parser)
-├── internal/transport/        # v1.1.x algorithm package (URL building, request execution)
-├── v2/                        # v2 SDK — separate Go module (own go.mod)
-│   ├── *.go, doc.go           # v2 root client and package doc
-│   ├── rest/                  # one subpackage per resource (workspaces, datastores, services, gwc, imports, …)
-│   ├── ows/                   # OWS clients (wms, wfs, wcs)
-│   ├── internal/transport/    # v2 transport helpers (DoJSON, DoXML, DoRaw, DoStream)
-│   └── examples/              # runnable v2 reference flows
-├── docs/                      # Architecture, REST quirks, version compat, migration, tier-2 gap backlog
-├── examples/                  # Runnable v1 reference flows
-├── docker/                    # Dockerfile for the dev/test GeoServer (Importer plugin baked in)
+├── *.go                       # Root package: *Client, options, *APIError, sentinels (geoserver.go, errors.go, options.go, doc.go)
+├── rest/                      # One subpackage per REST resource (workspaces, datastores, featuretypes,
+│                              #   coveragestores, coverages, layers, layergroups, styles, namespaces,
+│                              #   settings, about, security, acl, system, imports, gwc, services,
+│                              #   resources, templates, urlchecks, wmsstores, wmslayers, wmtsstores,
+│                              #   wmtslayers, wfstransforms, logging, fonts, monitor — 28 in total)
+├── ows/                       # OWS read-only clients: wms, wfs, wcs (GetCapabilities + descriptors)
+├── internal/transport/        # HTTP dispatch (DoJSON, DoXML, DoRaw, DoStream) and URL building (BuildURL)
+├── internal/wire/             # Helpers for delicate wire-format quirks (mixed-shape arrays, etc.)
+├── examples/                  # Runnable reference flows (workspaces, publish-postgis, style-upload, error-handling)
+├── docs/                      # Architecture, REST quirks, version compat, v1→v2 migration, tier-2 gap backlog
+├── docker/                    # Dockerfile for the dev/test GeoServer (Importer + Monitor extensions baked in)
 ├── docker-compose.yml         # Default dev stack (GeoServer 2.28 + PostGIS 16)
 ├── docker-compose.test.yml    # Integration test stack with 2.27 LTS leg
 ├── testdata/                  # Test fixtures (SLDs, shapefiles, JSON responses)
@@ -89,9 +91,9 @@ See [`docker/README.md`](docker/README.md) for what's in the image (Importer ext
 
 ## Releasing
 
-Releases are cut by maintainers via tags (`v1.x.y` for v1, `v2.x.y` for v2). The `release.yml` workflow assembles release notes from Conventional Commit messages.
+Releases are cut by maintainers via tags. v2 releases (`v2.x.y`) tag from `master`; v1 security-patch releases (`v1.1.x`) tag from `release/v1`. The `release.yml` workflow assembles release notes from Conventional Commit messages.
 
-Both `CHANGELOG.md` (v1) and `v2/CHANGELOG.md` (v2) follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The `[Unreleased]` block at the top of each file accumulates entries between tags; cutting a release promotes the block contents into a dated stanza and leaves a fresh `[Unreleased]` placeholder.
+`CHANGELOG.md` on `master` is the v2 changelog; the v1 changelog lives at `CHANGELOG.md` on the `release/v1` branch. Both follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The `[Unreleased]` block at the top of each file accumulates entries between tags; cutting a release promotes the block contents into a dated stanza and leaves a fresh `[Unreleased]` placeholder.
 
 ## Working with Claude Code in this repo
 
@@ -103,12 +105,12 @@ Available helpers:
 |---|---|---|
 | Slash command | `/integration-test [version]` | Boot the docker-compose stack and run the integration suite (default 2.28; `2.27` for the LTS leg). |
 | Slash command | `/lint-fix` | Run `golangci-lint --fix` + `gofmt` + `goimports`, report the diff and any remaining manual fixes. |
-| Slash command | `/release-prep` | Local-runnable subset of CI gates for a v1.1.x tag. |
-| Skill | `/add-context-twin <method> <file>` | Apply the *Context twin pattern to a new method on `*GeoServer`. |
-| Skill | `/non-breaking-v1` | Pre-PR checklist for the v1.1.x non-breaking contract. |
+| Slash command | `/release-prep` | Local-runnable subset of CI gates for a v1.1.x tag on `release/v1` (v1-only — v2 ships via a separate process). |
+| Skill | `/add-context-twin <method> <file>` | Apply the `*Context` twin pattern to a new method on `*GeoServer`. **`release/v1` only** — v2 is context-first natively, no twins. |
+| Skill | `/non-breaking-v1` | Pre-PR checklist for the v1.1.x non-breaking contract. **`release/v1` only.** |
 | Skill | `/geoserver-rest-quirks` | Reference for GeoServer 2.x REST quirks the client works around (auto-loads when relevant). |
-| Subagent | `go-reviewer` | Idiom + non-breaking review of changed Go files. |
+| Subagent | `go-reviewer` | Go-idiom review of changed files. Adapts its rule set per target branch — adds non-breaking-v1 + twin checks when reviewing PRs against `release/v1`. |
 | Subagent | `integration-runner` | Boots the stack, runs integration tests, diagnoses failures from container logs. |
-| Subagent | `breaking-change-checker` | Computes the exported-API diff against `master` / `v1.0.0` and classifies each change. |
+| Subagent | `breaking-change-checker` | Computes the exported-API diff against `release/v1` / `v1.0.0` and classifies each change. **`release/v1` only.** |
 
 Personal per-machine settings live in `.claude/settings.local.json` (gitignored). The team baseline (permissions, attribution, hooks) is intentionally **not** committed; revisit if the project grows enough contributors to warrant it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,9 @@
 
 | Version | Supported |
 |---|---|
-| 1.1.x   | ✅ Active development and security fixes |
-| 1.0.x   | ⚠️ Security fixes only |
-| < 1.0   | ❌ No support |
-| 2.x     | 🧪 Beta at `github.com/hishamkaram/geoserver/v2` (latest `v2.0.0-beta.1`); security fixes accepted; public API frozen for review until `v2.0.0` final |
+| 2.x     | ✅ Active development and security fixes — `github.com/hishamkaram/geoserver/v2` on `master` (latest `v2.0.0`) |
+| 1.1.x   | ⚠️ Security fixes only — `github.com/hishamkaram/geoserver` on the `release/v1` branch (latest `v1.1.2`; end-of-feature) |
+| ≤ 1.0   | ❌ No support |
 
 ## Reporting a vulnerability
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,110 +1,122 @@
 # Architecture
 
-This document describes how `github.com/hishamkaram/geoserver` is laid out, the design tenets, and the trade-offs that drive the v1.x shape. It is reference material; release notes live in [`CHANGELOG.md`](../CHANGELOG.md), and the forward-looking direction lives in [`../ROADMAP.md`](../ROADMAP.md).
+This document describes how `github.com/hishamkaram/geoserver/v2` is laid out, the design tenets, and the trade-offs behind v2's shape. It is reference material; release notes live in [`../CHANGELOG.md`](../CHANGELOG.md), and the forward-looking direction lives in [`../ROADMAP.md`](../ROADMAP.md).
 
 ## Package shape
 
-The library is a single `package geoserver` at the module root, with one subpackage:
+The library is rooted at `package geoserver` (the public client surface) plus one resource-client subpackage per REST resource and one OWS subpackage per service. The HTTP transport is hidden in `internal/`.
 
 | Path | Purpose |
 |---|---|
-| `github.com/hishamkaram/geoserver` | Public API — `*GeoServer` client, all resource methods, options, errors |
-| `github.com/hishamkaram/geoserver/wms` | XML types and parser for WMS GetCapabilities responses |
-| `github.com/hishamkaram/geoserver/internal/transport` (v1.1.x+) | HTTP request building / dispatch and URL construction. Implementation detail — not importable by external code |
+| `github.com/hishamkaram/geoserver/v2` | Public surface — `*Client`, options, `*APIError`, sentinel errors. The constructor lives here; the resource methods live in their per-resource subpackages, surfaced via exported fields on `*Client`. |
+| `github.com/hishamkaram/geoserver/v2/rest/<resource>` | One subpackage per REST resource: `workspaces`, `datastores`, `featuretypes`, `coveragestores`, `coverages`, `layers`, `layergroups`, `styles`, `namespaces`, `settings`, `about`, `security`, `acl`, `system`, `imports`, `gwc`, `services`, `resources`, `templates`, `urlchecks`, `wmsstores`, `wmslayers`, `wmtsstores`, `wmtslayers`, `wfstransforms`, `logging`, `fonts`, `monitor`. Each exposes a `*Client` (and where applicable scoped `*WorkspaceClient`, `*DatastoreClient`, etc.). |
+| `github.com/hishamkaram/geoserver/v2/ows/{wms,wfs,wcs}` | OWS read-only clients: `GetCapabilities` + `DescribeFeatureType` (WFS) / `DescribeCoverage` (WCS). Separate from `rest/services` because OWS endpoints are XML-over-HTTP and live at different URL roots. |
+| `github.com/hishamkaram/geoserver/v2/internal/transport` | HTTP request building, URL construction, JSON/XML/raw/stream dispatch. Implementation detail — not importable by external code. |
+| `github.com/hishamkaram/geoserver/v2/internal/wire` | Internal helpers for the more delicate wire-format quirks (mixed-shape arrays, empty-collection string-vs-object payloads). Not importable. |
 
-A separate module exists at `github.com/hishamkaram/geoserver/v2` (latest tag `v2.0.0-beta.1` — public API frozen for review) with a different shape — sub-clients per resource (`c.Workspaces`, `c.Datastores.InWorkspace(ws)`, `c.Services.WMS()`, `c.GWC.Seed()`, `c.Imports`, `c.Resources`, etc.) and surfaces v1 never had. v1 and v2 ship independently. See [`migration-v1-to-v2.md`](./migration-v1-to-v2.md) for the side-by-side mapping.
+v1 is a separate, end-of-feature release line on the `release/v1` branch (security fixes only; latest tag `v1.1.2`). See [`migration-v1-to-v2.md`](./migration-v1-to-v2.md) for the side-by-side mapping.
 
 ## Public API entry points
 
-There is **one** type users construct: `*GeoServer`. There are **two** ways to construct it:
-
-1. **`New(serverURL, username, password string, opts ...Option) *GeoServer`** — recommended (v1.1+). Functional options for HTTP client, timeout, logger, user agent, basic auth.
-2. **`GetCatalog(serverURL, username, password string) *GeoServer`** — legacy v1.0 entry point. Marked `// Deprecated: prefer New(...)`. Internally a one-liner around `New`.
-
-`*GeoServer` exposes ~90 methods covering the GeoServer REST resource set: workspaces, datastores, coverage stores, coverages, feature types, layers, layer groups, styles, namespaces, settings, security (users / groups / roles), ACL, about, capabilities, configuration. See `pkg.go.dev/github.com/hishamkaram/geoserver` for the full list.
-
-## *Context twin pattern (mandatory for new exports)
-
-Every exported method on `*GeoServer` comes in a pair:
+There is **one** type users construct: `*Client`. The constructor is functional-options-only:
 
 ```go
-// Non-context wrapper — delegates with context.Background()
-func (g *GeoServer) GetWorkspaces() ([]*Resource, error) {
-    return g.GetWorkspacesContext(context.Background())
-}
-
-// Context-aware variant — does the actual work
-func (g *GeoServer) GetWorkspacesContext(ctx context.Context) ([]*Resource, error) {
-    // ...
-}
+func New(serverURL string, opts ...Option) (*Client, error)
 ```
 
-Reference: `workspaces.go:16-38,57-79`. The non-context form exists only for source-compatibility with v1.0 callers; **new code should always use the `*Context` form** so it can honor cancellation and deadlines.
+Options live in `options.go`: `WithHTTPClient`, `WithTransport`, `WithTimeout`, `WithLogger`, `WithUserAgent`, `WithBasicAuth`, `WithBearerToken`, `WithHeader`. Credentials are passed through options, not positional args — that's the v2 break with v1's `New(url, user, pass, opts...)` shape.
 
-When a contributor adds a new method on `*GeoServer`, both the non-context wrapper and the `*Context` sibling must land together, plus the corresponding entry in the parallel `*ServiceWithContext` interface.
+`*Client` exposes 31 sub-clients as exported pointer fields (`c.Workspaces`, `c.Datastores`, `c.FeatureTypes`, `c.Styles`, …). Sub-client methods do the actual REST work; the parent `*Client` only constructs and owns them.
+
+Hierarchical resources scope through fluent `In*` methods that return a new lightweight scoped client:
+
+```go
+// Datastore scoped to a workspace
+c.Datastores.InWorkspace("topp").Create(ctx, datastores.PostGIS{...})
+
+// Feature type scoped to a workspace + datastore
+c.FeatureTypes.InWorkspace("topp").InDatastore("nyc").Create(ctx, ft)
+
+// Coverage scoped to a workspace + coverage store
+c.Coverages.InWorkspace("nurc").InCoverageStore("dem").Get(ctx, "elev")
+```
+
+Scoped clients are immutable value-shaped wrappers around the parent's `Core` interface — cheap to allocate, safe to discard.
+
+## Context-first methods
+
+Every exported method on every sub-client takes `ctx context.Context` as its first argument. There are **no** `*Context` twin methods, and no `context.Background()` shims; v1's twin pattern was a v1.0 source-compat affordance and was deliberately dropped at the v2 boundary.
+
+```go
+func (c *Client) GetWorkspaces(ctx context.Context) ([]*workspaces.Workspace, error)
+```
+
+If a caller has no context, they pass `context.Background()` at the call site. The library itself never does.
 
 ## Errors
 
-Every HTTP error is a `*Error` (`errors.go`):
+Every non-2xx GeoServer response surfaces as `*APIError` (`errors.go`):
 
 ```go
-type Error struct {
-    Op         string  // operation name, e.g. "GetWorkspaces"
+type APIError struct {
+    Op         string  // operation name, e.g. "Workspaces.Create"
+    Method     string  // HTTP method
     URL        string  // request URL
     StatusCode int     // HTTP status
-    Body       []byte  // response body, truncated to 8 KiB
-    Err        error   // wrapped sentinel (one of ErrNotFound, ErrConflict, ...)
+    Body       []byte  // response body, capped at 8 KiB internally
 }
 ```
 
-Status codes map to package sentinel errors. The mapping (`errors.go:13-32`) covers `ErrBadRequest`, `ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrMethodNotAllowed`, `ErrConflict`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`. Match via `errors.Is`:
+`*APIError.Is(target)` matches a fixed set of 12 sentinels: `ErrBadRequest`, `ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrMethodNotAllowed`, `ErrConflict`, `ErrUnsupportedMediaType`, `ErrRateLimited`, `ErrServerError`, `ErrBadGateway`, `ErrServiceUnavailable`, `ErrGatewayTimeout`. Match via `errors.Is`:
 
 ```go
-_, err := gs.GetWorkspaceContext(ctx, "doesnotexist")
+_, err := c.Workspaces.Get(ctx, "doesnotexist")
 if errors.Is(err, geoserver.ErrNotFound) {
     // handle
 }
 ```
 
-The `*Error.Error()` string preserves v1.0's `"abstract:%s\ndetails:%s\n"` format so existing string-matching callers don't break.
+The `Error()` string is a stable, parseable form:
+
+```
+geoserver: <Op> <Method> <URL>: <statusCode> <statusText>: <body-preview>
+```
+
+Body preview is truncated to ~120 bytes. Don't parse error strings for control flow — use `errors.Is` (sentinel) or `errors.As` (inspect fields).
+
+The v2 type rename (`*Error` → `*APIError`) and the format break (v1's `"abstract:%s\ndetails:%s\n"` is gone) are deliberate v2-boundary changes; v1.x callers cannot port unmodified.
 
 ## Logging
 
-`g.logger` is a `*Logger` wrapper (`logging.go:11-71`) over stdlib `*slog.Logger`. The wrapper exists for v1.0 source-compat (preserves `Errorf`/`Warnf`/`Infof`/`Debugf` and `Error`/`Warn`/`Info`/`Debug` shapes from the original logrus-based API).
+The library uses `*slog.Logger` directly. There is no `*Logger` wrapper — that abstraction was a v1.0 source-compat shim and was dropped in v2.
 
-Configure via `New(url, u, p, WithLogger(handler))` where `handler` is any `slog.Handler`. Default is `slog.DiscardHandler` (silent).
+Configure via `WithLogger(l *slog.Logger)`. Default is `slog.New(slog.DiscardHandler)` (silent). Internal call sites use structured logging — `logger.Debug(msg, args...)` with key/value pairs, not printf-style.
 
 The library logs at:
 
 - **Debug** — HTTP details (URL, status, body length).
 - **Warn** — transport-level retry exhaustion, unexpected response shapes.
-- **Error** — protocol violations, deserialization failures, type-assertion mismatches.
+- **Error** — protocol violations, deserialization failures.
 
 There is no `Info` chatter.
 
 ## HTTP transport
 
-All REST calls funnel through `(g *GeoServer).DoRequestContext` (`utils.go`). Exported, but not the recommended call surface — resource methods (e.g., `GetWorkspacesContext`) are. Internal organization in v1.1.x splits the algorithm:
+Every sub-client call funnels through `coreAdapter.Do(ctx, op, method, url, body, query, out)` (`geoserver.go:429`), which delegates to `transport.DoJSON / DoXML / DoRaw / DoStream` in `internal/transport/transport.go`. Sub-clients never touch `*http.Client.Do` directly.
 
-- `*GeoServer.DoRequestContext` — the public method, kept for v1.0 source-compat.
-- `internal/transport/transport.go` — the actual algorithm.
+The `coreAdapter` is the bridge between resource-client subpackages and the private `clientCore` (configured `*http.Client`, base URL, headers, logger). Sub-clients consume only the `Core` interface, not `*Client` itself, so they can be composed and unit-tested in isolation.
 
-`*GeoServer.DoRequest` is the `context.Background()` shim around `DoRequestContext` (same twin pattern as resource methods).
-
-## URL building
-
-`g.ParseURL(parts ...string)` (`utils.go`) builds REST URLs from segments with two non-trivial bits of correctness:
-
-1. **`url.PathEscape` per segment** — workspace and layer names with spaces, slashes, or non-ASCII characters produce correctly-escaped URLs. v1.0 used `fmt.Sprintf` and produced malformed URLs for these inputs.
-2. **`RawPath` preservation** — the encoded path survives `(*url.URL).String()` instead of being re-encoded. Without this, a segment escaped to `%2A` would be re-encoded to `%252A` by `String()`, which GeoServer's `StrictHttpFirewall` rejects as potentially malicious. The bug surfaced when ACL `DELETE` paths started carrying literal `*` wildcards. Regression-guarded by `utils_unit_test.go` `TestParseURL_NoDoubleEncoding`.
+URL building goes through `coreAdapter.URL(parts ...string)` (`geoserver.go:422`), which delegates to `transport.BuildURL` (`internal/transport/url.go`). Each segment is path-escaped and `RawPath` is preserved, so workspace/layer names with spaces, slashes, or non-ASCII characters produce correctly-escaped URLs that survive `(*url.URL).String()` without double-encoding. Regression-guarded by `internal/transport/url_test.go`.
 
 ## Concurrency
 
-`*GeoServer` exported fields are **not safe for concurrent mutation**. Construct once with `New(...)` and treat the returned value as immutable. Concurrent reads are safe (the `*http.Client` underneath is concurrency-safe by stdlib contract; the `*Logger` is `*slog.Logger`-backed, also safe).
+`*Client` is **immutable after `New(...)` returns.** All struct fields are private or pointers to sub-clients set once at construction and never reassigned. Concurrent use across goroutines is safe by design — no caller-side locking required.
 
-Concurrent reads include concurrent calls to different resource methods on the same `*GeoServer`. These are routine; the test suite exercises them via `-race`.
+The same posture holds for every sub-client (`workspaces.Client`, `datastores.Client`, …): they expose methods only, holding a single private `Core` interface reference. Scoped clients (`*WorkspaceClient`, `*DatastoreClient`, …) are value-shaped and similarly stateless.
 
-The "exported fields, accept reads, document non-mutability" model is a v1.0 carryover. v2 fixes this with private fields; see [`migration-v1-to-v2.md`](migration-v1-to-v2.md).
+The race-safety guarantee is verified by `TestClient_ConcurrentRequests` (`geoserver_concurrent_test.go:17`) running under `go test -race` in CI.
+
+User-supplied transports passed via `WithHTTPClient` / `WithTransport` are the caller's responsibility — if their `RoundTripper` mutates shared state, the race lives in their code.
 
 ## Test split
 
@@ -112,20 +124,20 @@ Two test layers, distinguished by file naming and build tag:
 
 | Layer | Naming | Build tag | What it does |
 |---|---|---|---|
-| Unit | `*_unit_test.go` | none | `httptest.Server` mocks; covers each method's request shape, response decode, status-code → sentinel mapping. `make test-unit` runs them in <5s. No Docker required. |
-| Integration | `*_test.go` (no `_unit_` suffix) | `//go:build integration` | Real GeoServer + PostGIS via `docker compose`. Exercises end-to-end flows. `make test-integration` boots the stack first. |
+| Unit | `*_unit_test.go` | none | `httptest.Server` fakes; covers each method's request shape, response decode, status-code → sentinel mapping. `make test-unit` runs them in <5s, no Docker required. |
+| Integration | `*_integration_test.go` | `//go:build integration` | Real GeoServer + PostGIS via `docker compose`. Exercises end-to-end flows. `make test-integration` boots the stack first. |
 
-This split is non-standard for Go (idiomatic Go puts unit tests in `*_test.go` next to the code, period), but the deliberate naming makes the split greppable. Both layers are mandatory on every PR; CI runs unit on `Lint` and `Unit tests (Go 1.25)`, integration on `GeoServer 2.27.4` and `GeoServer 2.28.0`.
+Both layers are mandatory on every PR. CI runs unit on **Go 1.23 + 1.25** and integration on **GeoServer 2.27.4 LTS + 2.28.0 stable** — all four legs must go green.
 
 ## GeoServer REST quirks
 
-GeoServer's REST API has version-specific quirks that this client works around. See [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) for the catalog.
+GeoServer's REST API has version-specific quirks the client works around (mixed-shape JSON arrays, empty-collection string-vs-object payloads, workspace-scoped style-endpoint Accept-header dispatch, etc.). See [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) for the catalog with code locations.
 
 ## Cross-references
 
-- [`../README.md`](../README.md) — quickstart, install, examples
-- [`../ROADMAP.md`](../ROADMAP.md) — v1.x maintenance, v2.x design, GeoServer 3 timeline
+- [`../README.md`](../README.md) — quickstart, install, capability surface, worked example
+- [`../ROADMAP.md`](../ROADMAP.md) — v1 maintenance window, v2 evolution, GeoServer 3 timeline
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — dev setup, PR workflow, required CI checks
-- [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) — GeoServer 2.x REST quirks the client handles
-- [`version-compat.md`](version-compat.md) — Go × GeoServer version matrix
-- [`migration-v1-to-v2.md`](migration-v1-to-v2.md) — v1 → v2 migration (in progress)
+- [`migration-v1-to-v2.md`](migration-v1-to-v2.md) — v1 → v2 migration mapping
+- [`version-compat.md`](version-compat.md) — Go × GeoServer support matrix
+- [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) — wire-format quirks the client handles

--- a/docs/geoserver-rest-quirks.md
+++ b/docs/geoserver-rest-quirks.md
@@ -12,7 +12,7 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** Send `Accept: "*/*"` to disable the dispatch and route to the metadata-creation path. The body's `Content-Type` should also be `application/json; charset=utf-8` — bare `application/json` 500s in some older 2.x versions.
 
-**Where:** `styles.go:178-186` (`CreateStyleContext`).
+**Where:** `rest/styles/styles.go:141-173` (`Create` — workspace-scoped branch sets `accept = "*/*"`).
 
 ## 2. Empty styles collection comes back as `{"styles":""}` (bare string)
 
@@ -20,7 +20,7 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** Decode into `json.RawMessage` first; branch on the first byte (`'"'` ⇒ empty list; `'{'` ⇒ decode as `{"style": [...]}`).
 
-**Where:** `styles.go:93-104` (`GetStylesContext`).
+**Where:** `rest/styles/styles.go:85` (`json.RawMessage` decode tolerates the empty-string shape).
 
 ## 3. `LayerGroup.styles.style` is a mixed `[string|object]` array
 
@@ -28,7 +28,7 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** Custom `UnmarshalJSON` on `LayerGroupStyles` that decodes the inner `style` array via `[]json.RawMessage`, then per-element handles `'"'` (string) vs `'{'` (object) and produces `[]*Resource`. String entries are stored as `&Resource{Name: stringValue}` to preserve the `[]*Resource` field type.
 
-**Where:** `layergroups.go` `LayerGroupStyles.UnmarshalJSON`.
+**Where:** `rest/layergroups/types.go:108` (`Styles.UnmarshalJSON`); the same trick handles the mixed `Published` shape at `rest/layergroups/types.go:60`.
 
 ## 4. POST style endpoints need explicit `; charset=utf-8`
 
@@ -36,7 +36,7 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** Send `Content-Type: application/json; charset=utf-8`.
 
-**Where:** Same site as quirk #1 — `styles.go:189` (`DataType: jsonType + "; charset=utf-8"`).
+**Where:** Same site as quirk #1 — `rest/styles/styles.go:173` (the body Content-Type is set to `"application/json; charset=utf-8"`).
 
 ## 5. PostGIS publish requires the table to exist with attributes
 
@@ -44,41 +44,39 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** Tests bootstrap a real PostGIS table via `docker/postgis/init/01-lbldyt.sql` (creates `public.lbldyt(gid, name, label, geom)` with sample rows + GIST index). Production callers must ensure their target table exists before publishing it.
 
-**Where:** `docker/postgis/init/01-lbldyt.sql`; tested in `feature_types_test.go` (integration).
+**Where:** `docker/postgis/init/01-lbldyt.sql`; tested in `rest/featuretypes/featuretypes_integration_test.go`.
 
-## 6. `Settings.Contact` is `interface{}` in v1
+## 6. `Settings.contact` returns the empty string when absent
 
-**Symptom:** Type assertions on `Settings.Contact` panic in v1.0; in v1.1 they return zero values silently.
+**Symptom:** `GET /rest/settings` on a freshly initialized GeoServer returns `"contact": ""` (bare string) instead of an empty object. Decoding into a `*Contact` field with the standard JSON decoder fails with `cannot unmarshal string into Go struct field`.
 
-**Root cause:** v1.0 modeled the contact subdocument loosely. The `Contact` *type* is defined in `settings.go:15` but never wired up; the field is `interface{}` (`settings.go:27`).
+**Workaround:** `*Contact` ships a custom `UnmarshalJSON` that treats both the empty-string and absent-field cases as a zero-value `Contact`, and decodes into the struct otherwise.
 
-**Workaround:** Don't trust the field type for new code. v2 will make this concrete.
-
-**Where:** `settings.go:27`.
+**Where:** `rest/settings/types.go` (`Contact.UnmarshalJSON`); regression-guarded by `rest/settings/settings_test.go:32` (`TestContact_UnmarshalEmptyString`).
 
 ## 7. Pagination drift across versions
 
 **Symptom:** `GET /rest/layers` and `GET /rest/styles` paginate via `?startIndex=&count=` on GeoServer 2.18+ but return everything on older versions.
 
-**Workaround:** Send pagination params and tolerate them being ignored on older servers. v2 wraps this in `iter.Seq2[T, error]` with single-page fallback.
+**Workaround:** Send pagination params and tolerate them being ignored on older servers. The client wraps this in `iter.Seq2[T, error]` with single-page fallback so callers iterate uniformly across versions.
 
-**Where:** Not currently mitigated in v1; documented for awareness.
+**Where:** `rest/styles/styles.go:104` (`Client.Iter`), `rest/layers/layers.go:83` (`WorkspaceClient.Iter`).
 
-## 8. `ParseURL` must escape per segment, not the whole path
+## 8. URL building must escape per segment, not the whole path
 
-**Symptom:** Workspace / layer names with spaces, slashes, or non-ASCII characters produced malformed URLs in v1.0. ACL rule strings carrying literal `*` wildcards were rejected by GeoServer's `StrictHttpFirewall` as "potentially malicious URL" with `%25` (double-encoded percent).
+**Symptom:** Workspace / layer names with spaces, slashes, or non-ASCII characters produce malformed URLs if a caller `fmt.Sprintf`s the path together. ACL rule strings carrying literal `*` wildcards are rejected by GeoServer's `StrictHttpFirewall` as "potentially malicious URL" if they end up double-encoded (`%25`).
 
-**Workaround:** `g.ParseURL(parts...)` applies `url.PathEscape` to each segment before `path.Join`, then preserves the encoding through `(*url.URL).String()` by setting `RawPath` alongside `Path`. Use multi-arg `ParseURL("rest", "workspaces", ws, "styles")` instead of `fmt.Sprintf("%srest/%s/styles", server, ws)`.
+**Workaround:** `transport.BuildURL(base, parts)` applies `url.PathEscape` to each segment before joining and preserves the encoding through `(*url.URL).String()` by setting `RawPath` alongside `Path`. Sub-clients reach it through `coreAdapter.URL(parts...)` (`geoserver.go:422`); never `fmt.Sprintf` REST paths.
 
-**Where:** `utils.go` `ParseURL`. Regression guarded by `utils_unit_test.go` `TestParseURL_NoDoubleEncoding`.
+**Where:** `internal/transport/url.go` (`BuildURL`); regression-guarded by `internal/transport/url_test.go`.
 
 ## 9. Empty `wfs:FeatureType` lists in capabilities
 
 **Symptom:** Older GeoServer versions emit `<FeatureTypeList></FeatureTypeList>` (empty) while newer ones omit the element entirely.
 
-**Workaround:** XML parser treats both as empty list; no caller-visible difference. WMS capabilities parser uses `wms.ParseCapabilitiesE` which returns `(*Capabilities, error)` — prefer it over the deprecated `ParseCapabilities` that swallowed errors.
+**Workaround:** The WFS capabilities XML decoder treats both as an empty `FeatureTypeList`; no caller-visible difference. The WMS side does the same for empty `Layer` lists.
 
-**Where:** `wms/wms.go` `ParseCapabilitiesE`.
+**Where:** `ows/wfs/types.go:106` (`FeatureTypeList`); `ows/wms/wms.go:114` (`ParseCapabilities`) returns `(*Capabilities, error)`.
 
 ## 10. Security service response keys differ across versions
 
@@ -86,7 +84,7 @@ If you're implementing a new REST resource client or debugging an integration-te
 
 **Workaround:** `GetRoles`, `GetUserRoles`, and `GetGroups` decode both shapes; whichever key has content wins.
 
-**Where:** `security.go` (`GetRolesContext`, `GetUserRolesContext`, `GetGroupsContext`).
+**Where:** `rest/security/security.go:246` (`GetRoles` decode), `rest/security/security.go:292` (`GetUserRoles` and `GetGroups` reuse the same shape-tolerant pattern); types live in `rest/security/types.go:64`.
 
 ---
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -1,6 +1,6 @@
 # Migration from v1.x to v2.x
 
-> **Status: beta.** Latest published tag is `v2.0.0-beta.1` — public API now frozen for review. v2 has full v1 feature parity at `master` plus surfaces v1 never had — per-service OWS settings, file-upload publishing, layer–style associations, GeoWebCache, the Importer extension, the full ACL surface (`Layers`/`Services`/`REST`/`Catalog`), the Resource API (data-dir byte-stream access), and the OWS read-only trio (GetCapabilities + DescribeFeatureType + DescribeCoverage). Until `v2.0.0` final, **prefer v1.x for production usage**.
+> **Status: stable.** Latest published tag is `v2.0.0`. v2 is the main line at the repo root on `master`; the public API is locked, no breaking changes will land in v2.x. v2 has full v1 feature parity plus surfaces v1 never had — per-service OWS settings, file-upload publishing, layer–style associations, GeoWebCache, the Importer extension, the full ACL surface (`Layers`/`Services`/`REST`/`Catalog`), the Resource API (data-dir byte-stream access), and the OWS read-only trio (GetCapabilities + DescribeFeatureType + DescribeCoverage). v1 is end-of-feature on the `release/v1` branch (security fixes only).
 
 This guide walks through the concrete API differences between v1.x (`github.com/hishamkaram/geoserver`) and v2.x (`github.com/hishamkaram/geoserver/v2`). Each section pairs a v1 snippet with the v2 equivalent.
 

--- a/docs/v2-tier2-gaps.md
+++ b/docs/v2-tier2-gaps.md
@@ -28,7 +28,7 @@ The original tier-2 list is now closed. Beyond it, narrower-audience endpoints t
 ## How to contribute
 
 1. Pick an item, file an issue summarizing the surface you intend to add (URL paths, request shapes, return shapes — verify against the official docs and the upstream OpenAPI YAML at `geoserver/geoserver/doc/en/api/1.0.0/`).
-2. Match the existing v2 patterns — see [`../README.md#contributing-to-v2`](../README.md#contributing-to-v2) for the per-pattern reference subpackage to copy from.
+2. Match the existing v2 patterns — copy the closest existing sub-client under `rest/` (e.g. `rest/workspaces/` for a flat resource, `rest/datastores/` for a workspace-scoped resource, `rest/featuretypes/` for a workspace-and-store-scoped resource, `rest/styles/` for a sub-client with both flat and `InWorkspace` modes). See [`architecture.md`](architecture.md) for the layout rationale.
 3. Run integration locally before push — `make compose-up && go test -tags=integration ./rest/<resource>/`.
 4. CI's wire-format coverage runs on real GeoServer 2.27.4 LTS + 2.28.0 stable; both legs must pass.
 

--- a/docs/version-compat.md
+++ b/docs/version-compat.md
@@ -24,7 +24,7 @@ CI uses `setup-go@v6` with `check-latest: true`, so the unit, vuln, and integrat
 | ≤ 2.17 | Unsupported | not in CI | Pre-modern security API; major drift in JSON response shapes. |
 | 3.0.x | Tracked for v2.x | not in CI | Jakarta EE / Tomcat 11 / ImageN raster engine. Validates only after the migration settles in production deploys. See [`../ROADMAP.md`](../ROADMAP.md). |
 
-**Integration coverage:** every PR runs the full integration suite against both 2.27.4 LTS and 2.28.0 stable. Both legs must pass before merge. Cross-version differences in REST response shapes are decoded transparently — `security.go` handles both `roles` and `roleNames` keys, both `groups` and `groupNames`, etc. See [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) for the full quirks catalog.
+**Integration coverage:** every PR runs the full integration suite against both 2.27.4 LTS and 2.28.0 stable. Both legs must pass before merge. Cross-version differences in REST response shapes are decoded transparently — `rest/security/security.go` handles both `roles` and `roleNames` keys, both `groups` and `groupNames`, etc. See [`geoserver-rest-quirks.md`](geoserver-rest-quirks.md) for the full quirks catalog.
 
 ## Tomcat / Java
 

--- a/docs/version-compat.md
+++ b/docs/version-compat.md
@@ -40,9 +40,9 @@ The dev / test Docker stack uses **`postgis/postgis:16-3.4`**. Older PostGIS ver
 
 | Path | Status |
 |---|---|
-| `github.com/hishamkaram/geoserver` | v1.x — supported |
-| `github.com/hishamkaram/geoserver/v2` | v2.x — beta (latest `v2.0.0-beta.1`); public API frozen for review until `v2.0.0` final |
-| `gopkg.in/hishamkaram/geoserver.v1` | Legacy alias — deprecated; resolves to the same source. New code should import the canonical path. |
+| `github.com/hishamkaram/geoserver/v2` | v2.x — stable (latest `v2.0.0`); main line at the repo root on `master`. New code should import this. |
+| `github.com/hishamkaram/geoserver` | v1.x — end-of-feature on the `release/v1` branch (latest `v1.1.2`); security fixes only. |
+| `gopkg.in/hishamkaram/geoserver.v1` | Legacy alias — deprecated; resolves to the same v1 source. New code should not use it. |
 
 ## When this matrix changes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,10 @@
-# Runnable v2 examples
+# Runnable examples
 
-Each subdirectory is a self-contained `main` package demonstrating one v2 idiom. Run any of them with:
+Each subdirectory is a self-contained `main` package demonstrating one client idiom. Run any of them from the repo root with:
 
 ```bash
-go run ./v2/examples/<name>
+go run ./examples/<name>
 ```
-
-(Or `cd v2 && go run ./examples/<name>`.)
 
 All examples expect a GeoServer + PostGIS stack reachable at the URL configured in code (default: `http://localhost:8080/geoserver/`, admin / geoserver). Boot the stack via `make compose-up` from the repo root.
 
@@ -17,7 +15,7 @@ All examples expect a GeoServer + PostGIS stack reachable at the URL configured 
 | [`style-upload/`](style-upload/) | Two-step style publish: register metadata via `Create`, then `UploadSLD` with a raw-XML body. |
 | [`error-handling/`](error-handling/) | Match GeoServer errors via `errors.Is(err, geoserver.ErrNotFound)` and inspect the typed `*geoserver.APIError` via `errors.As`. |
 
-These are reference flows, not test fixtures. The unit suite (`make test-v2-unit`) and the v2 integration ramp-up cover the same surface more rigorously.
+These are reference flows, not test fixtures. The unit suite (`make test-unit`) and the integration suite (`make test-integration`) cover the same surface more rigorously.
 
 ## Running against a different GeoServer
 
@@ -27,11 +25,11 @@ Each example reads the server URL and credentials from environment variables whe
 export GEOSERVER_URL="https://geoserver.example.com/geoserver/"
 export GEOSERVER_USER="admin"
 export GEOSERVER_PASS="hunter2"
-go run ./v2/examples/workspaces
+go run ./examples/workspaces
 ```
 
 Defaults match `make compose-up`: `http://localhost:8080/geoserver/`, `admin`, `geoserver`.
 
 ## v1 examples
 
-The parent [`examples/`](../../examples/) directory contains the v1 reference flows. Compare them side-by-side with the v2 versions here to see the API surface differences laid out in [`docs/migration-v1-to-v2.md`](../../docs/migration-v1-to-v2.md).
+v1's reference flows live on the `release/v1` branch under `examples/`. See [`docs/migration-v1-to-v2.md`](../docs/migration-v1-to-v2.md) for the API differences.


### PR DESCRIPTION
## Summary

Audited every `.md` file in the repo (24 total) for stale info after v2.0.0 final shipped (2026-05-04). The trigger was `SECURITY.md` still calling v1.1.x "active development" and v2 a "beta" pinned to `v2.0.0-beta.1` — a reader landing on the GitHub Security tab was seeing pre-ship state. Found analogous staleness in 16 other files; fixed in 8 logical commits.

### What changed

- **`SECURITY.md`** — supported-versions table inverted: v2.x stable on `master` is the active line; v1.1.x is security-fixes-only on `release/v1`.
- **`docs/migration-v1-to-v2.md`**, **`docs/version-compat.md`** — drop "beta / public API frozen for review / prefer v1.x for production" banners. v2.0.0 is GA.
- **`docs/architecture.md`** — full rewrite. Was an entire v1-architecture document (monolithic `*GeoServer`, ~90 flat methods, `*Context` twin pattern, `*Logger` wrapper, `*Error`); now describes v2 (`*Client` + 31 sub-clients, fluent `In*()` scoping, context-first methods, `*APIError`, `*slog.Logger` directly, `coreAdapter.Do` / `BuildURL` indirection, race-safe by construction).
- **`examples/README.md`** — drops pre-restructure paths (`./v2/examples/<name>`, `cd v2`, `make test-v2-unit`, `../../examples/`) that no longer exist.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — invert the breaking-change checkbox: master IS v2 (breaking changes belong here); v1 is on `release/v1` and must be non-breaking.
- **`docs/geoserver-rest-quirks.md`** + **`.claude/skills/geoserver-rest-quirks/SKILL.md`** — every `Where:` line repointed at the v2 path (`rest/styles/styles.go`, `rest/layergroups/types.go`, `internal/transport/url.go`, `ows/wms/wms.go`, etc.). Quirks 6–9 also got their text rewritten — they were written when v2 was still a future thing.
- **`.claude/` automation** (5 files: breaking-change-checker, go-reviewer, release-prep, add-context-twin, non-breaking-v1) — scoped to `release/v1`. Descriptions and intros explicitly say these run for v1 patches; diff bases swap `master` → `release/v1`. The go-reviewer agent now adapts its rule set per target branch (skips v1-only checks 1 and 2 on master; swaps v1/v2 symbol references for the rest).
- **`CONTRIBUTING.md`** — Project-layout tree was the pre-restructure shape (v1 at root, v2 under `v2/`); replaced with the actual current tree. Backward-compat rule split per target branch. Releasing section drops the `v2/CHANGELOG.md` reference. Claude Code helpers table notes which entries are `release/v1`-only.
- **`docs/v2-tier2-gaps.md`** — fixed dead anchor `../README.md#contributing-to-v2` (the section was removed in #105). Replaced with concrete sub-client templates to copy.
- **`CLAUDE.md`** + **`.claude/agents/integration-runner.md`** — small trailing v1-path fixes (stale `rest/styles/styles.go:75,91` line numbers; v1 flat-path examples in the trigger-keyword list).

### Files NOT changed (verified current)

`README.md` (refreshed in #105), `doc.go` (refreshed in #105), `ROADMAP.md` (the v2.0.0-beta entries are correct historical record), `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `LICENSE`, `docker/README.md`, `.claude/commands/integration-test.md`, `.claude/commands/lint-fix.md`. Workflow YAMLs already handle both `master` and `release/**`.

## Test plan

- [x] `make lint` — `0 issues.`
- [x] `make test-unit` — all packages green
- [x] `git grep -nE 'v2\.0\.0-beta'` outside CHANGELOG / ROADMAP — empty
- [x] `git grep -n 'README\.md#contributing-to-v2'` — empty
- [x] `git grep -n 'v1 flat path'` regex outside legitimate v2 paths — empty
- [x] `docs/architecture.md` cross-checked against `geoserver.go:415-444`, `errors.go`, `options.go`, `geoserver_concurrent_test.go:17`
- [x] `docs/geoserver-rest-quirks.md` `Where:` lines cross-checked against `rest/styles/styles.go:85,104,141-173`, `rest/layergroups/types.go:60,108`, `rest/settings/settings_test.go:32`, `rest/security/security.go:246,292`, `rest/layers/layers.go:83`, `internal/transport/url.go`, `ows/wfs/types.go:106`, `ows/wms/wms.go:114`
- [ ] CI green (Lint + Unit Go 1.25 + govulncheck + Integration 2.27.4 + 2.28.0 + CodeQL) — pending after push